### PR TITLE
feat: Prometheus remote_write ingestion and PromQL parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cactus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564"
+
+[[package]]
 name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1517,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cfgrammar"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf"
+dependencies = [
+ "indexmap 2.13.0",
+ "lazy_static",
+ "num-traits",
+ "regex",
+ "serde",
+ "vob",
+]
 
 [[package]]
 name = "chrono"
@@ -3242,6 +3262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4189,6 +4218,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lrlex"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e"
+dependencies = [
+ "cfgrammar",
+ "getopts",
+ "lazy_static",
+ "lrpar",
+ "num-traits",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "vergen",
+]
+
+[[package]]
+name = "lrpar"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71"
+dependencies = [
+ "bincode",
+ "cactus",
+ "cfgrammar",
+ "filetime",
+ "indexmap 2.13.0",
+ "lazy_static",
+ "lrtable",
+ "num-traits",
+ "packedvec",
+ "regex",
+ "serde",
+ "static_assertions",
+ "vergen",
+ "vob",
+]
+
+[[package]]
+name = "lrtable"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de"
+dependencies = [
+ "cfgrammar",
+ "fnv",
+ "num-traits",
+ "serde",
+ "sparsevec",
+ "vob",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,6 +4503,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4667,6 +4759,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+]
+
+[[package]]
+name = "packedvec"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70"
+dependencies = [
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5097,6 +5199,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "promql-parser"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe99e6f80a79abccf1e8fb48dd63473a36057e600cc6ea36147c8318698ae6f"
+dependencies = [
+ "cfgrammar",
+ "chrono",
+ "lazy_static",
+ "lrlex",
+ "lrpar",
+ "regex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,6 +5375,7 @@ dependencies = [
  "iceberg-rust",
  "log",
  "object_store",
+ "promql-parser",
  "serde",
  "serde_json",
  "tempo-api",
@@ -6407,6 +6524,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparsevec"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d"
+dependencies = [
+ "num-traits",
+ "packedvec",
+ "serde",
+ "vob",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6679,6 +6808,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -6982,7 +7117,9 @@ checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -7775,10 +7912,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vob"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,9 @@ prost-build = "0.14"
 # Snappy compression for Prometheus remote write
 snap = "1.1"
 
+# PromQL parser for Prometheus query compatibility
+promql-parser = "0.4"
+
 thiserror = "2.0.12"
 
 reqwest = { version = "0.12", features = ["json"] }

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -30,6 +30,9 @@ datafusion_iceberg.workspace = true
 
 thiserror.workspace = true
 
+# PromQL support
+promql-parser.workspace = true
+
 [[bin]]
 name = "signaldb-querier"
 path = "src/main.rs"

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use error::QuerierError;
 
 pub mod error;
+pub mod promql;
 pub mod trace;
 
 #[derive(Debug)]

--- a/src/querier/src/query/promql/error.rs
+++ b/src/querier/src/query/promql/error.rs
@@ -1,0 +1,54 @@
+//! PromQL-specific error types
+
+// Error variants are designed for the translator and evaluator (Issues 4-7)
+#![allow(dead_code)]
+
+use std::fmt;
+
+/// Errors that can occur during PromQL parsing and evaluation
+#[derive(Debug)]
+pub enum PromQLError {
+    /// Error parsing the PromQL query syntax
+    ParseError(String),
+    /// Error during query evaluation/translation
+    EvaluationError(String),
+    /// Invalid time range specification
+    InvalidTimeRange {
+        start: i64,
+        end: i64,
+        reason: String,
+    },
+    /// Unsupported PromQL feature
+    UnsupportedFeature(String),
+    /// Invalid label matcher
+    InvalidMatcher(String),
+    /// Function not found or invalid arguments
+    FunctionError { name: String, reason: String },
+}
+
+impl std::error::Error for PromQLError {}
+
+impl fmt::Display for PromQLError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParseError(msg) => write!(f, "PromQL parse error: {msg}"),
+            Self::EvaluationError(msg) => write!(f, "PromQL evaluation error: {msg}"),
+            Self::InvalidTimeRange { start, end, reason } => {
+                write!(f, "Invalid time range [{start}, {end}]: {reason}")
+            }
+            Self::UnsupportedFeature(feature) => {
+                write!(f, "Unsupported PromQL feature: {feature}")
+            }
+            Self::InvalidMatcher(msg) => write!(f, "Invalid label matcher: {msg}"),
+            Self::FunctionError { name, reason } => {
+                write!(f, "Function '{name}' error: {reason}")
+            }
+        }
+    }
+}
+
+impl From<PromQLError> for super::super::error::QuerierError {
+    fn from(err: PromQLError) -> Self {
+        super::super::error::QuerierError::InvalidInput(err.to_string())
+    }
+}

--- a/src/querier/src/query/promql/mod.rs
+++ b/src/querier/src/query/promql/mod.rs
@@ -1,0 +1,63 @@
+//! PromQL query support for SignalDB
+//!
+//! This module provides PromQL (Prometheus Query Language) parsing and
+//! evaluation capabilities, enabling Prometheus-compatible queries against
+//! metrics stored in SignalDB.
+//!
+//! # Architecture
+//!
+//! The PromQL implementation follows this flow:
+//!
+//! ```text
+//! PromQL String → Parser → AST (Expr) → Translator → DataFusion LogicalPlan → Execution
+//! ```
+//!
+//! # Modules
+//!
+//! - [`parser`] - PromQL parsing using the promql-parser crate
+//! - [`types`] - PromQL-specific types for query parameters and results
+//! - [`error`] - Error types for PromQL operations
+//!
+//! # Example
+//!
+//! ```ignore
+//! use querier::query::promql::{parser, types::InstantQueryParams};
+//!
+//! // Parse a PromQL query
+//! let expr = parser::parse("rate(http_requests_total[5m])")?;
+//!
+//! // Extract information from the AST
+//! let metric_names = parser::extract_metric_names(&expr);
+//! let has_range = parser::has_range_vector(&expr);
+//! ```
+//!
+//! # Supported Features
+//!
+//! ## Selectors
+//! - Instant vector selectors: `metric_name{label="value"}`
+//! - Range vector selectors: `metric_name[5m]`
+//! - Label matchers: `=`, `!=`, `=~`, `!~`
+//! - Offset modifier: `metric offset 5m`
+//! - @ modifier: `metric @ 1609459200`
+//!
+//! ## Aggregations (planned)
+//! - `sum`, `avg`, `min`, `max`, `count`
+//! - `stddev`, `stdvar`
+//! - `topk`, `bottomk`
+//! - `count_values`, `quantile`
+//! - Grouping with `by` and `without`
+//!
+//! ## Functions (planned)
+//! - Rate functions: `rate`, `irate`, `increase`, `delta`, `idelta`
+//! - Aggregation over time: `avg_over_time`, `sum_over_time`, etc.
+//! - Math functions: `abs`, `ceil`, `floor`, `round`, `sqrt`, etc.
+//! - Histogram: `histogram_quantile`
+//!
+//! # Compatibility
+//!
+//! This implementation targets compatibility with Prometheus 3.x, including
+//! support for UTF-8 metric and label names as introduced in Prometheus 3.0.
+
+pub mod error;
+pub mod parser;
+pub mod types;

--- a/src/querier/src/query/promql/parser.rs
+++ b/src/querier/src/query/promql/parser.rs
@@ -1,0 +1,334 @@
+//! PromQL parser wrapper for SignalDB
+//!
+//! This module provides a wrapper around the promql-parser crate with
+//! SignalDB-specific error handling and utility functions.
+
+// Parser functions are designed for the translator (Issue 4) and HTTP API (Issues 8-10)
+#![allow(dead_code)]
+
+use promql_parser::label::{MatchOp, Matcher};
+use promql_parser::parser::{self, Expr, VectorSelector};
+
+use super::error::PromQLError;
+use super::types::{LabelMatcher, MatcherOp};
+
+/// Parse a PromQL query string into an AST expression
+///
+/// # Arguments
+/// * `query` - The PromQL query string to parse
+///
+/// # Returns
+/// The parsed expression AST, or a parse error
+///
+/// # Examples
+/// ```ignore
+/// use querier::query::promql::parser::parse;
+///
+/// let expr = parse("http_requests_total{job=\"api\"}").unwrap();
+/// let expr = parse("rate(http_requests_total[5m])").unwrap();
+/// let expr = parse("sum by (job)(rate(http_requests_total[5m]))").unwrap();
+/// ```
+pub fn parse(query: &str) -> Result<Expr, PromQLError> {
+    parser::parse(query).map_err(|e| PromQLError::ParseError(format!("{e:?}")))
+}
+
+/// Check if a query string is syntactically valid
+///
+/// # Arguments
+/// * `query` - The PromQL query string to validate
+///
+/// # Returns
+/// `Ok(())` if valid, or a parse error describing the issue
+pub fn validate(query: &str) -> Result<(), PromQLError> {
+    parse(query).map(|_| ())
+}
+
+/// Extract label matchers from a parsed expression
+///
+/// This is useful for understanding what labels a query is filtering on,
+/// which helps with query planning and optimization.
+///
+/// # Arguments
+/// * `expr` - The parsed PromQL expression
+///
+/// # Returns
+/// A vector of label matchers found in the expression
+pub fn extract_matchers(expr: &Expr) -> Vec<LabelMatcher> {
+    let mut result = Vec::new();
+    collect_matchers_recursive(expr, &mut result);
+    result
+}
+
+fn collect_matchers_recursive(expr: &Expr, result: &mut Vec<LabelMatcher>) {
+    match expr {
+        Expr::VectorSelector(vs) => {
+            for matcher in vs.matchers.matchers.iter() {
+                result.push(convert_matcher(matcher));
+            }
+        }
+        Expr::MatrixSelector(ms) => {
+            for matcher in ms.vs.matchers.matchers.iter() {
+                result.push(convert_matcher(matcher));
+            }
+        }
+        Expr::Call(call) => {
+            for arg in &call.args.args {
+                collect_matchers_recursive(arg, result);
+            }
+        }
+        Expr::Aggregate(agg) => {
+            collect_matchers_recursive(&agg.expr, result);
+        }
+        Expr::Binary(bin) => {
+            collect_matchers_recursive(&bin.lhs, result);
+            collect_matchers_recursive(&bin.rhs, result);
+        }
+        Expr::Paren(paren) => {
+            collect_matchers_recursive(&paren.expr, result);
+        }
+        Expr::Unary(unary) => {
+            collect_matchers_recursive(&unary.expr, result);
+        }
+        Expr::Subquery(sq) => {
+            collect_matchers_recursive(&sq.expr, result);
+        }
+        Expr::Extension(_) | Expr::NumberLiteral(_) | Expr::StringLiteral(_) => {
+            // No matchers in literals or extensions
+        }
+    }
+}
+
+fn convert_matcher(matcher: &Matcher) -> LabelMatcher {
+    let op = match &matcher.op {
+        MatchOp::Equal => MatcherOp::Equal,
+        MatchOp::NotEqual => MatcherOp::NotEqual,
+        MatchOp::Re(_) => MatcherOp::RegexMatch,
+        MatchOp::NotRe(_) => MatcherOp::RegexNotMatch,
+    };
+
+    LabelMatcher {
+        name: matcher.name.clone(),
+        op,
+        value: matcher.value.clone(),
+    }
+}
+
+/// Extract the metric name from a vector selector
+///
+/// Returns `None` if the selector doesn't have a `__name__` matcher
+/// or if it's a regex match.
+pub fn get_metric_name(vs: &VectorSelector) -> Option<&str> {
+    for matcher in vs.matchers.matchers.iter() {
+        if matcher.name == "__name__" && matches!(matcher.op, MatchOp::Equal) {
+            return Some(&matcher.value);
+        }
+    }
+    // Also check the name field directly
+    vs.name.as_deref()
+}
+
+/// Extract all metric names referenced in an expression
+///
+/// This traverses the entire expression tree and collects all
+/// metric names that are directly selected (with exact match).
+pub fn extract_metric_names(expr: &Expr) -> Vec<String> {
+    let mut names = Vec::new();
+    collect_metric_names_recursive(expr, &mut names);
+    names
+}
+
+fn collect_metric_names_recursive(expr: &Expr, names: &mut Vec<String>) {
+    match expr {
+        Expr::VectorSelector(vs) => {
+            if let Some(name) = get_metric_name(vs) {
+                names.push(name.to_string());
+            }
+        }
+        Expr::MatrixSelector(ms) => {
+            if let Some(name) = get_metric_name(&ms.vs) {
+                names.push(name.to_string());
+            }
+        }
+        Expr::Call(call) => {
+            for arg in &call.args.args {
+                collect_metric_names_recursive(arg, names);
+            }
+        }
+        Expr::Aggregate(agg) => {
+            collect_metric_names_recursive(&agg.expr, names);
+        }
+        Expr::Binary(bin) => {
+            collect_metric_names_recursive(&bin.lhs, names);
+            collect_metric_names_recursive(&bin.rhs, names);
+        }
+        Expr::Paren(paren) => {
+            collect_metric_names_recursive(&paren.expr, names);
+        }
+        Expr::Unary(unary) => {
+            collect_metric_names_recursive(&unary.expr, names);
+        }
+        Expr::Subquery(sq) => {
+            collect_metric_names_recursive(&sq.expr, names);
+        }
+        Expr::Extension(_) | Expr::NumberLiteral(_) | Expr::StringLiteral(_) => {}
+    }
+}
+
+/// Check if an expression contains a range vector (matrix selector)
+///
+/// Range vectors are required for functions like rate(), irate(), etc.
+pub fn has_range_vector(expr: &Expr) -> bool {
+    match expr {
+        Expr::MatrixSelector(_) => true,
+        Expr::Call(call) => call.args.args.iter().any(|arg| has_range_vector(arg)),
+        Expr::Aggregate(agg) => has_range_vector(&agg.expr),
+        Expr::Binary(bin) => has_range_vector(&bin.lhs) || has_range_vector(&bin.rhs),
+        Expr::Paren(paren) => has_range_vector(&paren.expr),
+        Expr::Unary(unary) => has_range_vector(&unary.expr),
+        Expr::Subquery(sq) => has_range_vector(&sq.expr),
+        _ => false,
+    }
+}
+
+/// Get the range duration from a matrix selector in milliseconds
+pub fn get_range_duration_ms(expr: &Expr) -> Option<i64> {
+    match expr {
+        Expr::MatrixSelector(ms) => Some(ms.range.as_millis() as i64),
+        Expr::Call(call) => call
+            .args
+            .args
+            .iter()
+            .find_map(|arg| get_range_duration_ms(arg)),
+        Expr::Aggregate(agg) => get_range_duration_ms(&agg.expr),
+        Expr::Paren(paren) => get_range_duration_ms(&paren.expr),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_metric() {
+        let expr = parse("http_requests_total").unwrap();
+        assert!(matches!(expr, Expr::VectorSelector(_)));
+    }
+
+    #[test]
+    fn test_parse_metric_with_labels() {
+        let expr = parse(r#"http_requests_total{job="api", method="GET"}"#).unwrap();
+        if let Expr::VectorSelector(vs) = expr {
+            // promql-parser stores metric name separately, so matchers only contain job and method
+            assert_eq!(vs.matchers.matchers.len(), 2);
+            assert!(vs.name.is_some());
+            assert_eq!(vs.name.as_deref(), Some("http_requests_total"));
+        } else {
+            panic!("Expected VectorSelector");
+        }
+    }
+
+    #[test]
+    fn test_parse_rate_function() {
+        let expr = parse("rate(http_requests_total[5m])").unwrap();
+        assert!(matches!(expr, Expr::Call(_)));
+        assert!(has_range_vector(&expr));
+    }
+
+    #[test]
+    fn test_parse_aggregation() {
+        let expr = parse("sum by (job)(rate(http_requests_total[5m]))").unwrap();
+        assert!(matches!(expr, Expr::Aggregate(_)));
+    }
+
+    #[test]
+    fn test_parse_binary_expression() {
+        let expr = parse("http_requests_total / http_requests_failed").unwrap();
+        assert!(matches!(expr, Expr::Binary(_)));
+    }
+
+    #[test]
+    fn test_parse_complex_query() {
+        let query = r#"
+            histogram_quantile(0.95,
+                sum by (le)(
+                    rate(http_request_duration_seconds_bucket{job="api"}[5m])
+                )
+            )
+        "#;
+        let expr = parse(query).unwrap();
+        assert!(matches!(expr, Expr::Call(_)));
+    }
+
+    #[test]
+    fn test_parse_invalid_query() {
+        let result = parse("http_requests_total{job=}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_regex_matcher() {
+        let expr = parse(r#"http_requests_total{job=~"api.*"}"#).unwrap();
+        let matchers = extract_matchers(&expr);
+        let job_matcher = matchers.iter().find(|m| m.name == "job").unwrap();
+        assert_eq!(job_matcher.op, MatcherOp::RegexMatch);
+        assert_eq!(job_matcher.value, "api.*");
+    }
+
+    #[test]
+    fn test_parse_negative_matcher() {
+        let expr = parse(r#"http_requests_total{job!="internal"}"#).unwrap();
+        let matchers = extract_matchers(&expr);
+        let job_matcher = matchers.iter().find(|m| m.name == "job").unwrap();
+        assert_eq!(job_matcher.op, MatcherOp::NotEqual);
+    }
+
+    #[test]
+    fn test_extract_metric_names() {
+        let expr = parse("http_requests_total + http_errors_total").unwrap();
+        let names = extract_metric_names(&expr);
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"http_requests_total".to_string()));
+        assert!(names.contains(&"http_errors_total".to_string()));
+    }
+
+    #[test]
+    fn test_get_range_duration() {
+        let expr = parse("rate(http_requests_total[5m])").unwrap();
+        let duration_ms = get_range_duration_ms(&expr).unwrap();
+        assert_eq!(duration_ms, 5 * 60 * 1000); // 5 minutes in ms
+    }
+
+    #[test]
+    fn test_validate_valid_query() {
+        assert!(validate("http_requests_total").is_ok());
+        assert!(validate("rate(x[5m])").is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_query() {
+        assert!(validate("http_requests_total{").is_err());
+        assert!(validate("rate(x[])").is_err());
+    }
+
+    #[test]
+    fn test_parse_with_offset() {
+        let expr = parse("http_requests_total offset 5m").unwrap();
+        assert!(matches!(expr, Expr::VectorSelector(_)));
+    }
+
+    #[test]
+    fn test_parse_subquery() {
+        let expr = parse("rate(http_requests_total[5m])[30m:1m]").unwrap();
+        assert!(matches!(expr, Expr::Subquery(_)));
+    }
+
+    #[test]
+    fn test_parse_utf8_metric_name() {
+        // Prometheus 3.0 supports UTF-8 metric names
+        let expr = parse(r#"{"http.server.request.duration"}"#);
+        // This may or may not parse depending on promql-parser version
+        // The important thing is it doesn't panic
+        let _ = expr;
+    }
+}

--- a/src/querier/src/query/promql/types.rs
+++ b/src/querier/src/query/promql/types.rs
@@ -1,0 +1,251 @@
+//! PromQL types and conversions for SignalDB
+//!
+//! This module provides types for representing PromQL query results
+//! and intermediate representations during query translation.
+
+// These types are designed for the translator (Issue 4) and HTTP API (Issues 8-10)
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Result of a PromQL instant query (vector)
+#[derive(Debug, Clone)]
+pub struct InstantVector {
+    /// The samples in this vector
+    pub samples: Vec<Sample>,
+}
+
+/// Result of a PromQL range query (matrix)
+#[derive(Debug, Clone)]
+pub struct RangeVector {
+    /// The time series in this matrix
+    pub series: Vec<Series>,
+}
+
+/// A single sample (metric + value at a point in time)
+#[derive(Debug, Clone)]
+pub struct Sample {
+    /// Metric labels (including __name__)
+    pub metric: Metric,
+    /// The sample value
+    pub value: f64,
+    /// Timestamp in milliseconds since epoch
+    pub timestamp: i64,
+}
+
+/// A time series (metric + multiple values over time)
+#[derive(Debug, Clone)]
+pub struct Series {
+    /// Metric labels (including __name__)
+    pub metric: Metric,
+    /// Values with timestamps
+    pub values: Vec<(i64, f64)>,
+}
+
+/// Metric labels (the label set identifying a time series)
+#[derive(Debug, Clone, Default)]
+pub struct Metric {
+    /// Label name-value pairs
+    pub labels: HashMap<String, String>,
+}
+
+impl Metric {
+    /// Create a new metric with the given name
+    pub fn new(name: &str) -> Self {
+        let mut labels = HashMap::new();
+        labels.insert("__name__".to_string(), name.to_string());
+        Self { labels }
+    }
+
+    /// Add a label to this metric
+    pub fn with_label(mut self, name: &str, value: &str) -> Self {
+        self.labels.insert(name.to_string(), value.to_string());
+        self
+    }
+
+    /// Get the metric name (__name__ label)
+    pub fn name(&self) -> Option<&str> {
+        self.labels.get("__name__").map(|s| s.as_str())
+    }
+
+    /// Get a label value by name
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.labels.get(name).map(|s| s.as_str())
+    }
+}
+
+/// Parameters for an instant query
+#[derive(Debug, Clone)]
+pub struct InstantQueryParams {
+    /// The PromQL query string
+    pub query: String,
+    /// Evaluation timestamp (milliseconds since epoch)
+    /// If None, uses current time
+    pub time: Option<i64>,
+    /// Query timeout
+    pub timeout: Option<Duration>,
+    /// Tenant context for multi-tenancy
+    pub tenant_slug: String,
+    /// Dataset context
+    pub dataset_slug: String,
+}
+
+/// Parameters for a range query
+#[derive(Debug, Clone)]
+pub struct RangeQueryParams {
+    /// The PromQL query string
+    pub query: String,
+    /// Start timestamp (milliseconds since epoch)
+    pub start: i64,
+    /// End timestamp (milliseconds since epoch)
+    pub end: i64,
+    /// Query resolution step (milliseconds)
+    pub step: i64,
+    /// Query timeout
+    pub timeout: Option<Duration>,
+    /// Tenant context for multi-tenancy
+    pub tenant_slug: String,
+    /// Dataset context
+    pub dataset_slug: String,
+}
+
+/// Label matcher types matching Prometheus semantics
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatcherOp {
+    /// Exact string match (=)
+    Equal,
+    /// Not equal (!=)
+    NotEqual,
+    /// Regex match (=~)
+    RegexMatch,
+    /// Regex not match (!~)
+    RegexNotMatch,
+}
+
+impl std::fmt::Display for MatcherOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Equal => write!(f, "="),
+            Self::NotEqual => write!(f, "!="),
+            Self::RegexMatch => write!(f, "=~"),
+            Self::RegexNotMatch => write!(f, "!~"),
+        }
+    }
+}
+
+/// A single label matcher
+#[derive(Debug, Clone)]
+pub struct LabelMatcher {
+    /// Label name
+    pub name: String,
+    /// Match operation
+    pub op: MatcherOp,
+    /// Value to match against
+    pub value: String,
+}
+
+impl LabelMatcher {
+    /// Create a new equality matcher
+    pub fn equal(name: &str, value: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            op: MatcherOp::Equal,
+            value: value.to_string(),
+        }
+    }
+
+    /// Create a new not-equal matcher
+    pub fn not_equal(name: &str, value: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            op: MatcherOp::NotEqual,
+            value: value.to_string(),
+        }
+    }
+
+    /// Create a new regex matcher
+    pub fn regex_match(name: &str, pattern: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            op: MatcherOp::RegexMatch,
+            value: pattern.to_string(),
+        }
+    }
+
+    /// Create a new regex not-match matcher
+    pub fn regex_not_match(name: &str, pattern: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            op: MatcherOp::RegexNotMatch,
+            value: pattern.to_string(),
+        }
+    }
+}
+
+/// Aggregation operators supported by PromQL
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregationOp {
+    Sum,
+    Avg,
+    Min,
+    Max,
+    Count,
+    Stddev,
+    Stdvar,
+    TopK,
+    BottomK,
+    CountValues,
+    Quantile,
+    Group,
+}
+
+impl std::fmt::Display for AggregationOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sum => write!(f, "sum"),
+            Self::Avg => write!(f, "avg"),
+            Self::Min => write!(f, "min"),
+            Self::Max => write!(f, "max"),
+            Self::Count => write!(f, "count"),
+            Self::Stddev => write!(f, "stddev"),
+            Self::Stdvar => write!(f, "stdvar"),
+            Self::TopK => write!(f, "topk"),
+            Self::BottomK => write!(f, "bottomk"),
+            Self::CountValues => write!(f, "count_values"),
+            Self::Quantile => write!(f, "quantile"),
+            Self::Group => write!(f, "group"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metric_creation() {
+        let metric = Metric::new("http_requests_total")
+            .with_label("job", "api")
+            .with_label("method", "GET");
+
+        assert_eq!(metric.name(), Some("http_requests_total"));
+        assert_eq!(metric.get("job"), Some("api"));
+        assert_eq!(metric.get("method"), Some("GET"));
+        assert_eq!(metric.get("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_label_matcher_display() {
+        assert_eq!(format!("{}", MatcherOp::Equal), "=");
+        assert_eq!(format!("{}", MatcherOp::NotEqual), "!=");
+        assert_eq!(format!("{}", MatcherOp::RegexMatch), "=~");
+        assert_eq!(format!("{}", MatcherOp::RegexNotMatch), "!~");
+    }
+
+    #[test]
+    fn test_aggregation_op_display() {
+        assert_eq!(format!("{}", AggregationOp::Sum), "sum");
+        assert_eq!(format!("{}", AggregationOp::TopK), "topk");
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements Prometheus ecosystem compatibility for SignalDB:

### Phase 1: Prometheus Remote Write Ingestion (Issues #329, #330)
- **POST /api/v1/write** endpoint accepting Prometheus remote_write protocol
- Snappy-compressed protobuf decoding
- Bidirectional Prometheus ↔ OTEL metrics conversion
- Multi-tenant authentication integration

### Phase 2: PromQL Parser Integration (Issue #331)
- Added `promql-parser` v0.4 dependency (GreptimeTeam)
- Created `src/querier/src/query/promql/` module with:
  - Parser wrapper with utility functions
  - PromQL-specific error types
  - Query result types for future phases

## Changes

### New Files
- `src/acceptor/src/handler/prometheus_handler.rs` - HTTP handler
- `src/common/src/flight/conversion/conversion_prometheus/` - Conversion module
  - `mod.rs` - Module exports and 16 unit tests
  - `types.rs` - Prometheus types (TimeSeries, Label, Sample, etc.)
  - `proto.rs` - Prost-derived protobuf types
  - `to_otel.rs` - Prometheus → OTEL conversion
  - `from_otel.rs` - OTEL → Prometheus conversion
- `src/querier/src/query/promql/` - PromQL module
  - `mod.rs` - Module exports
  - `parser.rs` - Parser wrapper with 19 unit tests
  - `types.rs` - Query types
  - `error.rs` - Error types
- `tests-integration/tests/prometheus_remote_write_test.rs` - 7 integration tests

### Modified Files
- `Cargo.toml` - Added promql-parser, snap dependencies
- `src/acceptor/src/lib.rs` - Route registration
- `src/common/src/flight/conversion/mod.rs` - Module export

## Test Plan
- [x] 16 unit tests for Prometheus ↔ OTEL conversion
- [x] 19 unit tests for PromQL parser
- [x] 7 integration tests for remote_write endpoint:
  - Gauge, counter, histogram ingestion
  - Empty request handling
  - Authentication (valid, invalid, missing)
  - Invalid payload handling

## Related Issues
Closes #329 (Add Prometheus remote_write ingestion endpoint)
Closes #330 (Implement Prometheus to OTEL metrics conversion)
Closes #331 (Integrate PromQL parser library)

Part of Epic #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PromQL query support for querying metric time-series data
  * Introduced query validation and parsing for PromQL expressions
  * Added support for instant and range query types with configurable time ranges and timeouts
  * Implemented error handling for parsing, evaluation, and unsupported feature detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->