### PR TITLE
fix(heraclitus): add in-memory caching to ConsumerGroupManager to prevent race conditions

### DIFF
--- a/src/heraclitus-tests-integration/src/lib.rs
+++ b/src/heraclitus-tests-integration/src/lib.rs
@@ -290,9 +290,11 @@ enabled = false
 
         // Start Heraclitus process with stdout/stderr captured to pipes
         let mut cmd = Command::new(&heraclitus_path);
+        let rust_log = std::env::var("HERACLITUS_SERVER_LOG_LEVEL")
+            .unwrap_or_else(|_| "heraclitus=info".to_string());
         cmd.arg("--config")
             .arg(&config_path)
-            .env("RUST_LOG", "heraclitus=info")
+            .env("RUST_LOG", rust_log)
             .env("AWS_ACCESS_KEY_ID", "minioadmin")
             .env("AWS_SECRET_ACCESS_KEY", "minioadmin")
             .env("AWS_ENDPOINT_URL", &minio.endpoint)


### PR DESCRIPTION
## Summary

Fixes a race condition in Heraclitus consumer group coordination that was causing SyncGroup to fail to find group state immediately after JoinGroup created it.

## Problem

The ConsumerGroupManager was experiencing race conditions due to S3/MinIO latency and eventual consistency:

1. JoinGroup creates group state and calls `save_group()` which writes to S3
2. SyncGroup immediately calls `get_group()` to read the group state
3. Due to S3 latency, `get_group()` returns `None` - the write hasn't propagated yet
4. SyncGroup creates a new empty group with no members
5. Member lookup fails → `subscribed_topics` is empty
6. No partitions are assigned → consumer can't fetch messages
7. After ~105 seconds, session timeout triggers disconnect

## Solution

Added in-memory caching to `ConsumerGroupManager` (similar to the existing pattern in `MessageManager`):

- **Cache structure**: `Arc<Mutex<HashMap<String, ConsumerGroupState>>>`
- **get_group()**: Checks cache first, loads from storage on miss, updates cache
- **save_group()**: Updates cache immediately before persisting to S3

This ensures SyncGroup always finds the group state that JoinGroup just created, preventing the race condition.

## Changes

### Core Fix
- `src/heraclitus/src/state/consumer_group.rs`:
  - Added `group_cache` field to `ConsumerGroupManager`
  - Updated `new()` to initialize cache
  - Updated `get_group()` to check cache before storage read
  - Updated `save_group()` to update cache immediately before storage write

### Debugging Enhancements
- `src/heraclitus/src/protocol_v2/connection_handler.rs`:
  - Added comprehensive debug logging to SyncGroup handler
  - Logs when group is found vs not found
  - Logs when member is found vs not found
  - Helps trace consumer group coordination flow

- `src/heraclitus-tests-integration/src/lib.rs`:
  - Made server log level configurable via `HERACLITUS_SERVER_LOG_LEVEL` env var
  - Allows enabling debug logging for tests without code changes

## Testing

Verified the fix with debug logging enabled:

```
ConsumerGroupManager: Saving group test-list-offsets-latest with 1 members (updating cache immediately)
SyncGroup: Found existing group test-list-offsets-latest with 1 members  ✓
Member consumer-test-list-offsets-latest-xxx subscribed to topics: ["list-offsets-latest-test"]  ✓
```

**Before**: SyncGroup would get `None` from `get_group()` and create empty group
**After**: SyncGroup successfully finds group with members from cache

## Notes

- Some integration tests may still have **separate** timing issues related to batch flushing and offset management (e.g., `test_list_offsets_latest` polling at offset 10 when only 0-9 exist)
- This PR specifically fixes the consumer group race condition - other timing issues require separate investigation

## Test Plan

- [x] Code compiles (`cargo check`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy passes
- [x] No unused dependencies
- [x] Security audit passes
- [x] Verified cache behavior with debug logs
- [x] Confirmed SyncGroup finds group state after JoinGroup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Logging level is now configurable via the `HERACLITUS_SERVER_LOG_LEVEL` environment variable instead of using a default value
  * Enhanced diagnostics with improved logging for consumer group state management and member operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->