### PR TITLE
refactor(heraclitus): replace hardcoded Kafka error codes with ResponseError enum

### DIFF
--- a/src/heraclitus-tests-integration/tests/tcp/consumer_group/leave_group.rs
+++ b/src/heraclitus-tests-integration/tests/tcp/consumer_group/leave_group.rs
@@ -89,7 +89,10 @@ async fn test_leave_group_nonexistent_group() -> Result<()> {
     let mut cursor = Cursor::new(&response[..]);
     let _correlation_id = cursor.get_i32();
     let error_code = cursor.get_i16();
-    assert_eq!(error_code, 16, "Should return COORDINATOR_NOT_AVAILABLE"); // ERROR_COORDINATOR_NOT_AVAILABLE
+    assert_eq!(
+        error_code, 15,
+        "Should return COORDINATOR_NOT_AVAILABLE (15)"
+    ); // ERROR_COORDINATOR_NOT_AVAILABLE
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #232 (discussion r2443307794)

Replaces all hardcoded i16 error codes in `connection_handler.rs` with the `kafka_protocol::error::ResponseError` enum to improve code readability and prevent semantic errors.

## Key Changes

### Fixed Semantic Errors

1. **Heartbeat handler (line 1059)**: Now correctly returns `UNKNOWN_MEMBER_ID` (25) instead of incorrect value 15 when group doesn't exist
2. **LeaveGroup handler (line 1121)**: Now correctly returns `COORDINATOR_NOT_AVAILABLE` (15) instead of incorrect value 16 when group doesn't exist  
3. **CreateTopics error handler (line 1490)**: Now correctly returns `UNKNOWN_SERVER_ERROR` (-1) instead of incorrect value 1

### Code Quality Improvements

- Import `kafka_protocol::error::ResponseError` enum
- Replace all error code literals with `ResponseError::{Variant}.code()`
- Update test expectation in `leave_group.rs` to match corrected error code (16 → 15)

### Error Codes Updated

- `UnknownTopicOrPartition` (3): metadata responses for missing topics
- `CoordinatorNotAvailable` (15): LeaveGroup when group doesn't exist
- `IllegalGeneration` (22): Heartbeat generation mismatch
- `UnknownMemberId` (25): Heartbeat when group/member doesn't exist
- `TopicAlreadyExists` (36): CreateTopics when topic exists
- `UnknownServerError` (-1): CreateTopics failure handler

## Test Plan

- [x] All heraclitus library tests pass (26 passed)
- [x] TCP integration tests pass:
  - [x] leave_group tests (including nonexistent group test)
  - [x] heartbeat tests (basic, wrong generation, unknown member)
  - [x] metadata tests
- [x] cargo clippy: clean
- [x] cargo fmt: clean
- [x] All pre-commit hooks pass

## Benefits

1. **Correctness**: Fixes semantic errors where wrong error codes were returned
2. **Maintainability**: Using enum variants prevents future errors
3. **Readability**: `ResponseError::UnknownMemberId.code()` is clearer than `25`
4. **Type Safety**: Compiler ensures we use valid error codes from the protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error reporting by standardizing error code handling across protocol operations including heartbeat messages, consumer group management, topic creation, and metadata queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->