### PR TITLE
fix(docker): add dummy benchmark files for writer crate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ COPY xtask/Cargo.toml xtask/
 RUN mkdir -p src/acceptor/src && echo "fn main() {}" > src/acceptor/src/main.rs && \
     mkdir -p src/router/src && echo "fn main() {}" > src/router/src/main.rs && \
     mkdir -p src/writer/src && echo "fn main() {}" > src/writer/src/main.rs && \
+    mkdir -p src/writer/benches && echo "fn main() {}" > src/writer/benches/iceberg_benchmarks.rs && \
+    echo "fn main() {}" > src/writer/benches/connection_pool_benchmarks.rs && \
     mkdir -p src/querier/src && echo "fn main() {}" > src/querier/src/main.rs && \
     mkdir -p src/common/src && echo "pub fn dummy() {}" > src/common/src/lib.rs && \
     mkdir -p src/tempo-api/src && echo "pub fn dummy() {}" > src/tempo-api/src/lib.rs && \
@@ -61,7 +63,7 @@ RUN cargo build --release \
     --bin signaldb
 
 # Remove dummy files and build artifacts (keep cached dependencies)
-RUN rm -rf src/*/src && \
+RUN rm -rf src/*/src src/*/benches && \
     find target/release -type f -executable -delete && \
     rm -f target/release/deps/signaldb*
 


### PR DESCRIPTION
## Summary

Fixes the Docker build failure in CI where the build was failing with:
```
error: failed to parse manifest at `/build/src/writer/Cargo.toml`

Caused by:
  can't find `connection_pool_benchmarks` bench at 
  `benches/connection_pool_benchmarks.rs`
```

## Root Cause

The `writer/Cargo.toml` declares two benchmarks:
- `iceberg_benchmarks`
- `connection_pool_benchmarks`

The Dockerfile uses a two-stage dependency caching strategy:
1. Create dummy source files → build dependencies (cached layer)
2. Copy real source → build binaries

However, the dummy file creation step only created `src/` directories but not `benches/` directories. When cargo tried to parse the writer's manifest during the dependency build, it failed because the benchmark files referenced in Cargo.toml didn't exist.

## Changes

- Added dummy benchmark file creation in the Dockerfile's dependency caching step
- Updated cleanup step to remove dummy benchmark files before the real build

## Testing

- [x] Pre-commit hooks pass locally (compilation, formatting, clippy, machete, audit)
- Docker build will be tested in CI

Fixes #459 (Docker build failure)