### PR TITLE
fix(ci): resolve clippy 1.97 lints, security advisories, and ethnum build failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ catalog_uri = "sqlite::memory:"  # or sqlite:///path/to/catalog.db
 
 ### Rust Edition 2024
 
-Project requires Rust 1.88.0+ minimum.
+Project requires Rust 1.91.0+ minimum.
 
 ### Clippy Compliance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,15 +505,15 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -653,14 +653,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1287,7 +1288,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1301,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -1311,7 +1312,6 @@ dependencies = [
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -1329,14 +1329,13 @@ dependencies = [
  "rand 0.9.2",
  "rustls 0.23.36",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1361,19 +1360,18 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "chrono",
  "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -1612,6 +1610,17 @@ dependencies = [
  "regex",
  "serde",
  "vob",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1868,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1945,6 +1954,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3224,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "euclid"
@@ -3266,12 +3284,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferroid"
-version = "0.8.9"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.10.2",
  "web-time",
 ]
 
@@ -3585,6 +3603,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4664,9 +4683,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash",
 ]
@@ -6034,6 +6053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6071,6 +6101,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -6587,7 +6623,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6637,7 +6673,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -6662,9 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7006,7 +7042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7017,7 +7053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7776,9 +7812,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.26.3"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81ec0158db5fbb9831e09d1813fe5ea9023a2b5e6e8e0a5fe67e2a820733629"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -7789,6 +7825,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
+ "http 1.4.0",
  "itertools 0.14.0",
  "log",
  "memchr",
@@ -7806,9 +7843,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e75e78ff453128a2c7da9a5d5a3325ea34ea214d4bf51eab3417de23a4e5147"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
 dependencies = [
  "testcontainers",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,8 +146,8 @@ hex = "0.4"
 env_logger = "0.11.5"
 tower = "0.5.2"
 
-testcontainers = { version = "0.26.3", features = ["blocking"] }
-testcontainers-modules = { version = "0.14", features = ["postgres", "kafka", "minio"] }
+testcontainers = { version = "0.27.3", features = ["blocking"] }
+testcontainers-modules = { version = "0.15", features = ["postgres", "kafka", "minio"] }
 tempfile = "3.20.0"
 rand = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-members = [
 version = "0.1.0"
 edition = "2024"
 license = "AGPL-3.0"
-rust-version = "1.88.0"
+rust-version = "1.91.0"
 
 [workspace.dependencies]
 acceptor = { path = "src/acceptor", features = ["testing"] }

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,11 @@ ignore = [
     { id = "RUSTSEC-2025-0111", reason = "tokio-tar is a transitive dependency of testcontainers (dev-only). The crate is archived with no safe upgrade available. Only used in integration tests." },
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.x is unmaintained but widely used. It's a transitive dependency from datafusion and other crates. No security issues, just maintenance status." },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile 1.x/2.x is unmaintained but transitioning. It's a transitive dependency from AWS SDK and other TLS-related crates." },
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.38 is pinned by object_store 0.12, which must stay aligned with datafusion 51. Fixed by the coordinated object_store 0.13 / datafusion 52 upgrade (PR #275/#492). XML parsing only used for S3 list responses from trusted endpoints." },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.38 is pinned by object_store 0.12, which must stay aligned with datafusion 51. Fixed by the coordinated object_store 0.13 / datafusion 52 upgrade (PR #275/#492). XML parsing only used for S3 list responses from trusted endpoints." },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101 comes via rustls 0.21, a legacy TLS path in aws-smithy-http-client. Only pulled in by aws-config in tests-integration (dev-only). The 0.103 copy used in production paths is updated to the fixed 0.103.13." },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101 comes via rustls 0.21, a legacy TLS path in aws-smithy-http-client. Only pulled in by aws-config in tests-integration (dev-only). The 0.103 copy used in production paths is updated to the fixed 0.103.13." },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101 comes via rustls 0.21, a legacy TLS path in aws-smithy-http-client. Only pulled in by aws-config in tests-integration (dev-only). The 0.103 copy used in production paths is updated to the fixed 0.103.13." },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -746,6 +746,8 @@ impl Configuration {
 }
 
 #[cfg(test)]
+// figment::Error is >200 bytes but Jail::expect_with's closure signature is figment's API
+#[allow(clippy::result_large_err)]
 mod tests {
     use super::*;
     use figment::Jail;

--- a/src/compactor/src/iceberg/snapshot.rs
+++ b/src/compactor/src/iceberg/snapshot.rs
@@ -96,7 +96,7 @@ impl SnapshotManager {
         let mut snapshots = self.list_snapshots(table)?;
 
         // Sort by timestamp descending (most recent first)
-        snapshots.sort_by(|a, b| b.timestamp_ms.cmp(&a.timestamp_ms));
+        snapshots.sort_by_key(|s| std::cmp::Reverse(s.timestamp_ms));
 
         // Take the first N
         snapshots.truncate(count);
@@ -124,7 +124,7 @@ impl SnapshotManager {
         }
 
         // Sort by timestamp descending (most recent first)
-        all_snapshots.sort_by(|a, b| b.timestamp_ms.cmp(&a.timestamp_ms));
+        all_snapshots.sort_by_key(|s| std::cmp::Reverse(s.timestamp_ms));
 
         // Keep the first N, expire the rest
         let mut to_expire: Vec<SnapshotInfo> = all_snapshots.into_iter().skip(keep_count).collect();

--- a/src/writer/src/storage/iceberg.rs
+++ b/src/writer/src/storage/iceberg.rs
@@ -193,11 +193,9 @@ impl IcebergTableWriter {
         // Calculate optimal split size
         let max_rows_per_split = std::cmp::min(
             self.batch_config.max_rows_per_batch,
-            if memory_size > 0 {
-                (self.batch_config.max_memory_per_batch_bytes * row_count) / memory_size
-            } else {
-                self.batch_config.max_rows_per_batch
-            },
+            (self.batch_config.max_memory_per_batch_bytes * row_count)
+                .checked_div(memory_size)
+                .unwrap_or(self.batch_config.max_rows_per_batch),
         );
 
         log::info!(


### PR DESCRIPTION
Unblocks CI for all open Dependabot PRs. Main currently fails `Check & Lint` and `Security Audit` on every PR because:

## Clippy 1.97 (new stable) introduced lints that main trips
- `result_large_err` on the figment `Jail::expect_with` closures in `src/common/src/config/mod.rs` tests — allowed with justification (figment's API, can't box their error)
- `manual_checked_ops` in `src/writer/src/storage/iceberg.rs` — replaced with `checked_div`
- `unnecessary_sort_by` in `src/compactor/src/iceberg/snapshot.rs` — replaced with `sort_by_key(Reverse(..))`

## rustc 1.97 breaks ethnum 1.5.2
Transitive dep via apache-avro/iceberg-rust; its `transmute(())` to `TryFromIntError` is now a hard error (E0512). Lockfile bump to 1.5.3.

## Security Audit (cargo deny) failures
- **RUSTSEC-2026-0066** (astral-tokio-tar): fixed by bumping testcontainers 0.26 → 0.27 and testcontainers-modules 0.14 → 0.15 (dev-deps)
- **RUSTSEC-2026-0044** (aws-lc): lockfile update to aws-lc-rs 1.17 / aws-lc-sys 0.43
- **RUSTSEC-2026-0041** (lz4_flex): lockfile update to 0.12.2 (supersedes #503)
- **RUSTSEC-2026-0098/0099/0104** (rustls-webpki): 0.103 copy updated to fixed 0.103.13; legacy 0.101 copy (via rustls 0.21 in aws-smithy's legacy TLS path, test-only) ignored with justification
- **RUSTSEC-2026-0194/0195** (quick-xml): ignored with justification — pinned by object_store 0.12 which must stay aligned with datafusion 51; will be resolved by the coordinated object_store 0.13 / datafusion 52 upgrade (#275/#492)
- yanked `spin` 0.10.0 updated

Verified locally: `cargo check --workspace --all-targets --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo deny check` all pass.