### PR TITLE
chore: bump typify to 0.6 and add codegen-toolchain dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,12 @@ updates:
       opentelemetry:
         patterns:
           - "opentelemetry*"
+      codegen-toolchain:
+        patterns:
+          - "progenitor*"
+          - "typify"
+          - "openapiv3"
+          - "schemars"
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5098,7 +5098,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "percent-encoding",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5122,7 +5122,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.114",
  "thiserror 2.0.18",
- "typify 0.6.0",
+ "typify",
  "unicode-ident",
 ]
 
@@ -5666,15 +5666,15 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5710,7 +5710,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5964,7 +5964,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6411,7 +6411,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde_json",
  "signaldb-sdk",
  "tokio",
@@ -6440,7 +6440,7 @@ name = "signaldb-sdk"
 version = "0.1.0"
 dependencies = [
  "progenitor-client",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
 ]
 
@@ -7647,42 +7647,12 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typify"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5bcc6f62eb1fa8aa4098f39b29f93dcb914e17158b76c50360911257aa629"
-dependencies = [
- "typify-impl 0.5.0",
- "typify-macro 0.5.0",
-]
-
-[[package]]
-name = "typify"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1dac028e66a2f46bca342cc50d8b4a8cae7faa22bb1827d0edff2ba541137e"
 dependencies = [
- "typify-impl 0.6.0",
- "typify-macro 0.6.0",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1eb359f7ffa4f9ebe947fa11a1b2da054564502968db5f317b7e37693cb2240"
-dependencies = [
- "heck",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "syn 2.0.114",
- "thiserror 2.0.18",
- "unicode-ident",
+ "typify-impl",
+ "typify-macro",
 ]
 
 [[package]]
@@ -7707,23 +7677,6 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911c32f3c8514b048c1b228361bebb5e6d73aeec01696e8cc0e82e2ffef8ab7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 2.0.114",
- "typify-impl 0.5.0",
-]
-
-[[package]]
-name = "typify-macro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e11d93420ad3953f85e71a8662726a5fc20f2745d1c971a0102806f144157e"
@@ -7736,7 +7689,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "syn 2.0.114",
- "typify-impl 0.6.0",
+ "typify-impl",
 ]
 
 [[package]]
@@ -8047,6 +8000,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8068,9 +8034,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8589,7 +8555,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "syn 2.0.114",
- "typify 0.5.0",
+ "typify",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 progenitor = "0.12.0"
-typify = "0.5.0"
+typify = "0.6.0"
 openapiv3 = "2.2.0"
 schemars = "0.8"
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- Bumps `typify` from 0.5.0 to 0.6.0 in `xtask/Cargo.toml` (aligns with `progenitor` 0.12.0 which was upgraded in #385)
- Adds a `codegen-toolchain` group to `.github/dependabot.yml` so Dependabot tracks `progenitor*`, `typify`, `openapiv3`, and `schemars` together as a single update group