### PR TITLE
feat(grafana-plugin): implement real metrics/logs queries and authentication

### DIFF
--- a/src/grafana-plugin/src/components/ConfigEditor.tsx
+++ b/src/grafana-plugin/src/components/ConfigEditor.tsx
@@ -45,6 +45,26 @@ export function ConfigEditor(props: Props) {
     });
   };
 
+  const onTenantIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        tenantId: event.target.value || undefined,
+      },
+    });
+  };
+
+  const onDatasetIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        datasetId: event.target.value || undefined,
+      },
+    });
+  };
+
   const onAPIKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
       ...options,
@@ -103,6 +123,26 @@ export function ConfigEditor(props: Props) {
           placeholder="30"
           width={20}
           type="number"
+        />
+      </InlineField>
+
+      <InlineField label="Tenant ID" labelWidth={20} interactive tooltip="Tenant identifier for multi-tenancy (optional)">
+        <Input
+          id="config-editor-tenant-id"
+          onChange={onTenantIdChange}
+          value={jsonData.tenantId || ''}
+          placeholder="default"
+          width={30}
+        />
+      </InlineField>
+
+      <InlineField label="Dataset ID" labelWidth={20} interactive tooltip="Dataset identifier for data isolation (optional)">
+        <Input
+          id="config-editor-dataset-id"
+          onChange={onDatasetIdChange}
+          value={jsonData.datasetId || ''}
+          placeholder="default"
+          width={30}
         />
       </InlineField>
 

--- a/src/grafana-plugin/src/types.ts
+++ b/src/grafana-plugin/src/types.ts
@@ -67,6 +67,16 @@ export interface SignalDBDataSourceOptions extends DataSourceJsonData {
    * Timeout for queries in seconds
    */
   timeout?: number;
+
+  /**
+   * Tenant ID for multi-tenancy
+   */
+  tenantId?: string;
+
+  /**
+   * Dataset ID for data isolation
+   */
+  datasetId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace mock data for metrics and logs with real Flight queries using the same Arrow-to-Grafana conversion pipeline as traces
- Add authentication support: API key (stored in Grafana secure JSON), tenant ID, and dataset ID sent as Flight request headers (`Authorization`, `X-Tenant-ID`, `X-Dataset-ID`)
- Add tenant ID and dataset ID configuration fields to the Grafana datasource config editor

## Test plan

- [ ] Build backend: `cd src/grafana-plugin && npm run build:backend`
- [ ] Run tests: `cargo test -p signaldb-grafana-datasource`
- [ ] Start SignalDB without auth (`./scripts/run-dev.sh`), query logs and metrics in Grafana, verify real data is returned (not mock 2021 timestamps)
- [ ] Configure `signaldb.toml` with auth enabled, add API key in Grafana datasource config, verify queries work with valid key and fail with invalid key
- [ ] Verify auth headers are received by router: `RUST_LOG=debug ./scripts/run-dev.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-tenant and data isolation support with new Tenant ID and Dataset ID configuration fields
  * Introduced API key-based authentication for secure data access
  * Enhanced datasource configuration to support optional authentication parameters
  * New configuration editor fields for tenant and dataset management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->