### PR TITLE
docs: rewrite architecture overview and add storage layout design doc

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -2,132 +2,289 @@
 
 ## Introduction
 
-SignalDB is a production-ready distributed observability signal database built on the FDAP stack (Flight, DataFusion, Arrow, Parquet). This document provides a comprehensive overview of the architecture, implementation status, and operational characteristics.
-
-## Current Implementation Status
-
-🎉 **Phase 2 Complete**: SignalDB has achieved production readiness with comprehensive WAL integration, Flight-based inter-service communication, and robust service discovery.
-
-### Key Milestones Achieved
-
-- ✅ **WAL Integration**: Complete durability implementation with crash recovery
-- ✅ **Flight Communication**: High-performance inter-service data transfer
-- ✅ **Service Discovery**: Capability-based service routing and registration
-- ✅ **Integration Testing**: 15/15 integration tests passing
-- ✅ **Production Deployments**: Support for both monolithic and microservices patterns
+SignalDB is a distributed observability signal database built on the FDAP stack (Flight, DataFusion, Arrow, Parquet). It ingests metrics, logs, and traces via native OTLP support, stores them in Apache Iceberg tables backed by Parquet files, and exposes a Tempo-compatible query API. SignalDB supports multi-tenancy with per-tenant and per-dataset isolation at the storage, WAL, and catalog layers.
 
 ## Architecture Principles
 
 ### 1. Flight-First Communication
-Apache Arrow Flight serves as the primary inter-service communication protocol, providing:
-- **Zero-copy data transfer** with native Arrow format
-- **High-throughput, low-latency** network communication
-- **Streaming capabilities** for large datasets
-- **Built-in authentication and encryption** via gRPC
+
+Apache Arrow Flight serves as the primary inter-service communication protocol:
+
+- **Zero-copy data transfer** using the native Arrow columnar format
+- **Streaming capabilities** for large dataset transfer between services
+- **Connection pooling** with configurable limits, timeouts, and expiry
+- **gRPC-based** with built-in TLS and authentication support
 
 ### 2. WAL-Based Durability
+
 Write-Ahead Logging ensures data persistence and crash recovery:
-- **Before acknowledgment**: All data written to WAL before client response
+
+- **Before acknowledgment**: Data written to WAL before client response
 - **Automatic recovery**: Unprocessed entries replayed on restart
-- **Configurable policies**: Tunable flush intervals and buffer sizes
-- **Entry tracking**: WAL entries marked as processed after successful storage
+- **Per-tenant/dataset isolation**: Separate WAL directories per tenant, dataset, and signal type
+- **Segment management**: Automatic rotation, compaction, and cleanup of processed segments
 
-### 3. Catalog-Based Discovery
-Database-backed service registry with capability routing:
-- **PostgreSQL/SQLite backend** for service metadata
-- **Capability-based routing** (TraceIngestion, Storage, QueryExecution, Routing)
-- **Heartbeat monitoring** with automatic TTL-based cleanup
-- **ServiceBootstrap pattern** for automatic registration
+### 3. Dual Catalog System
 
-### 4. Iceberg Table Format
-Apache Iceberg provides ACID transactions and metadata management:
-- **ACID Transactions** with commit/rollback operations for data integrity
-- **Schema Evolution** supporting safe table structure changes
-- **Time Travel** enabling historical data queries and point-in-time recovery
-- **Metadata Management** with efficient partition and file tracking
+SignalDB maintains two distinct catalog systems:
+
+- **Service Catalog** (`Catalog`): PostgreSQL or SQLite-backed registry for service discovery, tenant management, API keys, and datasets. Used by `ServiceBootstrap` for heartbeat-based registration.
+- **Iceberg Catalog** (`CatalogManager`): SQLite-backed SQL catalog named `"signaldb"` for Iceberg table metadata (schemas, snapshots, manifests). Shared across all services via `Arc<dyn IcebergCatalog>`.
+
+### 4. Apache Iceberg Table Format
+
+Apache Iceberg provides ACID transactions and structured metadata management:
+
+- **ACID transactions** with commit/rollback for data integrity
+- **Schema versioning** via `schemas.toml` with inheritance, field renames, and computed fields
+- **Hour-based partitioning** on `timestamp` for all table types
+- **Namespace isolation**: Tables namespaced as `[tenant_slug, dataset_slug]`
 
 ### 5. Columnar Storage
-Efficient Parquet storage with DataFusion query processing:
-- **Arrow-native processing** throughout the pipeline
+
+Parquet storage with DataFusion query processing:
+
+- **Arrow-native processing** throughout the entire pipeline
 - **Columnar compression** for cost-effective storage
 - **SQL query capabilities** via DataFusion with Iceberg integration
-- **Object store abstraction** supporting multiple backends
+- **Object store abstraction** supporting local filesystem, S3/MinIO, and in-memory backends
 
 ## System Architecture
+
+### Workspace Members
+
+| Crate | Path | Type | Description |
+|-------|------|------|-------------|
+| **acceptor** | `src/acceptor/` | Binary + Library | OTLP gRPC/HTTP ingestion endpoint |
+| **router** | `src/router/` | Binary + Library | HTTP API + Flight routing layer |
+| **writer** | `src/writer/` | Binary + Library | Iceberg-based data persistence (the "Ingester") |
+| **querier** | `src/querier/` | Binary + Library | Query execution engine via DataFusion |
+| **common** | `src/common/` | Library | Shared config, auth, WAL, Flight, catalog, schema |
+| **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
+| **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
+| **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
+| **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, and dataset management |
+| **signaldb-sdk** | `src/signaldb-sdk/` | Library | Generated SDK client |
+| **grafana-plugin** | `src/grafana-plugin/` | Plugin | Grafana datasource (TypeScript frontend + Rust backend) |
+| **signal-producer** | `src/signal-producer/` | Binary | Test data generator (OTLP traces) |
+| **tests-integration** | `tests-integration/` | Test crate | Integration test suite |
+| **xtask** | `xtask/` | Binary | Build automation tasks |
 
 ### Data Flow Overview
 
 ```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│  OTLP Clients   │    │    Acceptor     │    │     Writer      │    │  Parquet Store  │
-│                 │───▶│                 │───▶│                 │───▶│                 │
-│ (gRPC/HTTP)     │    │  (Flight Out)   │    │ (Flight In/Out) │    │ (Object Store)  │
-└─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘
-                              │                       │
-                              ▼                       ▼
-                       ┌─────────────┐         ┌─────────────┐
-                       │ Acceptor    │         │  Writer     │
-                       │    WAL      │         │    WAL      │
-                       │  (Disk)     │         │  (Disk)     │
-                       └─────────────┘         └─────────────┘
+Write Path:
 
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   HTTP Clients  │    │     Router      │    │    Querier      │    │  Parquet Store  │
-│                 │◀───│                 │◀───│                 │◀───│                 │
-│ (Tempo API)     │    │ (HTTP In/Out)   │    │ (Flight In/Out) │    │ (Object Store)  │
-└─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘
+  OTLP Client (gRPC/HTTP)
+       |
+       v
+  ┌──────────┐      Flight       ┌──────────┐      Parquet      ┌──────────────┐
+  │ Acceptor │ ────────────────> │  Writer  │ ────────────────> │ Object Store │
+  │ :4317/18 │                   │  :50061  │                   │ (file/s3)    │
+  └──────────┘                   └──────────┘                   └──────────────┘
+                                      |                               |
+                                      v                               v
+                                 ┌──────────┐                  ┌──────────────┐
+                                 │   WAL    │                  │   Iceberg    │
+                                 │ (Disk)   │                  │   Catalog    │
+                                 └──────────┘                  │  (SQLite)   │
+                                                               └──────────────┘
+
+Query Path:
+
+  HTTP Client (Tempo API)
+       |
+       v
+  ┌──────────┐      Flight       ┌──────────┐    DataFusion     ┌──────────────┐
+  │  Router  │ ────────────────> │ Querier  │ ────────────────> │ Object Store │
+  │  :3000   │                   │  :50054  │                   │  (Parquet)   │
+  │  :50053  │                   └──────────┘                   └──────────────┘
+  └──────────┘                        |
+                                      v
+                                 ┌──────────────┐
+                                 │   Iceberg    │
+                                 │   Catalog    │
+                                 │  (SQLite)    │
+                                 └──────────────┘
 ```
 
 ### Write Path Detail
 
-1. **OTLP Ingestion**: Client sends traces via gRPC/HTTP to Acceptor
-2. **WAL Persistence**: Acceptor writes data to WAL and fsyncs to disk
-3. **Client Acknowledgment**: Client receives success response (data is durable)
-4. **Flight Transfer**: Acceptor converts OTLP to Arrow and sends via Flight
-5. **Storage Persistence**: Writer receives Arrow data and stores to Parquet
-6. **WAL Cleanup**: Acceptor marks WAL entry as processed
+1. **OTLP Ingestion**: Client sends traces/logs/metrics via gRPC (port 4317) or HTTP (port 4318) to the Acceptor. The Acceptor also supports Prometheus remote_write at `/api/v1/write`.
+2. **Authentication**: Acceptor validates the API key via `Authorization: Bearer <key>` header, resolves tenant and dataset context.
+3. **OTLP-to-Arrow Conversion**: Acceptor converts OTLP protobuf data to Arrow RecordBatches using Flight schemas (v1 format).
+4. **Flight Transfer**: Acceptor sends Arrow RecordBatches to a Writer via Flight `do_put`, discovered by `Storage` capability.
+5. **Schema Transformation**: Writer transforms v1 Flight schema to v2 Iceberg schema (field renames, type conversions, computed partition fields).
+6. **WAL Persistence**: Writer writes transformed data to its WAL (segmented by tenant/dataset/signal type).
+7. **Client Acknowledgment**: Acceptor receives success from Writer and acknowledges to the client.
+8. **Background Flush**: Writer's `WalProcessor` reads WAL entries every 5 seconds, creates/loads Iceberg tables, and writes Parquet files to the object store via DataFusion.
+9. **WAL Cleanup**: Processed WAL entries are marked and fully-processed segments are deleted.
 
 ### Query Path Detail
 
-1. **HTTP Request**: Client sends query to Router (Tempo API compatible)
-2. **Service Discovery**: Router discovers available Querier services
-3. **Flight Query**: Router forwards query to Querier via Flight
-4. **DataFusion Execution**: Querier executes SQL against Parquet files
-5. **Result Streaming**: Results streamed back via Flight → HTTP
-6. **Client Response**: Router returns formatted response to client
+1. **HTTP Request**: Client sends a query to the Router's HTTP API (port 3000), e.g., `GET /tempo/api/traces/{trace_id}`.
+2. **Authentication**: Router validates API key and resolves tenant/dataset context.
+3. **Service Discovery**: Router discovers available Querier services via `QueryExecution` capability from the service catalog.
+4. **Flight Query**: Router forwards the query as a Flight `do_get` ticket to the Querier (port 50054). Tickets encode the query type and tenant context, e.g., `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}`.
+5. **DataFusion Execution**: Querier resolves the tenant catalog and dataset schema, builds a DataFusion query against the Iceberg table, and executes it against Parquet files in the object store.
+6. **Result Streaming**: Results streamed back as Arrow RecordBatches via Flight to the Router.
+7. **Client Response**: Router formats the response as JSON (Tempo API format) and returns it to the client.
 
 ## Service Components
 
 ### Acceptor
-**Purpose**: OTLP data ingestion with durability guarantees
-- **Protocols**: gRPC (4317), HTTP (4318)
-- **Capabilities**: TraceIngestion
-- **WAL**: Persistent durability before acknowledgment
-- **Output**: Arrow data via Flight to Writers
 
-### Writer  
-**Purpose**: Data persistence to Apache Iceberg tables with ACID transactions
-- **Capabilities**: Storage
-- **Input**: Arrow data via Flight from Acceptors
-- **WAL**: Processing state tracking and recovery
-- **Output**: Iceberg tables (Parquet + metadata) to object store
-- **Transactions**: Full ACID support with commit/rollback operations
-- **Optimization**: Intelligent batch processing and connection pooling
+**Purpose**: OTLP data ingestion with multi-protocol support
+
+| Property | Value |
+|----------|-------|
+| **Ports** | gRPC: 4317, HTTP: 4318 |
+| **Capability** | `TraceIngestion` |
+| **Protocols** | OTLP/gRPC, OTLP/HTTP, Prometheus remote_write |
+| **Signal types** | Traces, Logs, Metrics |
+
+- Runs separate gRPC (tonic) and HTTP (Axum) servers in parallel
+- `WalManager` creates per-tenant/dataset/signal WAL instances with tuned configs:
+  - Traces: 1000 entries, 30s flush
+  - Logs: 2000 entries, 15s flush
+  - Metrics: 5000 entries, 10s flush
+- Converts OTLP protobuf to Arrow RecordBatches using `FlightSchemas`
+- Discovers Writers via `Storage` capability and sends data via Flight `do_put`
+
+### Writer
+
+**Purpose**: Data persistence to Apache Iceberg tables
+
+| Property | Value |
+|----------|-------|
+| **Port** | Flight: 50061 (standalone), 50051 (monolithic) |
+| **Capabilities** | `TraceIngestion`, `Storage` |
+| **Input** | Arrow data via Flight `do_put` from Acceptors |
+| **Output** | Iceberg tables (Parquet + metadata) to object store |
+
+- `IcebergWriterFlightService`: Flight server accepting `do_put` for trace/log/metric data
+- Transforms v1 Flight schema to v2 Iceberg schema before WAL write
+- `WalProcessor`: Background task (5s interval) that reads WAL entries and writes to Iceberg tables
+- Caches `IcebergTableWriter` instances per `{tenant}:{dataset}:{table}` combination
+- Creates Iceberg tables on first write with schema and partition spec from `iceberg_schemas`
 
 ### Router
-**Purpose**: HTTP API and query routing
-- **Protocols**: HTTP (3000), Flight (50053)
-- **Capabilities**: Routing
-- **APIs**: Grafana Tempo compatible endpoints
-- **Output**: Query requests via Flight to Queriers
+
+**Purpose**: HTTP API gateway and query routing
+
+| Property | Value |
+|----------|-------|
+| **Ports** | HTTP: 3000, Flight: 50053 |
+| **Capability** | `Routing` |
+| **APIs** | Tempo-compatible, Admin API, OpenAPI |
+
+**Tempo API Endpoints**:
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /tempo/api/echo` | Implemented |
+| `GET /tempo/api/traces/{trace_id}` | Implemented -- routes to Querier |
+| `GET /tempo/api/search` | Implemented -- routes to Querier |
+| `GET /tempo/api/search/tags` | Stub (returns empty) |
+| `GET /tempo/api/search/tag/{tag_name}/values` | Stub (returns empty) |
+| `GET /tempo/api/v2/search/tags` | Stub (returns empty) |
+| `GET /tempo/api/v2/search/tag/{tag_name}/values` | Stub (returns empty) |
+| `GET /tempo/api/metrics/query` | Stub (returns hardcoded) |
+| `GET /tempo/api/metrics/query_range` | Stub (returns hardcoded) |
+
+**Admin API Endpoints** (requires `admin_api_key`):
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/v1/admin/tenants` | CRUD for tenants |
+| `/api/v1/admin/tenants/{id}/api-keys` | Manage tenant API keys |
+| `/api/v1/admin/tenants/{id}/datasets` | Manage tenant datasets |
+
+- `ServiceRegistry`: Maintains cached map of discovered services, polls catalog at configurable interval
+- Discovers Queriers via `QueryExecution` capability for query forwarding
 
 ### Querier
-**Purpose**: Query execution against Iceberg tables
-- **Capabilities**: QueryExecution  
-- **Engine**: DataFusion SQL processing with Iceberg integration
-- **Input**: Queries via Flight from Routers
-- **Storage**: Iceberg table access (Parquet + metadata)
-- **Features**: Schema evolution, time travel, partition pruning
+
+**Purpose**: Query execution against Iceberg tables via DataFusion
+
+| Property | Value |
+|----------|-------|
+| **Port** | Flight: 50054 |
+| **Capability** | `QueryExecution` |
+| **Engine** | DataFusion with Iceberg integration |
+
+- Creates a DataFusion `SessionContext` with per-tenant `TenantCatalog` wrappers
+- `TenantCatalog` bridges DataFusion's 3-level model (`catalog.schema.table`) to Iceberg's 2-level namespace (`[tenant_slug, dataset_slug]`)
+- Registers per-dataset object stores with DataFusion's runtime environment
+- Handles Flight `do_get` tickets:
+  - `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}` -- single trace lookup
+  - `search_traces:{tenant_slug}:{dataset_slug}:{params}` -- trace search with filters
+- Uses `TableReference::full(tenant_slug, dataset_slug, "traces")` with slug validation to prevent SQL injection
+
+## Multi-Tenancy and Authentication
+
+### Tenant Model
+
+SignalDB provides full multi-tenant isolation:
+
+```
+Tenant (e.g., "acme")
+  ├── API Keys (SHA-256 hashed, with revocation support)
+  ├── Datasets
+  │   ├── "production" (slug: "prod", default)
+  │   └── "staging" (slug: "staging")
+  └── Schema Config (optional per-tenant overrides)
+```
+
+### Authentication Flow
+
+1. Client sends `Authorization: Bearer <api-key>` with optional `X-Tenant-ID` and `X-Dataset-ID` headers
+2. `Authenticator` hashes the key (SHA-256) and checks:
+   - Config-based API keys first (from `signaldb.toml`)
+   - Database-backed API keys second (from service catalog)
+3. Validates tenant_id matches the key's tenant (403 on mismatch)
+4. Resolves dataset: explicit header -> tenant default_dataset -> first `is_default` dataset -> 400 error
+5. Returns `TenantContext` with tenant_id, dataset_id, tenant_slug, dataset_slug
+
+### Isolation Layers
+
+| Layer | Isolation Mechanism |
+|-------|-------------------|
+| **WAL** | Separate directories: `{wal_dir}/{tenant}/{dataset}/{signal_type}/` |
+| **Iceberg Namespace** | Per-tenant/dataset: `[tenant_slug, dataset_slug]` |
+| **Object Store** | Per-tenant/dataset paths: `{base}/{tenant_slug}/{dataset_slug}/{table}/` |
+| **DataFusion** | Per-tenant catalog registration in SessionContext |
+| **Storage Backend** | Per-dataset storage override (different datasets can use different backends) |
+
+### Configuration
+
+```toml
+[auth]
+enabled = true
+admin_api_key = "sk-admin-key"
+
+[[auth.tenants]]
+id = "acme"
+slug = "acme"
+name = "Acme Corporation"
+default_dataset = "production"
+
+[[auth.tenants.datasets]]
+id = "production"
+slug = "prod"
+is_default = true
+
+[[auth.tenants.datasets]]
+id = "archive"
+slug = "archive"
+# Per-dataset storage override
+[auth.tenants.datasets.storage]
+dsn = "s3://acme-archive/signals"
+
+[[auth.tenants.api_keys]]
+key = "sk-acme-prod-key-123"
+name = "Production Key"
+```
 
 ## Service Discovery
 
@@ -137,228 +294,178 @@ Services register with specific capabilities enabling automatic routing:
 
 | Service | Capabilities | Discovery Pattern |
 |---------|-------------|------------------|
-| Acceptor | TraceIngestion | Clients connect directly |
-| Writer | Storage | Acceptors discover via Storage capability |
-| Router | Routing | Clients connect directly |
-| Querier | QueryExecution | Routers discover via QueryExecution capability |
+| Acceptor | `TraceIngestion` | Clients connect directly via OTLP |
+| Writer | `TraceIngestion`, `Storage` | Acceptors discover via `Storage` capability |
+| Router | `Routing` | Clients connect directly via HTTP |
+| Querier | `QueryExecution` | Routers discover via `QueryExecution` capability |
 
 ### ServiceBootstrap Pattern
 
-```rust
-// Automatic service registration
-let bootstrap = ServiceBootstrap::new(
-    config.clone(),
-    ServiceType::Writer,
-    "127.0.0.1:50051".to_string(),
-).await?;
+Each service creates a `ServiceBootstrap` at startup which:
 
-// Flight transport with discovery
-let flight_transport = Arc::new(InMemoryFlightTransport::new(bootstrap));
+1. Connects to the service catalog (SQLite or PostgreSQL, from `[discovery]` or `[database]` DSN)
+2. Generates a unique UUID `service_id`
+3. Registers in the `ingesters` table with service_type, address, and capabilities (comma-separated)
+4. Spawns a background heartbeat task updating `last_seen` at the configured interval
+5. On shutdown, deregisters from the catalog and stops the heartbeat
 
-// Capability-based service discovery
-let client = flight_transport
-    .get_client_for_capability(ServiceCapability::Storage)
-    .await?;
-```
+### Discovery Mechanism
+
+- `InMemoryFlightTransport`: Provides connection pooling (max 50 connections, 30s timeout, 5min expiry) and capability-based client lookup
+- `ServiceRegistry` (Router-specific): Cached HashMap of services, polls catalog at configurable interval
+- Service selection: Currently picks the first available service (round-robin is planned but not yet implemented)
+- Automatic TTL-based cleanup removes stale services that stop heartbeating
+
+## Schema Management
+
+Schema definitions are managed in `schemas.toml` at the repository root and compiled into the binary via `include_str!`. The schema system supports:
+
+- **Versioned schemas** with metadata tracking current versions (e.g., traces v2, logs v1, metrics v1)
+- **Inheritance**: A schema version can inherit fields from a parent version
+- **Field renames**: e.g., `name` -> `span_name` in traces v2
+- **Field additions**: e.g., `timestamp`, `date_day`, `hour` computed partition fields
+- **Computed fields**: Fields derived from other fields at write time (e.g., `date_day` from `start_time_unix_nano`)
+
+The Flight wire format (v1) and Iceberg storage format (v2) differ intentionally. The Writer applies schema transformations at ingestion time via `transform_trace_v1_to_v2()`.
+
+For full details on table schemas, partitioning, and the object store layout, see [Storage Layout Design](design/storage-layout.md).
 
 ## Deployment Models
 
 ### Monolithic Mode
 
-**Use Cases**: Development, small deployments, edge computing
-- **Single binary**: All services in one process
-- **Local communication**: Flight via localhost
-- **Shared catalog**: Single SQLite database
-- **Configuration**: Zero-config startup with sensible defaults
+**Use Cases**: Development, small deployments, testing
 
 ```bash
-# Start all services
 cargo run --bin signaldb
-
-# Services communicate internally:
-# - Acceptor: localhost:4317 (gRPC), localhost:4318 (HTTP)
-# - Router: localhost:3000 (HTTP), localhost:50053 (Flight)
-# - Writer: localhost:50051 (Flight)
-# - Querier: localhost:9000 (Flight)
 ```
+
+Starts Acceptor, Router, and Writer in a single process:
+- Acceptor: `0.0.0.0:4317` (gRPC), `0.0.0.0:4318` (HTTP)
+- Router: `0.0.0.0:3000` (HTTP), `0.0.0.0:50053` (Flight)
+- Writer: `0.0.0.0:50051` (Flight)
+
+Shared SQLite database for both service catalog and Iceberg catalog. Zero-config startup with sensible defaults.
+
+> **Known issue**: Monolithic mode does not currently start a Querier service. Query requests from the Router to a Querier will fail unless a standalone Querier is running separately. This is tracked as a bug.
 
 ### Microservices Mode
 
 **Use Cases**: Production, scalable deployments, cloud environments
-- **Independent services**: Separate processes/containers
-- **Network communication**: Flight via network
-- **Shared catalog**: PostgreSQL or shared SQLite
-- **Configuration**: Per-service configuration with discovery
 
 ```bash
-# Start services independently
-cargo run --bin acceptor   # OTLP ingestion
-cargo run --bin router     # HTTP API
-cargo run --bin writer     # Data persistence  
-cargo run --bin querier    # Query execution
+cargo run --bin acceptor   # OTLP ingestion (:4317, :4318)
+cargo run --bin router     # HTTP API (:3000, :50053)
+cargo run --bin writer     # Data persistence (:50061)
+cargo run --bin querier    # Query execution (:50054)
 ```
+
+Independent processes with network Flight communication. Requires shared catalog access (PostgreSQL or shared SQLite) for service discovery.
 
 ### Hybrid Mode
 
-**Use Cases**: Specialized deployments, migration scenarios
-- **Mixed deployment**: Some services co-located, others distributed
-- **Flexible routing**: Discovery handles both local and remote services
-- **Gradual migration**: Transition from monolithic to microservices
+Mixed deployment where some services are co-located and others are distributed. Discovery handles both local and remote services transparently.
 
-## Performance Characteristics
+## Grafana Integration
 
-### Throughput
-- **OTLP Ingestion**: 10K+ spans/second per Acceptor instance
-- **Flight Communication**: GB/second data transfer rates
-- **WAL Performance**: Sub-millisecond write latency with NVMe storage
-- **Query Performance**: DataFusion provides SQL-level optimization
+### Native Datasource Plugin
 
-### Latency
-- **End-to-end Ingestion**: P95 < 10ms with WAL durability
-- **Service Discovery**: Sub-millisecond cached lookups
-- **Flight Connection**: Connection pooling reduces overhead
-- **Query Response**: Streaming results for large datasets
+The Grafana plugin (`src/grafana-plugin/`) provides a native datasource with:
 
-### Scalability
-- **Horizontal Scaling**: Independent scaling of each service type
-- **Load Distribution**: Multiple instances of each service type
-- **Storage Scaling**: Object store horizontal scaling
-- **Geographic Distribution**: Multi-region deployment support
+- **TypeScript frontend**: React-based query editor and config editor using `@grafana/data` and `@grafana/ui`
+- **Rust backend**: Uses `grafana-plugin-sdk` to connect to the Router's Flight service (default `http://localhost:50053`)
+- **Auth passthrough**: Passes API key, tenant ID, and dataset ID from Grafana secure JSON config to Flight headers
+- **Signal support**: Traces, metrics, and logs query types
+- **Arrow conversion**: Direct Arrow RecordBatch to Grafana Frame conversion
 
-## Operational Characteristics
+### Tempo API Compatibility
 
-### Monitoring & Observability
+The Router exposes Tempo-compatible endpoints at `/tempo/api/...` for direct use with Grafana's built-in Tempo datasource. Currently supports trace lookup by ID and basic trace search. Tag search, tag values, and metrics query endpoints are stubs.
 
-**Health Endpoints**:
-```bash
-# Service health with WAL status
-curl http://acceptor:8080/health
-curl http://writer:8080/health
-```
+## Configuration
 
-**Key Metrics**:
-- WAL entry processing rates and latency
-- Flight connection pool statistics
-- Service discovery cache hit rates
-- DataFusion query execution metrics
-
-### Configuration Management
-
-**Precedence**: defaults → TOML file → environment variables
+**Precedence**: defaults -> TOML file (`signaldb.toml`) -> environment variables (`SIGNALDB_*`)
 
 ```toml
-# Complete configuration example
+# Service catalog / discovery
+[database]
+dsn = "sqlite://.data/signaldb.db"
+
 [discovery]
-dsn = "postgres://user:pass@localhost:5432/signaldb"
+dsn = "sqlite://.data/signaldb.db"   # Falls back to [database].dsn
 heartbeat_interval = "30s"
 poll_interval = "60s"
 ttl = "300s"
 
+# Object store for Parquet data
 [storage]
-default = "s3"
-[storage.adapters.s3]
-type = "s3"
-url = "s3://my-bucket"
-prefix = "traces"
+dsn = "file:///.data/storage"
+# dsn = "memory://"
+# dsn = "s3://bucket/prefix"
 
+# WAL configuration
 [wal]
-max_segment_size = 1048576
+wal_dir = ".data/wal"
+max_segment_size = 67108864          # 64 MB
 max_buffer_entries = 1000
-flush_interval_secs = 10
+flush_interval_secs = 30
+
+# Iceberg catalog
+[schema]
+catalog_type = "sql"
+catalog_uri = "sqlite::memory:"      # or sqlite:///path/to/catalog.db
+```
+
+For S3/MinIO, set environment variables:
+
+```bash
+AWS_ENDPOINT_URL=http://localhost:9000
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_REGION=us-east-1
+```
+
+## Operational Characteristics
+
+### Health Endpoints
+
+```bash
+curl http://localhost:4318/health   # Acceptor
+curl http://localhost:3000/health   # Router
 ```
 
 ### Disaster Recovery
 
-**WAL-Based Recovery**:
-1. WAL provides point-in-time recovery capabilities
-2. Unprocessed entries automatically replayed on restart
-3. Cross-service WAL coordination ensures consistency
-4. Backup procedures for WAL and catalog data
+- **WAL-Based Recovery**: Unprocessed WAL entries automatically replayed on Writer restart
+- **Segment Management**: Fully-processed segments deleted, partially-processed segments compacted
+- **Service Failure**: Automatic TTL-based deregistration; discovery cache invalidation on changes
+- **Graceful Shutdown**: Services deregister from catalog, flush WAL, and stop heartbeat on shutdown
 
-**Service Failure Handling**:
-1. Automatic service deregistration via TTL
-2. Flight client connection pooling with failover
-3. Discovery cache invalidation on service changes
-4. Graceful degradation during partial outages
+### Security
 
-## Security Considerations
+- **API Key Authentication**: SHA-256 hashed keys with config-based and database-backed storage
+- **Admin API**: Separate admin key for tenant/dataset management
+- **Input Validation**: Tenant/dataset slugs validated against alphanumeric + hyphen pattern; path traversal checks (`../`)
+- **TLS**: Flight supports gRPC-level TLS encryption
+- **gRPC Auth**: Separate interceptor for tonic gRPC services using metadata headers
 
-### Network Security
-- **TLS Encryption**: Flight supports gRPC-level encryption
-- **Authentication**: Pluggable authentication for Flight connections
-- **Network Isolation**: Services can be deployed in secure networks
+## CLI Tool
 
-### Data Security
-- **WAL Encryption**: Filesystem-level encryption for WAL directories
-- **Storage Encryption**: Object store encryption at rest
-- **Access Control**: Database-level access control for catalog
+`signaldb-cli` provides command-line management for tenants, API keys, and datasets:
 
-### Operational Security
-- **Service Isolation**: Process/container-level isolation
-- **Resource Limits**: Configurable resource constraints
-- **Audit Logging**: Comprehensive logging for security monitoring
+```bash
+signaldb-cli tenant list
+signaldb-cli tenant create --name "Acme Corp" --slug acme
+signaldb-cli api-key create --tenant acme --name "Production Key"
+signaldb-cli dataset create --tenant acme --name production --slug prod
+```
 
-## Integration & Compatibility
+## Testing
 
-### OTLP Compatibility
-- **Full OTLP Support**: Complete OpenTelemetry Protocol implementation
-- **gRPC & HTTP**: Both OTLP transport protocols supported
-- **Schema Evolution**: Arrow schema versioning for compatibility
+```bash
+cargo test                          # All tests across workspace
+cargo test -p <package>             # Tests for specific package
+cargo test -p tests-integration     # Integration tests
+```
 
-### Grafana Integration
-- **Tempo API**: Native Grafana Tempo API compatibility
-- **TraceQL Support**: Advanced trace query capabilities
-- **Dashboard Integration**: Seamless Grafana dashboard integration
-
-### Client SDKs
-- **OpenTelemetry**: Native support for all OTel language SDKs
-- **Custom Clients**: Flight-based clients for high-performance access
-- **HTTP Clients**: Standard HTTP/JSON for simple integration
-
-## Testing & Validation
-
-### Integration Test Coverage
-- **15/15 Tests Passing**: Comprehensive integration test suite
-- **End-to-End Validation**: Complete data flow testing
-- **Service Discovery**: Capability-based routing validation
-- **WAL Durability**: Crash recovery and replay testing
-- **Flight Communication**: Inter-service data transfer validation
-
-### Performance Testing
-- **Load Testing**: High-throughput ingestion scenarios
-- **Stress Testing**: Resource exhaustion and recovery
-- **Latency Testing**: P95/P99 latency characterization
-- **Scalability Testing**: Multi-instance deployment validation
-
-## Roadmap & Future Enhancements
-
-### Near-Term (Q1-Q2 2024)
-- **Enhanced Monitoring**: Prometheus metrics and alerting
-- **Performance Optimization**: DataFusion query optimization
-- **Documentation**: Comprehensive operational runbooks
-- **Packaging**: Container images and Helm charts
-
-### Medium-Term (Q3-Q4 2024)
-- **Multi-Region Support**: Geographic distribution capabilities
-- **Advanced Querying**: Enhanced TraceQL and SQL features
-- **Storage Optimization**: Intelligent data tiering
-- **Service Mesh Integration**: Consul, etcd, Kubernetes native discovery
-
-### Long-Term (2025+)
-- **Real-Time Analytics**: Stream processing capabilities
-- **Machine Learning**: Anomaly detection and insights
-- **Federation**: Multi-cluster observability
-- **Edge Computing**: Lightweight edge deployments
-
-## Conclusion
-
-SignalDB represents a significant advancement in observability infrastructure, combining the performance benefits of the FDAP stack with production-ready reliability features. The completed Phase 2 implementation provides a solid foundation for large-scale observability deployments while maintaining flexibility for diverse use cases.
-
-Key achievements include:
-- **Production-ready WAL durability** with comprehensive crash recovery
-- **High-performance Flight communication** with automatic service discovery
-- **Comprehensive testing** with 100% integration test coverage
-- **Flexible deployment models** supporting both monolithic and microservices patterns
-- **Native observability** with extensive monitoring and debugging capabilities
-
-The architecture provides a robust, scalable foundation for modern observability infrastructure that can grow from development environments to large-scale production deployments.
+The integration test suite (`tests-integration/`) validates end-to-end data flow, service discovery, WAL durability, and Flight communication.

--- a/docs/design/storage-layout.md
+++ b/docs/design/storage-layout.md
@@ -1,0 +1,636 @@
+# Storage Layout Design
+
+## Overview
+
+SignalDB uses a three-tier storage model to balance durability, query performance, and operational flexibility:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Write-Ahead Log (WAL)                       │
+│  Durability layer. Segmented files on local disk, per-tenant,      │
+│  per-dataset, per-signal type. Data is buffered here before        │
+│  being flushed to Iceberg tables.                                  │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ WalProcessor (background, 5s interval)
+                             v
+┌─────────────────────────────────────────────────────────────────────┐
+│                      Iceberg SQL Catalog                           │
+│  Metadata layer. SQLite-backed catalog named "signaldb" tracking   │
+│  table schemas, snapshots, manifest lists, and partition specs.    │
+│  Namespace = [tenant_slug, dataset_slug].                          │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ Table location pointers
+                             v
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Object Store                               │
+│  Data layer. Parquet files + Iceberg metadata JSON files stored    │
+│  in local filesystem, S3/MinIO, or in-memory backends.             │
+│  Path = {base}/{tenant_slug}/{dataset_slug}/{table_name}/          │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Object Store Layout
+
+### Physical Directory Structure
+
+All persistent data (Parquet files and Iceberg metadata) is stored in the object store configured via `[storage].dsn`. The path structure is:
+
+```
+{storage_base}/
+  {tenant_slug}/
+    {dataset_slug}/
+      {table_name}/
+        metadata/
+          v1.metadata.json          # Iceberg table metadata
+          snap-{id}.avro            # Manifest lists
+          {uuid}-m0.avro            # Manifest files
+        data/
+          {uuid}.parquet            # Data files
+```
+
+### Concrete Example
+
+With `dsn = "file:///.data/storage"`, tenant "acme" (slug `acme`), datasets "production" (slug `prod`) and "archive" (slug `archive`):
+
+```
+.data/storage/
+  acme/
+    prod/
+      traces/
+        metadata/
+          v1.metadata.json
+        data/
+          00000-0-{uuid}.parquet
+      logs/
+        metadata/
+        data/
+      metrics_gauge/
+        metadata/
+        data/
+      metrics_sum/
+        metadata/
+        data/
+      metrics_histogram/
+        metadata/
+        data/
+    archive/
+      traces/
+        metadata/
+        data/
+  beta/
+    staging/
+      traces/
+        metadata/
+        data/
+```
+
+### Storage Backends
+
+The `[storage].dsn` config accepts three URL schemes:
+
+| Scheme | Backend | Example | Notes |
+|--------|---------|---------|-------|
+| `file://` | Local filesystem | `file:///.data/storage` | `LocalFileSystem` with prefix |
+| `memory://` | In-memory | `memory://` | For testing only; data lost on restart |
+| `s3://` | S3-compatible | `s3://bucket/prefix` | AWS S3, MinIO, or compatible. Uses env vars for credentials. |
+
+**Path resolution** (`storage_dsn_to_path()` in `src/common/src/storage.rs`):
+
+- `file:///.data/storage` -> `.data/storage` (strips leading `/.` for relative paths)
+- `file:///tmp/data` -> `/tmp/data` (keeps absolute paths)
+- `s3://bucket/prefix` -> kept as-is
+
+### Per-Dataset Storage Override
+
+Each dataset can optionally specify its own storage backend, enabling scenarios like:
+
+- Production data on local NVMe for low latency
+- Archive data on S3 for cost efficiency
+- Test data in memory
+
+```toml
+[[auth.tenants]]
+id = "acme"
+slug = "acme"
+
+[[auth.tenants.datasets]]
+id = "production"
+slug = "prod"
+# Uses global [storage].dsn (no override)
+
+[[auth.tenants.datasets]]
+id = "archive"
+slug = "archive"
+[auth.tenants.datasets.storage]
+dsn = "s3://acme-archive/signals"    # Per-dataset override
+```
+
+The resolution chain in `Configuration::get_dataset_storage_config()` (`src/common/src/config/mod.rs`):
+
+1. Check `dataset.storage` -- if `Some`, use it
+2. Fall back to global `config.storage`
+
+The Querier registers per-dataset object stores with DataFusion's runtime environment so it can read Parquet files from whichever backend each dataset uses.
+
+## Iceberg Catalog
+
+### Catalog Configuration
+
+The Iceberg metadata catalog is a SQLite-backed `SqlCatalog` (from `iceberg-sql-catalog`) named `"signaldb"`. It is configured via:
+
+```toml
+[schema]
+catalog_type = "sql"
+catalog_uri = "sqlite::memory:"          # In-memory (default, for dev/testing)
+# catalog_uri = "sqlite:///.data/catalog.db"  # Persistent (recommended for production)
+```
+
+> **Limitation**: Only SQLite is supported for the Iceberg catalog. PostgreSQL URIs are rejected. This is distinct from the service discovery catalog which supports both SQLite and PostgreSQL.
+
+### Namespace Structure
+
+Iceberg namespaces use a two-level hierarchy based on **slugs**:
+
+```
+Namespace: [tenant_slug, dataset_slug]
+Table:     table_name
+Full:      Identifier([tenant_slug, dataset_slug], table_name)
+```
+
+Examples:
+
+| Tenant | Dataset | Table | Iceberg Identifier |
+|--------|---------|-------|--------------------|
+| acme | prod | traces | `Identifier(["acme", "prod"], "traces")` |
+| acme | archive | logs | `Identifier(["acme", "archive"], "logs")` |
+| beta | staging | metrics_gauge | `Identifier(["beta", "staging"], "metrics_gauge")` |
+
+Namespaces are implicitly created when tables are created -- there is no explicit `create_namespace` call.
+
+### CatalogManager
+
+`CatalogManager` (`src/common/src/catalog_manager.rs`) is the centralized singleton that holds the shared Iceberg catalog instance. All services (Writer, Querier, Router in monolithic mode) use the same `CatalogManager` to ensure consistent metadata access.
+
+```rust
+pub struct CatalogManager {
+    catalog: Arc<dyn IcebergCatalog>,
+    config: Configuration,
+}
+```
+
+Key methods:
+
+- `catalog()` -- returns `Arc<dyn IcebergCatalog>` for direct Iceberg operations
+- `get_tenant_slug(tenant_id)` -- resolves slug from config (falls back to tenant_id)
+- `get_dataset_slug(tenant_id, dataset_id)` -- resolves slug from config (falls back to dataset_id)
+- `get_dataset_storage_config(tenant_id, dataset_id)` -- resolves per-dataset or global storage config
+
+### DataFusion Integration
+
+The Querier (`src/querier/src/flight.rs`) wraps the Iceberg catalog with a `TenantCatalog` to bridge DataFusion's 3-level naming model to Iceberg's 2-level namespace:
+
+```
+DataFusion:   SELECT * FROM acme.prod.traces
+                            ^^^^  ^^^^  ^^^^^^
+                          catalog schema table
+
+Iceberg:      Identifier(["acme", "prod"], "traces")
+                          ^^^^^^^^^^^^^^^   ^^^^^^
+                            namespace       table
+```
+
+`TenantCatalog` implements `CatalogProvider`:
+
+- `schema_names()`: Filters Iceberg namespaces to those starting with `{tenant_slug}.`, strips the prefix
+- `schema(name)`: Prepends `{tenant_slug}.` to look up the full namespace `{tenant_slug}.{dataset_slug}`
+
+At startup, the Querier registers a `TenantCatalog` per enabled tenant, plus a backward-compatible `"iceberg"` catalog.
+
+## Table Types
+
+SignalDB creates up to 7 table types per tenant-dataset combination. Table creation is controlled by the `[schema.default_schemas]` config and happens lazily on first write.
+
+### Signal Type to Table Mapping
+
+| Signal Type | Table Name | WalOperation | Schema Source |
+|-------------|-----------|--------------|---------------|
+| Traces | `traces` | `WriteTraces` | `schemas.toml` (v2, inherits v1) |
+| Logs | `logs` | `WriteLogs` | `schemas.toml` (v1) |
+| Metrics (Gauge) | `metrics_gauge` | `WriteMetrics` | `iceberg_schemas.rs` (hardcoded) |
+| Metrics (Sum) | `metrics_sum` | `WriteMetrics` | `iceberg_schemas.rs` (hardcoded) |
+| Metrics (Histogram) | `metrics_histogram` | `WriteMetrics` | `iceberg_schemas.rs` (hardcoded) |
+| Metrics (Exp. Histogram) | `metrics_exponential_histogram` | `WriteMetrics` | `iceberg_schemas.rs` (hardcoded) |
+| Metrics (Summary) | `metrics_summary` | `WriteMetrics` | `iceberg_schemas.rs` (hardcoded) |
+
+For metrics, the target table name is extracted from the WAL entry's `metadata` JSON field (`target_table`), defaulting to `metrics_gauge`.
+
+### Partitioning
+
+All tables are partitioned by **hour** using Iceberg's built-in `Hour` transform on the `timestamp` column:
+
+```
+PartitionField {
+    source_id: <timestamp field id>,
+    field_id: 1000 + <timestamp field id>,
+    name: "timestamp_hour",
+    transform: Transform::Hour,
+}
+```
+
+Hour-level partitioning automatically enables day/month/year pruning in DataFusion queries.
+
+### Table Schemas
+
+Schema definitions come from two sources:
+
+- **`schemas.toml`** (compiled into the binary): Traces and Logs schemas with versioning and inheritance
+- **`iceberg_schemas.rs`** (hardcoded): Metric table schemas
+
+#### Traces Table (v2 -- current)
+
+Defined in `schemas.toml` via v1 base + v2 inheritance with renames and additions.
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1 | `trace_id` | String | Yes | |
+| 2 | `span_id` | String | Yes | |
+| 3 | `parent_span_id` | String | No | |
+| 4 | `span_name` | String | Yes | Renamed from `name` in v2 |
+| 5 | `service_name` | String | Yes | |
+| 6 | `start_time_unix_nano` | Long | Yes | Nanoseconds since epoch |
+| 7 | `end_time_unix_nano` | Long | Yes | Nanoseconds since epoch |
+| 8 | `duration_nanos` | Long | Yes | Renamed from `duration_nano` in v2 |
+| 9 | `span_kind` | String | Yes | |
+| 10 | `status_code` | String | Yes | |
+| 11 | `status_message` | String | No | |
+| 12 | `is_root` | Boolean | Yes | |
+| 13 | `span_attributes` | String | No | JSON. Renamed from `attributes_json` in v2 |
+| 14 | `resource_attributes` | String | No | JSON. Renamed from `resource_json` in v2 |
+| 15 | `events` | String | No | JSON serialized (nested List<Struct> in Flight) |
+| 16 | `links` | String | No | JSON serialized (nested List<Struct> in Flight) |
+| 17 | `trace_state` | String | No | |
+| 18 | `resource_schema_url` | String | No | |
+| 19 | `scope_name` | String | No | |
+| 20 | `scope_version` | String | No | |
+| 21 | `scope_schema_url` | String | No | |
+| 22 | `scope_attributes` | String | No | |
+| 23 | `timestamp` | Timestamp | Yes | Computed from `start_time_unix_nano`. Partition key. |
+| 24 | `date_day` | Date | Yes | Computed from timestamp |
+| 25 | `hour` | Int | Yes | Computed from timestamp |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Logs Table (v1 -- current)
+
+Defined in `schemas.toml`.
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1 | `timestamp` | Timestamp | Yes | Partition key |
+| 2 | `observed_timestamp` | Timestamp | No | |
+| 3 | `trace_id` | String | No | Correlation with traces |
+| 4 | `span_id` | String | No | Correlation with traces |
+| 5 | `trace_flags` | Int | No | |
+| 6 | `severity_text` | String | No | |
+| 7 | `severity_number` | Int | No | |
+| 8 | `service_name` | String | Yes | |
+| 9 | `body` | String | No | |
+| 10 | `resource_schema_url` | String | No | |
+| 11 | `resource_attributes` | String | No | JSON |
+| 12 | `scope_schema_url` | String | No | |
+| 13 | `scope_name` | String | No | |
+| 14 | `scope_version` | String | No | |
+| 15 | `scope_attributes` | String | No | JSON |
+| 16 | `log_attributes` | String | No | JSON |
+| 17 | `date_day` | Date | Yes | Computed from timestamp |
+| 18 | `hour` | Int | Yes | Computed from timestamp |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Metrics Gauge Table (v1 -- current)
+
+Defined in `iceberg_schemas.rs`.
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1 | `timestamp` | Timestamp | Yes | Partition key |
+| 2 | `start_timestamp` | Timestamp | No | |
+| 3 | `service_name` | String | Yes | |
+| 4 | `metric_name` | String | Yes | |
+| 5 | `metric_description` | String | No | |
+| 6 | `metric_unit` | String | No | |
+| 7 | `value` | Double | Yes | |
+| 8 | `flags` | Int | No | |
+| 9 | `resource_schema_url` | String | No | |
+| 10 | `resource_attributes` | String | No | JSON |
+| 11 | `scope_name` | String | No | |
+| 12 | `scope_version` | String | No | |
+| 13 | `scope_schema_url` | String | No | |
+| 14 | `scope_attributes` | String | No | JSON |
+| 15 | `scope_dropped_attr_count` | Int | No | |
+| 16 | `attributes` | String | No | JSON |
+| 17 | `exemplars` | String | No | JSON |
+| 18 | `date_day` | Date | Yes | Computed |
+| 19 | `hour` | Int | Yes | Computed |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Metrics Sum Table (v1 -- current)
+
+Extends Gauge with aggregation fields.
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1-8 | *(same as Gauge 1-8)* | | | |
+| 9 | `aggregation_temporality` | Int | Yes | 0=Unspecified, 1=Delta, 2=Cumulative |
+| 10 | `is_monotonic` | Boolean | Yes | |
+| 11-21 | *(same as Gauge 9-19)* | | | |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Metrics Histogram Table (v1 -- current)
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1-6 | *(same as Gauge 1-6)* | | | |
+| 7 | `count` | Long | Yes | Total count |
+| 8 | `sum` | Double | No | |
+| 9 | `min` | Double | No | |
+| 10 | `max` | Double | No | |
+| 11 | `bucket_counts` | String | No | JSON array |
+| 12 | `explicit_bounds` | String | No | JSON array |
+| 13 | `flags` | Int | No | |
+| 14 | `aggregation_temporality` | Int | Yes | |
+| 15-25 | *(resource/scope/attributes/exemplars/date_day/hour)* | | | |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Metrics Exponential Histogram Table (v1 -- current)
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1-6 | *(same as Gauge 1-6)* | | | |
+| 7 | `count` | Long | Yes | |
+| 8 | `sum` | Double | No | |
+| 9 | `min` | Double | No | |
+| 10 | `max` | Double | No | |
+| 11 | `scale` | Int | No | |
+| 12 | `zero_count` | Long | No | |
+| 13 | `positive_offset` | Int | No | |
+| 14 | `positive_bucket_counts` | String | No | JSON array |
+| 15 | `negative_offset` | Int | No | |
+| 16 | `negative_bucket_counts` | String | No | JSON array |
+| 17 | `flags` | Int | No | |
+| 18 | `aggregation_temporality` | Int | Yes | |
+| 19 | `zero_threshold` | Double | No | |
+| 20-30 | *(resource/scope/attributes/exemplars/date_day/hour)* | | | |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+#### Metrics Summary Table (v1 -- current)
+
+| # | Field | Iceberg Type | Required | Notes |
+|---|-------|-------------|----------|-------|
+| 1-6 | *(same as Gauge 1-6)* | | | |
+| 7 | `count` | Long | Yes | |
+| 8 | `sum` | Double | Yes | |
+| 9 | `quantile_values` | String | No | JSON array of `{quantile, value}` objects |
+| 10 | `flags` | Int | No | |
+| 11-21 | *(resource/scope/attributes/exemplars/date_day/hour)* | | | |
+
+**Partition**: `Hour(timestamp)` as `timestamp_hour`
+
+## WAL Layout
+
+### Directory Structure
+
+The WAL is organized by tenant, dataset, and signal type under the configured base directory:
+
+```
+{wal_dir}/
+  {tenant_id}/
+    {dataset_id}/
+      {signal_type}/
+        wal-0000000000.log      # Entry metadata (bincode-serialized WalEntry structs)
+        wal-0000000000.data     # Raw data (Arrow IPC StreamWriter format)
+        wal-0000000000.index    # Processed entry tracking (UUID list)
+        wal-0000000001.log      # Next segment after rotation
+        wal-0000000001.data
+        wal-0000000001.index
+```
+
+### Concrete Example
+
+With default `wal_dir = ".data/wal"`:
+
+```
+.data/wal/
+  acme/
+    production/
+      traces/
+        wal-0000000000.log
+        wal-0000000000.data
+        wal-0000000000.index
+      logs/
+        wal-0000000000.log
+        wal-0000000000.data
+        wal-0000000000.index
+      metrics/
+        wal-0000000000.log
+        wal-0000000000.data
+        wal-0000000000.index
+    staging/
+      traces/
+        ...
+  beta/
+    staging/
+      traces/
+        ...
+```
+
+### WAL Configuration
+
+```rust
+pub struct WalConfig {
+    pub wal_dir: PathBuf,
+    pub max_segment_size: u64,       // Default: 64 MB (67108864 bytes)
+    pub max_buffer_entries: usize,   // Default: 1000
+    pub flush_interval_secs: u64,    // Default: 30 seconds
+    pub max_buffer_size: usize,      // Default: 128 MB
+    pub tenant_id: String,           // Required, non-empty
+    pub dataset_id: String,          // Required, non-empty
+}
+```
+
+The WAL enforces non-empty `tenant_id` and `dataset_id` at construction time.
+
+### Segment Files
+
+Each WAL segment consists of three files:
+
+| File | Format | Content |
+|------|--------|---------|
+| `.log` | Length-prefixed bincode | Sequence of `WalEntry` structs (8-byte length prefix + bincode bytes) |
+| `.data` | Raw bytes | Arrow IPC `StreamWriter` format. Entries reference data by offset and size. |
+| `.index` | Binary | 8-byte count + 16-byte UUIDs of processed entries |
+
+### WAL Entry Structure
+
+```rust
+pub struct WalEntry {
+    pub id: Uuid,
+    pub timestamp: u64,
+    pub operation: WalOperation,      // WriteTraces | WriteLogs | WriteMetrics | Flush
+    pub data_size: u64,               // Size of data in .data file
+    pub data_offset: u64,             // Offset into .data file
+    pub processed: bool,
+    pub tenant_id: String,
+    pub dataset_id: String,
+    pub metadata: Option<String>,     // JSON with schema_version, signal_type, target_table, etc.
+}
+```
+
+### Segment Lifecycle
+
+1. **Write**: New entries appended to current segment's `.log` and `.data` files
+2. **Rotation**: When segment exceeds `max_segment_size` (64MB default), a new segment is created with incremented ID
+3. **Processing**: `WalProcessor` reads unprocessed entries, writes to Iceberg, marks entries in `.index`
+4. **Cleanup**: Fully-processed segments are deleted. Partially-processed segments above compaction threshold are compacted.
+
+### Data Serialization
+
+Arrow RecordBatches are serialized to/from bytes using Arrow's IPC StreamWriter/StreamReader:
+
+```rust
+// Write
+let mut writer = StreamWriter::try_new(&mut buffer, &batch.schema())?;
+writer.write(batch)?;
+writer.finish()?;
+
+// Read
+let reader = StreamReader::try_new(&data[offset..offset + size], None)?;
+let batch = reader.into_iter().next().unwrap()?;
+```
+
+## Schema Versioning and Evolution
+
+### Schema Definition System
+
+Schemas are defined in `schemas.toml` at the repository root and compiled into the binary via `include_str!`. The system supports:
+
+| Feature | Description |
+|---------|-------------|
+| **Versioning** | Each signal type tracks a current version (e.g., `current_trace_version = "v2"`) |
+| **Inheritance** | A version can inherit all fields from a parent: `inherits = "v1"` |
+| **Field renames** | Rename fields across versions: `{ from = "name", to = "span_name" }` |
+| **Field additions** | Add new fields: `{ name = "timestamp", type = "timestamp_ns", computed = "start_time_unix_nano" }` |
+| **Computed fields** | Fields derived from other fields at write time |
+
+### Schema Resolution
+
+The `SchemaDefinitions` struct (`src/common/src/schema/schema_parser.rs`) resolves a versioned schema by:
+
+1. Loading the base version's fields
+2. If `inherits` is specified, recursively resolving the parent and starting with its fields
+3. Applying `field_renames` to inherited fields
+4. Appending `field_additions`
+
+### Flight Schema vs Iceberg Schema
+
+The Flight wire format (v1) and Iceberg storage format (v2) are intentionally different:
+
+| Aspect | Flight Schema (v1) | Iceberg Schema (v2) |
+|--------|-------------------|---------------------|
+| Span name field | `name` | `span_name` |
+| Duration field | `duration_nano` (UInt64) | `duration_nanos` (Long/Int64) |
+| Attributes field | `attributes_json` | `span_attributes` |
+| Resource field | `resource_json` | `resource_attributes` |
+| Time fields | UInt64 (nanoseconds) | Long/Int64 (nanoseconds) |
+| Events/Links | `List<Struct>` (nested Arrow) | `String` (JSON serialized) |
+| Partition fields | None | `timestamp`, `date_day`, `hour` |
+
+### Write-Time Transformation
+
+The Writer applies `transform_trace_v1_to_v2()` (`src/writer/src/schema_transform.rs`) at ingestion time:
+
+1. **Detection**: Checks if batch has `name` field (v1) or `span_name` field (v2)
+2. **Field renames**: Maps v1 field names to v2 names
+3. **Type conversions**: `UInt64` -> `Int64` for Iceberg compatibility
+4. **Complex type serialization**: `List<Struct>` events/links -> JSON strings
+5. **Computed fields**: Generates `timestamp`, `date_day`, `hour` from `start_time_unix_nano`
+
+The transformation is applied in the Writer's Flight `do_put` handler before data is written to the WAL, ensuring all WAL data is in v2 format.
+
+### No Iceberg-Level Schema Evolution
+
+Currently, there is no Iceberg ALTER TABLE or runtime schema evolution. Tables are created with the current schema version (v2 for traces, v1 for logs/metrics). If a table already exists, it is loaded as-is. Incoming v1 data is always transformed to v2 before writing.
+
+## Multi-Tenant Storage Isolation
+
+### Isolation Summary
+
+```
+Tenant: "acme" (slug: "acme")
+├── Dataset: "production" (slug: "prod")
+│   ├── WAL:         .data/wal/acme/production/traces/
+│   ├── Iceberg NS:  ["acme", "prod"]
+│   ├── Object Path: .data/storage/acme/prod/traces/
+│   └── DataFusion:  acme.prod.traces
+│
+└── Dataset: "archive" (slug: "archive")
+    ├── WAL:         .data/wal/acme/archive/traces/
+    ├── Iceberg NS:  ["acme", "archive"]
+    ├── Object Path: s3://acme-archive/signals/acme/archive/traces/  (override)
+    └── DataFusion:  acme.archive.traces
+```
+
+### Slug-Based Naming
+
+All storage paths and Iceberg identifiers use **slugs** (URL-friendly identifiers), not raw IDs. Slugs are resolved from the tenant/dataset configuration:
+
+- `CatalogManager::get_tenant_slug(tenant_id)` -- returns slug from config, or `tenant_id` if not found
+- `CatalogManager::get_dataset_slug(tenant_id, dataset_id)` -- returns slug from config, or `dataset_id` if not found
+
+### Table Creation Flow
+
+When the `WalProcessor` encounters data for a new tenant/dataset/table combination:
+
+1. Resolve `tenant_slug` and `dataset_slug` from `CatalogManager`
+2. Resolve `StorageConfig` (per-dataset override or global)
+3. Compute table location: `{storage_base}/{tenant_slug}/{dataset_slug}/{table_name}`
+4. Check if table exists in Iceberg catalog: `catalog.tabular_exists(&table_ident)`
+5. If not, create with `CreateTableBuilder`:
+   - Schema from `iceberg_schemas` (matched by table name)
+   - Partition spec (Hour on timestamp)
+   - Table location pointing to the object store path
+6. Cache the `IcebergTableWriter` for future writes to the same combination
+
+### Configuration Toggles
+
+Table creation can be controlled per-tenant via `[schema.default_schemas]`:
+
+```toml
+[schema.default_schemas]
+traces_enabled = true
+logs_enabled = true
+metrics_enabled = true
+# custom_schemas = { "custom_table" = "..." }
+```
+
+## Key Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `schemas.toml` | Schema definitions with versioning and inheritance |
+| `src/common/src/schema/mod.rs` | Iceberg catalog creation, `TenantSchemaRegistry` |
+| `src/common/src/schema/schema_parser.rs` | TOML schema parser with inheritance resolution |
+| `src/common/src/schema/iceberg_schemas.rs` | Hardcoded metric schemas, partition specs, `TableSchema` enum |
+| `src/common/src/catalog_manager.rs` | `CatalogManager` singleton for shared Iceberg catalog |
+| `src/common/src/storage.rs` | Object store creation from DSN, path resolution |
+| `src/common/src/wal/mod.rs` | WAL implementation (segments, entries, flush, cleanup) |
+| `src/common/src/config/mod.rs` | Configuration structs including tenant/dataset/storage |
+| `src/writer/src/storage/iceberg.rs` | `IcebergTableWriter` -- table creation and data writes |
+| `src/writer/src/processor.rs` | `WalProcessor` -- background WAL-to-Iceberg processing |
+| `src/writer/src/schema_transform.rs` | Flight v1 -> Iceberg v2 schema transformation |
+| `src/querier/src/flight.rs` | `TenantCatalog` -- DataFusion/Iceberg namespace bridge |
+| `src/querier/src/query/table_ref.rs` | Safe table reference construction with slug validation |


### PR DESCRIPTION
## Summary

- **Rewrites `docs/architecture-overview.md`** from scratch to accurately reflect the current codebase, fixing numerous factual errors and adding missing sections
- **Creates `docs/design/storage-layout.md`** as a comprehensive design doc covering the object store layout, Iceberg catalog structure, table schemas, WAL layout, and multi-tenant storage isolation

## Key Changes to Architecture Overview

- Fixed incorrect service ports (Querier: 50054 not 9000, Writer standalone: 50061 not 50051)
- Fixed config format documentation (flat `[storage] dsn = "..."` not nested adapters)
- Added all 14 workspace members (was missing signaldb-cli, signaldb-api, signaldb-sdk, xtask, grafana-plugin backend)
- Added Multi-Tenancy and Authentication section (tenant model, auth flow, isolation layers)
- Documented dual catalog system (Service Catalog vs Iceberg Catalog)
- Marked Tempo API stubs honestly (tags, metrics endpoints return empty/hardcoded data)
- Flagged monolithic mode missing Querier as a known bug
- Added Schema Management, Grafana Plugin, CLI tool, and Admin API sections
- Removed unsubstantiated performance claims and stale 2024/2025 roadmap

## Storage Layout Design Doc

New `docs/design/storage-layout.md` covers:
- Three-tier storage model (WAL → Iceberg Catalog → Object Store)
- Physical object store directory structure with concrete examples
- All 7 table types with complete field-level schema definitions
- Hour-based Iceberg partitioning strategy
- WAL directory layout, segment files (.log/.data/.index), and entry format
- Schema versioning via `schemas.toml` with inheritance and v1→v2 transformation
- Multi-tenant isolation at every layer (WAL, Iceberg namespace, object store paths, DataFusion catalogs)
- Per-dataset storage override mechanism
- DataFusion `TenantCatalog` bridge for query resolution