### PR TITLE
chore: add github skill for gh CLI interactions

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: github
+description: Guidelines for interacting with GitHub repositories.
+user-invocable: false
+---
+
+Use `gh`cli for all GitHub interactions.
+
+Preflight checklist:
+
+- [ ] Ensure you have the latest version of `gh` installed.
+- [ ] Read the currently logged in user with `gh auth status` to confirm you have access to the relevant repositories.
+
+## Issues
+
+- Prefer to update existing issues rather than creating new ones, to maintain context and history.
+- When interacting with issues, confirm whether you are the author of the issue or if you are commenting on someone else's issue. This will guide your actions (e.g., editing vs commenting).
+
+## Tone
+
+- When commenting on issues, maintain a respectful and collaborative tone. Acknowledge the contributions of others and provide constructive feedback.
+- Prefer a based tone, but avoid being dismissive or confrontational. Aim to foster a positive and inclusive environment for discussion.
+- Dont be overly enthusiastic or use excessive emojis, as this can come across as unprofessional. Keep your comments clear and concise while still being friendly.


### PR DESCRIPTION
## Summary
- Add GitHub skill defining best practices for gh CLI usage
- Includes preflight checklist for gh auth verification
- Establishes tone guidelines for issue interactions

## Changes
- New skill at `.claude/skills/github/SKILL.md`
- Provides guidelines for respectful, professional GitHub interactions
- Emphasizes using gh CLI for all GitHub operations

## Test Plan
- [x] Skill file properly formatted with frontmatter
- [x] Guidelines are clear and actionable
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GitHub interaction guidelines for the development team, covering issue management, command-line tool usage, and professional communication standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->