### PR TITLE
fix(ci): split Docker build into native arch jobs to prevent timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,25 @@ jobs:
           path: target/release/signaldb*
           retention-days: 7
 
-  # Docker image build - validates Dockerfile, only pushes on main
+  # Docker image build - split by architecture for native builds
   docker-build:
-    name: Build Docker Image
-    runs-on: ubuntu-latest
+    name: Build Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     needs: check
+    # Skip ARM64 on PRs for faster feedback
+    if: ${{ !(matrix.skip_on_pr && github.event_name == 'pull_request') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            skip_on_pr: false
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm64
+            skip_on_pr: true
     steps:
       - uses: actions/checkout@v6
 
@@ -221,21 +235,41 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=branch,suffix=-${{ matrix.arch }}
+            type=ref,event=pr,suffix=-${{ matrix.arch }}
 
-      - name: Build and optionally push monolithic image
+      - name: Build and optionally push image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           target: monolithic
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+  # Merge architecture-specific images into multi-arch manifest (main only)
+  docker-manifest:
+    name: Create Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    needs: docker-build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ github.repository }}:main \
+            ghcr.io/${{ github.repository }}:main-amd64 \
+            ghcr.io/${{ github.repository }}:main-arm64
 
   # Lightweight deployment test - only essential combinations
   deployment-test:


### PR DESCRIPTION
## Summary

- Split Docker build into architecture-specific jobs using native runners
- Use `ubuntu-latest` for amd64 (native) and `ubuntu-24.04-arm64` for arm64 (native)
- Skip ARM64 builds on PRs for faster CI feedback
- Add manifest merge job to create multi-arch image on main branch

## Problem

The Docker build job was timing out after 6 hours because:
- Single job built for `linux/amd64,linux/arm64` on `ubuntu-latest` (amd64)
- ARM64 builds used QEMU emulation, which is 10-100x slower for Rust compilation
- Every PR CI was blocked waiting for a job that would never complete

## Solution

| Scenario | AMD64 Build | ARM64 Build | Manifest |
|----------|-------------|-------------|----------|
| PR | ✅ Runs (~10-15 min) | ⏭️ Skipped | ⏭️ Skipped |
| Push to main | ✅ Runs | ✅ Runs (native) | ✅ Created |

## Test plan

- [ ] Verify this PR only runs the amd64 Docker build job
- [ ] After merge, verify both arch jobs run on main
- [ ] Verify `docker pull ghcr.io/cedricziel/signaldb:main` works on both amd64 and arm64 hosts