### PR TITLE
feat: use in-memory SQLite as default for service discovery catalog

### DIFF
--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -40,6 +40,15 @@ impl Default for DatabaseConfig {
     }
 }
 
+impl DatabaseConfig {
+    /// Create an in-memory database configuration for monolithic mode
+    pub fn in_memory() -> Self {
+        Self {
+            dsn: String::from("sqlite::memory:"),
+        }
+    }
+}
+
 /// Configuration for service discovery (Catalog)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DiscoveryConfig {
@@ -59,7 +68,7 @@ pub struct DiscoveryConfig {
 impl Default for DiscoveryConfig {
     fn default() -> Self {
         Self {
-            dsn: String::from("sqlite://.data/signaldb.db"),
+            dsn: String::from("sqlite::memory:"),
             heartbeat_interval: Duration::from_secs(30),
             poll_interval: Duration::from_secs(60),
             ttl: Duration::from_secs(300),
@@ -138,10 +147,10 @@ mod tests {
         // Database should default to SQLite in .data directory
         assert_eq!(config.database.dsn, "sqlite://.data/signaldb.db");
 
-        // Discovery should be enabled by default with SQLite
+        // Discovery should be enabled by default with in-memory SQLite
         assert!(config.discovery.is_some());
         let discovery = config.discovery.unwrap();
-        assert_eq!(discovery.dsn, "sqlite://.data/signaldb.db");
+        assert_eq!(discovery.dsn, "sqlite::memory:");
         assert_eq!(discovery.heartbeat_interval, Duration::from_secs(30));
         assert_eq!(discovery.poll_interval, Duration::from_secs(60));
         assert_eq!(discovery.ttl, Duration::from_secs(300));
@@ -157,6 +166,7 @@ mod tests {
         // Should work completely configless with SQLite defaults
         assert_eq!(config.database.dsn, "sqlite://.data/signaldb.db");
         assert!(config.discovery.is_some());
+        assert_eq!(config.discovery.unwrap().dsn, "sqlite::memory:");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR addresses issue #92 by leveraging the existing catalog-aware Flight transport with an in-memory SQLite database as the default for service discovery. This provides the same benefits as a pure in-memory transport while maintaining compatibility with the existing architecture.

## Changes

- 🔧 Changed default discovery database configuration to use `sqlite::memory:`
- ✨ Added `DatabaseConfig::in_memory()` helper method for explicit in-memory configuration
- 🧪 Updated configuration tests to reflect new defaults
- 🧹 Cleaned up unused pure in-memory Flight transport implementation

## Benefits

- **Zero-configuration setup**: Works out of the box for monolithic deployments
- **High performance**: In-memory SQLite provides fast service discovery operations  
- **Flexible configuration**: Users can still configure persistent storage via environment variables or config files
- **Maintains existing architecture**: Leverages proven catalog-based service discovery
- **Backward compatible**: Existing configuration overrides continue to work

## Testing

- ✅ All existing tests pass
- ✅ Configuration tests updated and passing
- ✅ `cargo fmt` and `cargo clippy` checks pass
- ✅ Main binary starts successfully with in-memory configuration

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an in-memory SQLite database for discovery.

* **Bug Fixes**
  * Updated default settings to use an in-memory database for discovery, ensuring consistency in configless operation.

* **Tests**
  * Enhanced tests to verify the use of the in-memory SQLite database for discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->