### PR TITLE
fix(ci): use explicit version in grafana-plugin to fix release-please

### DIFF
--- a/src/grafana-plugin/backend/Cargo.toml
+++ b/src/grafana-plugin/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signaldb-grafana-datasource"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Fix release-please CI failure caused by `cargo-workspace` plugin not supporting `version.workspace = true` syntax
- Changed `src/grafana-plugin/backend/Cargo.toml` to use explicit `version = "0.1.0"` matching other workspace packages

## Test plan

- [x] `cargo check -p signaldb-grafana-datasource` passes
- [x] `cargo clippy` passes
- [ ] release-please workflow succeeds on merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package version configuration in the Grafana plugin backend build settings.

---

**Note:** This release contains no user-facing changes. The update affects build configuration only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->