### PR TITLE
fix(heraclitus): return actual member metadata in JoinGroup responses for librdkafka compatibility

### DIFF
--- a/src/heraclitus/src/state/consumer_group.rs
+++ b/src/heraclitus/src/state/consumer_group.rs
@@ -25,6 +25,9 @@ pub struct ConsumerGroupMember {
     pub last_heartbeat_ms: i64,
     pub subscribed_topics: Vec<String>,
     pub protocol_version: i16,
+    /// The protocol metadata (subscription data) from the JoinGroup request
+    /// This must be returned in the JoinGroup response for librdkafka compatibility
+    pub protocol_metadata: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Fixes a critical librdkafka compatibility issue where JoinGroup responses returned empty metadata, causing rdkafka e2e tests to crash with a buffer underflow assertion in the C library.

## Problem

The JoinGroup handler was returning empty metadata (`bytes::Bytes::new()`) for group members instead of the actual subscription data from the request. When librdkafka tried to parse this empty metadata buffer, it triggered:

```
Assertion failed: (r == 0), function rd_slice_init_full, file rdbuf.c, line 834.
signal: 6, SIGABRT: process abort signal
```

This caused `test_produce_consume_roundtrip` and potentially other rdkafka e2e tests to fail.

## Root Cause Analysis

**IMPORTANT**: This was a **pre-existing issue** from the initial JoinGroup implementation (commit f22ecab), NOT introduced by recent error code refactoring in PR #233. The original implementation had a TODO comment acknowledging the missing metadata.

## Changes

### 1. Updated `ConsumerGroupMember` struct
**File**: `src/heraclitus/src/state/consumer_group.rs`

Added `protocol_metadata: Vec<u8>` field to store the raw protocol metadata from JoinGroup requests, with documentation explaining its purpose for librdkafka compatibility.

### 2. Updated `handle_join_group` in connection handler
**File**: `src/heraclitus/src/protocol_v2/connection_handler.rs`

- **Line 795**: Added variable to capture protocol metadata from request
- **Line 806**: Store raw protocol metadata: `protocol_metadata = protocol.metadata.to_vec()`
- **Line 858**: Include metadata in `ConsumerGroupMember` struct initialization
- **Line 902**: Return actual metadata in response: `bytes::Bytes::from(m.protocol_metadata.clone())`

## Test Results

✅ **All 6 rdkafka e2e tests now pass**:
- `test_concurrent_clients` ✅
- `test_consumer_group_coordination` ✅
- `test_high_volume_throughput` ✅
- `test_message_headers` ✅
- `test_produce_consume_roundtrip` ✅ (previously failing)
- `test_rdkafka_connectivity` ✅

✅ **Code quality**:
- Clippy: Clean (no warnings)
- Formatted with `cargo fmt`
- All pre-commit hooks pass

## Benefits

1. **Correctness**: Fixes librdkafka crashes when parsing JoinGroup responses
2. **Protocol Compliance**: Proper Kafka protocol implementation for consumer group coordination
3. **Test Stability**: Enables all rdkafka e2e tests to run reliably
4. **Documentation**: Adds clear documentation about why metadata preservation is required

## Additional Context

Investigation showed this issue was consistently reproducible and existed before PR #233. The fix ensures that subscription metadata flows correctly through the consumer group coordination protocol, which is essential for librdkafka client compatibility.