### PR TITLE
fix: correct environment variable parsing using double underscore separator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,12 @@ jobs:
           mkdir -p .data
           if [ "${{ matrix.database }}" = "postgresql" ]; then
             echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
-            echo "SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
-            echo "SIGNALDB_DISCOVERY_DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
+            echo "SIGNALDB__DATABASE__DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
+            echo "SIGNALDB__DISCOVERY__DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
           else
             echo "DATABASE_URL=sqlite://.data/test.db" >> $GITHUB_ENV
-            echo "SIGNALDB_DATABASE_DSN=sqlite://.data/test.db" >> $GITHUB_ENV
-            echo "SIGNALDB_DISCOVERY_DSN=sqlite://.data/test.db" >> $GITHUB_ENV
+            echo "SIGNALDB__DATABASE__DSN=sqlite://.data/test.db" >> $GITHUB_ENV
+            echo "SIGNALDB__DISCOVERY__DSN=sqlite://.data/test.db" >> $GITHUB_ENV
           fi
 
       - name: Run all tests
@@ -266,15 +266,15 @@ jobs:
           chmod 755 ${{ runner.temp }}/signaldb-data
           
           if [ "${{ matrix.database }}" = "postgresql" ]; then
-            echo "SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
-            echo "SIGNALDB_DISCOVERY_DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
+            echo "SIGNALDB__DATABASE__DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
+            echo "SIGNALDB__DISCOVERY__DSN=postgres://postgres:postgres@localhost:5432/signaldb_test" >> $GITHUB_ENV
           else
-            echo "SIGNALDB_DATABASE_DSN=sqlite://${{ runner.temp }}/signaldb-data/test_deployment.db" >> $GITHUB_ENV
-            echo "SIGNALDB_DISCOVERY_DSN=sqlite://${{ runner.temp }}/signaldb-data/test_deployment.db" >> $GITHUB_ENV
+            echo "SIGNALDB__DATABASE__DSN=sqlite://${{ runner.temp }}/signaldb-data/test_deployment.db" >> $GITHUB_ENV
+            echo "SIGNALDB__DISCOVERY__DSN=sqlite://${{ runner.temp }}/signaldb-data/test_deployment.db" >> $GITHUB_ENV
           fi
           
           # Configure storage to use temp directory as well
-          echo "SIGNALDB_STORAGE_ADAPTERS_LOCAL_URL=file://${{ runner.temp }}/signaldb-data/storage" >> $GITHUB_ENV
+          echo "SIGNALDB__STORAGE__ADAPTERS__LOCAL__URL=file://${{ runner.temp }}/signaldb-data/storage" >> $GITHUB_ENV
 
       - name: Test deployment
         run: |

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -78,8 +78,8 @@ jobs:
     - name: Setup test environment
       run: |
         mkdir -p .data
-        echo "SIGNALDB_DATABASE_DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
-        echo "SIGNALDB_DISCOVERY_DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
+        echo "SIGNALDB__DATABASE__DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
+        echo "SIGNALDB__DISCOVERY__DSN=${{ matrix.database.dsn }}" >> $GITHUB_ENV
     
     - name: Run database schema tests
       if: matrix.database.type == 'postgresql' || matrix.database.type == 'sqlite'
@@ -245,9 +245,9 @@ jobs:
       run: |
         mkdir -p .data
         if [ "${{ matrix.database }}" = "postgresql" ]; then
-          echo "SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@localhost:5432/signaldb_bench" >> $GITHUB_ENV
+          echo "SIGNALDB__DATABASE__DSN=postgres://postgres:postgres@localhost:5432/signaldb_bench" >> $GITHUB_ENV
         else
-          echo "SIGNALDB_DATABASE_DSN=sqlite://.data/benchmark.db" >> $GITHUB_ENV
+          echo "SIGNALDB__DATABASE__DSN=sqlite://.data/benchmark.db" >> $GITHUB_ENV
         fi
     
     - name: Build release binaries
@@ -321,8 +321,8 @@ jobs:
     - name: Setup test environment
       run: |
         mkdir -p .data
-        echo "SIGNALDB_DATABASE_DSN=${{ matrix.scenario.database }}" >> $GITHUB_ENV
-        echo "SIGNALDB_DISCOVERY_DSN=${{ matrix.scenario.database }}" >> $GITHUB_ENV
+        echo "SIGNALDB__DATABASE__DSN=${{ matrix.scenario.database }}" >> $GITHUB_ENV
+        echo "SIGNALDB__DISCOVERY__DSN=${{ matrix.scenario.database }}" >> $GITHUB_ENV
     
     - name: Build all binaries
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,5 @@ Signaldb has a microservices and a monolothic mode
 ## Development Memories
 - For arrow & parquet try using the ones re-exported by datafusion
 - We need to run cargo fmt after bigger chunks of work to apply the canonical formatting
+- We need to format the code before committing
+- Always run cargo commands from the workspace root

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,4 @@ Signaldb has a microservices and a monolothic mode
 - We need to run cargo fmt after bigger chunks of work to apply the canonical formatting
 - We need to format the code before committing
 - Always run cargo commands from the workspace root
+- run cargo clippy and fix all warnings before committing

--- a/src/common/src/catalog.rs
+++ b/src/common/src/catalog.rs
@@ -35,9 +35,7 @@ impl Catalog {
             Catalog::Sqlite(pool)
         } else {
             let pool = PgPool::connect(dsn).await.map_err(|e| {
-                log::error!(
-                    "Failed to connect to PostgreSQL database with DSN '{dsn}': {e}"
-                );
+                log::error!("Failed to connect to PostgreSQL database with DSN '{dsn}': {e}");
                 e
             })?;
             Catalog::Postgres(pool)

--- a/src/common/src/service_bootstrap.rs
+++ b/src/common/src/service_bootstrap.rs
@@ -116,9 +116,9 @@ impl ServiceBootstrap {
             if path.starts_with("///") {
                 // Absolute path: sqlite:///absolute/path/file.db -> /absolute/path/file.db
                 &path[2..] // Remove only 2 slashes to keep the leading /
-            } else if path.starts_with("//") {
+            } else if let Some(stripped) = path.strip_prefix("//") {
                 // Relative path with //: sqlite://relative/path/file.db -> relative/path/file.db
-                &path[2..] // Remove both slashes
+                stripped // Remove both slashes
             } else if path.starts_with('/') {
                 // Single slash: sqlite:/path/file.db -> /path/file.db
                 path // Keep as is

--- a/src/common/src/service_bootstrap.rs
+++ b/src/common/src/service_bootstrap.rs
@@ -458,7 +458,7 @@ mod tests {
 
         // The operation should succeed with in-memory SQLite
         assert!(result.is_ok());
-        
+
         // Verify the service was created with correct properties
         let bootstrap = result.unwrap();
         assert_eq!(bootstrap.service_type, ServiceType::Writer);


### PR DESCRIPTION
## Summary

Fixes GitHub issue #124 where environment variables like `SIGNALDB_DATABASE_DSN` and `SIGNALDB_DISCOVERY_DSN` were not being parsed correctly by the figment configuration system.

• Fixed figment configuration to use proper double underscore separator (`SIGNALDB__DATABASE__DSN`)
• Updated all CI workflow files to use the correct format
• Added comprehensive tests to verify environment variable parsing works correctly
• Ensured nested configurations work properly (storage adapters, discovery, etc.)

## Changes Made

- **Configuration**: Updated `Configuration::load()` to use `Env::prefixed("SIGNALDB__").split("__")`
- **CI Workflows**: Changed from single underscore (`SIGNALDB_*`) to double underscore (`SIGNALDB__*__*`) format  
- **Tests**: Added comprehensive test coverage for environment variable parsing

## Test Plan

- [x] New tests pass: `test_env_var_override`, `test_nested_storage_config_env_vars`
- [x] All existing tests continue to pass
- [x] Code formatting and linting passes
- [x] CI workflows updated to use correct format

## Breaking Change

This is a breaking change for users who were setting environment variables with single underscores. The new format requires double underscores to separate nested configuration keys:

**Before**: `SIGNALDB_DATABASE_DSN=sqlite://test.db`
**After**: `SIGNALDB__DATABASE__DSN=sqlite://test.db`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded development guidelines with notes on code formatting and workspace usage.

* **Style**
  * Simplified error logging for PostgreSQL connection errors.
  * Removed unnecessary whitespace in test code.

* **Chores**
  * Updated environment variable naming conventions to use double underscores for improved nested configuration support in both application configuration and CI workflows.

* **Tests**
  * Added tests to verify new environment variable parsing behavior for nested configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->