### PR TITLE
feat(ci): add Rust version maintenance workflow and update Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,10 @@ updates:
       interval: "daily"
     assignees:
       - cedricziel
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - cedricziel

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Create Dockerfile
         run: |
           cat > Dockerfile.monolithic << 'EOF'
-          FROM rust:1.75 as builder
+          FROM rust:1.93 as builder
 
           RUN apt-get update && apt-get install -y protobuf-compiler
 

--- a/.github/workflows/rust-version-maintenance.yml
+++ b/.github/workflows/rust-version-maintenance.yml
@@ -1,0 +1,63 @@
+name: Rust Version Maintenance
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sundays
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-update-msrv:
+    name: Check and Update MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current project MSRV
+        id: current
+        run: |
+          MSRV=$(grep -E '^rust-version\s*=' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+          echo "msrv=${MSRV}" >> $GITHUB_OUTPUT
+
+      - name: Get DataFusion MSRV from crates.io
+        id: datafusion
+        run: |
+          CRATE_INFO=$(curl -sL "https://crates.io/api/v1/crates/datafusion")
+          DF_MSRV=$(echo "$CRATE_INFO" | jq -r '.versions[0].rust_version // empty')
+          echo "msrv=${DF_MSRV}" >> $GITHUB_OUTPUT
+
+      - name: Compare and update if needed
+        if: steps.current.outputs.msrv != steps.datafusion.outputs.msrv
+        run: |
+          NEW_MSRV="${{ steps.datafusion.outputs.msrv }}"
+          CURRENT="${{ steps.current.outputs.msrv }}"
+
+          # Update Cargo.toml
+          sed -i "s/^rust-version = \"[^\"]*\"/rust-version = \"${NEW_MSRV}\"/" Cargo.toml
+
+          # Update CI test matrix
+          sed -i "s/\[stable, beta, ${CURRENT}\]/[stable, beta, ${NEW_MSRV}]/" .github/workflows/ci.yml
+
+      - name: Create PR
+        if: steps.current.outputs.msrv != steps.datafusion.outputs.msrv
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_MSRV="${{ steps.datafusion.outputs.msrv }}"
+          CURRENT="${{ steps.current.outputs.msrv }}"
+          BRANCH="chore/update-msrv-${NEW_MSRV}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Cargo.toml .github/workflows/ci.yml
+          git commit -m "chore(deps): update Rust MSRV from ${CURRENT} to ${NEW_MSRV}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(deps): update Rust MSRV to ${NEW_MSRV}" \
+            --body "Aligns project MSRV with DataFusion ${NEW_MSRV}." \
+            --label "dependencies"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Uses Alpine Linux for minimal image sizes (~15-25MB per service)
 
 # Builder stage - compile all services with musl for Alpine compatibility
-FROM rust:1.86-alpine AS builder
+FROM rust:1.93-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile for testing different deployment models
-FROM rust:1.86 as base
+FROM rust:1.93 as base
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

- Add Docker ecosystem to Dependabot for automatic Rust image updates
- Create MSRV maintenance workflow that aligns with DataFusion's MSRV
- Update Docker images from outdated versions to Rust 1.93

## Changes

| File | Change |
|------|--------|
| `.github/dependabot.yml` | Added Docker ecosystem (weekly) |
| `.github/workflows/rust-version-maintenance.yml` | New MSRV maintenance workflow |
| `Dockerfile` | `rust:1.86-alpine` → `rust:1.93-alpine` |
| `Dockerfile.test` | `rust:1.86` → `rust:1.93` |
| `.github/workflows/release-please.yml` | `rust:1.75` → `rust:1.93` |

## How it works

**Dependabot Docker**: Creates PRs when new stable Rust images are available.

**MSRV Maintenance Workflow**: Runs weekly on Sundays and:
1. Fetches DataFusion's MSRV from crates.io
2. Compares with current project MSRV in `Cargo.toml`
3. If different, updates `Cargo.toml` and CI matrix
4. Creates a PR with the changes

## Test plan

- [ ] Verify Dependabot config is valid (will show in Dependabot insights after merge)
- [ ] Manually trigger MSRV workflow via `workflow_dispatch` to test it works
- [ ] Verify CI passes with updated configurations