### PR TITLE
docs(common): correct database env var to SIGNALDB_DATABASE_DSN

### DIFF
--- a/src/common/README.md
+++ b/src/common/README.md
@@ -417,7 +417,7 @@ cargo test -p common -- flight_integration
 ### Configuration Testing
 ```bash
 # Test configuration loading
-SIGNALDB_DATABASE_URL=test://url cargo test -p common -- config
+SIGNALDB_DATABASE_DSN=test://url cargo test -p common -- config
 ```
 
 ## Integration


### PR DESCRIPTION
One-line docs fix from backlog grooming (#125): the config example in `src/common/README.md` referenced `SIGNALDB_DATABASE_URL`, but the config loader only reads `SIGNALDB_DATABASE_DSN` (`database.dsn` via the `SIGNALDB_` figment prefix in `src/common/src/config/mod.rs`).

Refs #125