### PR TITLE
feat(acceptor): background WAL retry consumer for failed forwards

### DIFF
--- a/src/acceptor/src/handler/forward.rs
+++ b/src/acceptor/src/handler/forward.rs
@@ -1,0 +1,57 @@
+//! # Batch Forwarding
+//!
+//! Shared helper for forwarding Arrow RecordBatches from the acceptor to a
+//! writer service via Flight. Used by the OTLP/Prometheus handlers on the
+//! hot path and by the WAL retry consumer when replaying entries whose
+//! initial forward failed.
+
+use anyhow::Context;
+use arrow_flight::utils::batches_to_flight_data;
+use bytes::Bytes;
+use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::{StreamExt, stream};
+
+/// Forward a RecordBatch to a writer service with Storage capability.
+///
+/// `metadata_json` is attached as `app_metadata` on the first FlightData
+/// message (the schema message) so the writer can route the batch to the
+/// right table.
+///
+/// Returns an error if no storage service is discoverable, the batch cannot
+/// be encoded, or the Flight put fails. The caller decides whether the data
+/// stays in the WAL for retry.
+pub async fn forward_batch_to_writer(
+    flight_transport: &InMemoryFlightTransport,
+    record_batch: RecordBatch,
+    metadata_json: Option<&str>,
+) -> anyhow::Result<()> {
+    let mut client = flight_transport
+        .get_client_for_capability(ServiceCapability::Storage)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get Flight client for storage service: {e}"))?;
+
+    let schema = record_batch.schema();
+    let mut flight_data = batches_to_flight_data(&schema, vec![record_batch])
+        .context("Failed to convert batch to flight data")?;
+
+    // Add metadata to the first FlightData message (which contains the schema)
+    if let Some(metadata_json) = metadata_json
+        && let Some(first) = flight_data.first_mut()
+    {
+        first.app_metadata = Bytes::from(metadata_json.as_bytes().to_vec());
+    }
+
+    let response = client
+        .do_put(stream::iter(flight_data))
+        .await
+        .context("Flight do_put failed")?;
+
+    let mut response_stream = response.into_inner();
+    while let Some(result) = response_stream.next().await {
+        let put_result = result.context("Flight put error")?;
+        tracing::debug!(response = ?put_result, "Flight put response");
+    }
+
+    Ok(())
+}

--- a/src/acceptor/src/handler/mod.rs
+++ b/src/acceptor/src/handler/mod.rs
@@ -1,8 +1,11 @@
+pub mod forward;
 pub mod otlp_grpc;
 pub mod otlp_log_handler;
 pub mod otlp_metrics_handler;
 pub mod prometheus_handler;
 pub mod wal_manager;
+pub mod wal_retry;
 
 pub use prometheus_handler::{PrometheusHandler, PrometheusHandlerState, handle_prometheus_write};
 pub use wal_manager::WalManager;
+pub use wal_retry::WalRetryConsumer;

--- a/src/acceptor/src/handler/otlp_grpc.rs
+++ b/src/acceptor/src/handler/otlp_grpc.rs
@@ -2,15 +2,12 @@ use std::sync::Arc;
 
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_traces_to_arrow;
-use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use common::flight::transport::InMemoryFlightTransport;
 use common::wal::{WalOperation, record_batch_to_bytes};
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 
 use super::WalManager;
-// Flight protocol imports
-use arrow_flight::utils::batches_to_flight_data;
-use bytes::Bytes;
-use futures::{StreamExt, stream};
+use super::forward::forward_batch_to_writer;
 
 pub struct TraceHandler {
     /// Flight transport for forwarding telemetry
@@ -154,68 +151,22 @@ impl TraceHandler {
         tracing::debug!(entry_id = %wal_entry_id, "Traces written to WAL");
 
         // Step 2: Forward from WAL to writer via Flight
-        // Get a Flight client for a writer service with storage capability (excludes acceptor)
-        let mut client = match self
-            .flight_transport
-            .get_client_for_capability(ServiceCapability::Storage)
-            .await
+        match forward_batch_to_writer(
+            &self.flight_transport,
+            record_batch,
+            Some(&metadata.to_string()),
+        )
+        .await
         {
-            Ok(client) => client,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to get Flight client for storage service");
-                // Data remains in WAL for retry by background processor
-                return;
-            }
-        };
-
-        let schema = record_batch.schema();
-        let mut flight_data = match batches_to_flight_data(&schema, vec![record_batch]) {
-            Ok(data) => data,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to convert batch to flight data");
-                // Data remains in WAL for retry
-                return;
-            }
-        };
-
-        // Add metadata to the first FlightData message (which contains the schema)
-        if !flight_data.is_empty() {
-            let metadata_bytes = metadata.to_string().into_bytes();
-            flight_data[0].app_metadata = Bytes::from(metadata_bytes);
-        }
-
-        let flight_stream = stream::iter(flight_data);
-
-        match client.do_put(flight_stream).await {
-            Ok(response) => {
-                let mut response_stream = response.into_inner();
-                let mut success = true;
-                while let Some(result) = response_stream.next().await {
-                    match result {
-                        Ok(put_result) => {
-                            tracing::debug!(response = ?put_result, "Flight put response");
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "Flight put error");
-                            success = false;
-                            break;
-                        }
-                    }
-                }
-
-                if success {
-                    tracing::debug!("Successfully forwarded traces via Flight protocol");
-                    // Mark WAL entry as processed after successful forwarding
-                    if let Err(e) = wal.mark_processed(wal_entry_id).await {
-                        tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
-                    }
-                } else {
-                    tracing::error!("Failed to forward traces - data remains in WAL for retry");
+            Ok(()) => {
+                tracing::debug!("Successfully forwarded traces via Flight protocol");
+                // Mark WAL entry as processed after successful forwarding
+                if let Err(e) = wal.mark_processed(wal_entry_id).await {
+                    tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
                 }
             }
             Err(e) => {
-                tracing::error!(error = %e, "Failed to forward traces via Flight protocol");
-                // Data remains in WAL for retry by background processor
+                tracing::error!(error = %e, "Failed to forward traces - data remains in WAL for retry");
             }
         }
     }

--- a/src/acceptor/src/handler/otlp_log_handler.rs
+++ b/src/acceptor/src/handler/otlp_log_handler.rs
@@ -2,15 +2,12 @@ use std::sync::Arc;
 
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_logs_to_arrow;
-use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use common::flight::transport::InMemoryFlightTransport;
 use common::wal::{WalOperation, record_batch_to_bytes};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 
 use super::WalManager;
-// Flight protocol imports
-use arrow_flight::utils::batches_to_flight_data;
-use bytes::Bytes;
-use futures::{StreamExt, stream};
+use super::forward::forward_batch_to_writer;
 
 pub struct LogHandler {
     /// Flight transport for forwarding telemetry
@@ -155,68 +152,22 @@ impl LogHandler {
         tracing::debug!(entry_id = %wal_entry_id, "Logs written to WAL");
 
         // Step 2: Forward from WAL to writer via Flight
-        // Get a Flight client for a writer service with storage capability
-        let mut client = match self
-            .flight_transport
-            .get_client_for_capability(ServiceCapability::Storage)
-            .await
+        match forward_batch_to_writer(
+            &self.flight_transport,
+            record_batch,
+            Some(&metadata.to_string()),
+        )
+        .await
         {
-            Ok(client) => client,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to get Flight client for storage service");
-                // Data remains in WAL for retry by background processor
-                return;
-            }
-        };
-
-        let schema = record_batch.schema();
-        let mut flight_data = match batches_to_flight_data(&schema, vec![record_batch]) {
-            Ok(data) => data,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to convert batch to flight data");
-                // Data remains in WAL for retry
-                return;
-            }
-        };
-
-        // Add metadata to the first FlightData message (which contains the schema)
-        if !flight_data.is_empty() {
-            let metadata_bytes = metadata.to_string().into_bytes();
-            flight_data[0].app_metadata = Bytes::from(metadata_bytes);
-        }
-
-        let flight_stream = stream::iter(flight_data);
-
-        match client.do_put(flight_stream).await {
-            Ok(response) => {
-                let mut response_stream = response.into_inner();
-                let mut success = true;
-                while let Some(result) = response_stream.next().await {
-                    match result {
-                        Ok(put_result) => {
-                            tracing::debug!(response = ?put_result, "Flight put response");
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "Flight put error");
-                            success = false;
-                            break;
-                        }
-                    }
-                }
-
-                if success {
-                    tracing::debug!("Successfully forwarded logs via Flight protocol");
-                    // Mark WAL entry as processed after successful forwarding
-                    if let Err(e) = wal.mark_processed(wal_entry_id).await {
-                        tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
-                    }
-                } else {
-                    tracing::error!("Failed to forward logs - data remains in WAL for retry");
+            Ok(()) => {
+                tracing::debug!("Successfully forwarded logs via Flight protocol");
+                // Mark WAL entry as processed after successful forwarding
+                if let Err(e) = wal.mark_processed(wal_entry_id).await {
+                    tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
                 }
             }
             Err(e) => {
-                tracing::error!(error = %e, "Failed to forward logs via Flight protocol");
-                // Data remains in WAL for retry by background processor
+                tracing::error!(error = %e, "Failed to forward logs - data remains in WAL for retry");
             }
         }
     }

--- a/src/acceptor/src/handler/otlp_metrics_handler.rs
+++ b/src/acceptor/src/handler/otlp_metrics_handler.rs
@@ -2,16 +2,13 @@ use std::sync::Arc;
 
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_metrics_to_arrow;
-use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use common::flight::transport::InMemoryFlightTransport;
 use common::wal::{WalOperation, record_batch_to_bytes};
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 
 use super::WalManager;
-// Flight protocol imports
-use arrow_flight::utils::batches_to_flight_data;
-use bytes::Bytes;
-use futures::{StreamExt, stream};
+use super::forward::forward_batch_to_writer;
 
 pub struct MetricsHandler {
     /// Flight transport for forwarding telemetry
@@ -376,79 +373,30 @@ impl MetricsHandler {
             }
 
             // Step 2: Forward from WAL to writer via Flight
-            // Get a Flight client for a writer service with storage capability
-            let mut client = match self
-                .flight_transport
-                .get_client_for_capability(ServiceCapability::Storage)
-                .await
+            match forward_batch_to_writer(
+                &self.flight_transport,
+                record_batch,
+                Some(&metadata.to_string()),
+            )
+            .await
             {
-                Ok(client) => client,
-                Err(e) => {
-                    tracing::error!(metric_type = %metric_type, error = %e, "Failed to get Flight client for metrics");
-                    // Data remains in WAL for retry by background processor
-                    continue;
-                }
-            };
-
-            let schema = record_batch.schema();
-            let mut flight_data = match batches_to_flight_data(&schema, vec![record_batch]) {
-                Ok(data) => data,
-                Err(e) => {
-                    tracing::error!(metric_type = %metric_type, error = %e, "Failed to convert batch to flight data");
-                    // Data remains in WAL for retry
-                    continue;
-                }
-            };
-
-            // Add metadata to the first FlightData message (which contains the schema)
-            if !flight_data.is_empty() {
-                let metadata_bytes = metadata.to_string().into_bytes();
-                flight_data[0].app_metadata = Bytes::from(metadata_bytes);
-            }
-
-            let flight_stream = stream::iter(flight_data);
-
-            match client.do_put(flight_stream).await {
-                Ok(response) => {
-                    let mut response_stream = response.into_inner();
-                    let mut success = true;
-                    while let Some(result) = response_stream.next().await {
-                        match result {
-                            Ok(put_result) => {
-                                tracing::debug!(
-                                    metric_type = %metric_type,
-                                    response = ?put_result,
-                                    "Flight put response"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::error!(metric_type = %metric_type, error = %e, "Flight put error");
-                                success = false;
-                                break;
-                            }
-                        }
-                    }
-
-                    if success {
-                        tracing::debug!(
-                            metric_type = %metric_type,
-                            target_table = %target_table,
-                            "Successfully forwarded metrics via Flight"
-                        );
-                        // Mark WAL entry as processed after successful forwarding
-                        if let Err(e) = wal.mark_processed(wal_entry_id).await {
-                            tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
-                        }
-                    } else {
-                        tracing::error!(
-                            metric_type = %metric_type,
-                            "Failed to forward metrics - data remains in WAL for retry"
-                        );
+                Ok(()) => {
+                    tracing::debug!(
+                        metric_type = %metric_type,
+                        target_table = %target_table,
+                        "Successfully forwarded metrics via Flight"
+                    );
+                    // Mark WAL entry as processed after successful forwarding
+                    if let Err(e) = wal.mark_processed(wal_entry_id).await {
+                        tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
                     }
                 }
                 Err(e) => {
-                    tracing::error!(metric_type = %metric_type, error = %e, "Failed to forward metrics via Flight");
-                    // Data remains in WAL for retry by background processor
+                    tracing::error!(
+                        metric_type = %metric_type,
+                        error = %e,
+                        "Failed to forward metrics - data remains in WAL for retry"
+                    );
                 }
             }
         }

--- a/src/acceptor/src/handler/prometheus_handler.rs
+++ b/src/acceptor/src/handler/prometheus_handler.rs
@@ -29,7 +29,7 @@ use common::{
             conversion_prometheus::{decode_prometheus_remote_write, prometheus_to_otel_metrics},
             otlp_metrics_to_arrow,
         },
-        transport::{InMemoryFlightTransport, ServiceCapability},
+        transport::InMemoryFlightTransport,
     },
     wal::{WalOperation, record_batch_to_bytes},
 };
@@ -37,9 +37,8 @@ use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use tracing;
 
 use super::WalManager;
+use super::forward::forward_batch_to_writer;
 use crate::middleware::TenantContextExtractor;
-use arrow_flight::utils::batches_to_flight_data;
-use futures::{StreamExt, stream};
 
 /// Content type for Prometheus remote_write requests
 pub const PROMETHEUS_CONTENT_TYPE: &str = "application/x-protobuf";
@@ -242,67 +241,26 @@ impl PrometheusHandler {
             }
 
             // Forward to writer via Flight
-            let mut client = match self
-                .flight_transport
-                .get_client_for_capability(ServiceCapability::Storage)
-                .await
+            match forward_batch_to_writer(
+                &self.flight_transport,
+                record_batch,
+                Some(&metadata.to_string()),
+            )
+            .await
             {
-                Ok(client) => client,
-                Err(e) => {
-                    tracing::error!(error = ?e, "Failed to get Flight client");
-                    // Data remains in WAL for retry
-                    continue;
-                }
-            };
-
-            let schema = record_batch.schema();
-            let mut flight_data = match batches_to_flight_data(&schema, vec![record_batch]) {
-                Ok(data) => data,
-                Err(e) => {
-                    tracing::error!(error = ?e, "Failed to convert to flight data");
-                    continue;
-                }
-            };
-
-            // Add metadata to first FlightData message
-            if !flight_data.is_empty() {
-                flight_data[0].app_metadata = Bytes::from(metadata.to_string().into_bytes());
-            }
-
-            let flight_stream = stream::iter(flight_data);
-
-            match client.do_put(flight_stream).await {
-                Ok(response) => {
-                    let mut response_stream = response.into_inner();
-                    let mut success = true;
-                    while let Some(result) = response_stream.next().await {
-                        match result {
-                            Ok(put_result) => {
-                                tracing::debug!(?put_result, "Flight put response");
-                            }
-                            Err(e) => {
-                                tracing::error!(error = ?e, "Flight put error");
-                                success = false;
-                                break;
-                            }
-                        }
+                Ok(()) => {
+                    // Mark WAL entry as processed
+                    if let Err(e) = wal.mark_processed(wal_entry_id).await {
+                        tracing::warn!(error = ?e, wal_entry_id = %wal_entry_id, "Failed to mark WAL entry as processed");
                     }
-
-                    if success {
-                        // Mark WAL entry as processed
-                        if let Err(e) = wal.mark_processed(wal_entry_id).await {
-                            tracing::warn!(error = ?e, wal_entry_id = %wal_entry_id, "Failed to mark WAL entry as processed");
-                        }
-                        tracing::debug!(
-                            metric_type = %metric_type,
-                            target_table = %target_table,
-                            "Successfully forwarded to writer"
-                        );
-                    }
+                    tracing::debug!(
+                        metric_type = %metric_type,
+                        target_table = %target_table,
+                        "Successfully forwarded to writer"
+                    );
                 }
                 Err(e) => {
-                    tracing::error!(error = ?e, "Failed to forward via Flight");
-                    // Data remains in WAL for retry
+                    tracing::error!(error = ?e, "Failed to forward via Flight - data remains in WAL for retry");
                 }
             }
         }

--- a/src/acceptor/src/handler/wal_manager.rs
+++ b/src/acceptor/src/handler/wal_manager.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Key for WAL cache: (tenant_id, dataset_id, signal_type)
-type WalKey = (String, String, String);
+pub type WalKey = (String, String, String);
 
 /// Manager for creating and caching per-tenant/dataset WAL instances
 ///
@@ -176,6 +176,121 @@ impl WalManager {
     /// Useful for monitoring and debugging.
     pub async fn wal_count(&self) -> usize {
         self.wals.lock().await.len()
+    }
+
+    /// Snapshot of all cached WAL instances with their keys
+    ///
+    /// Used by the WAL retry consumer to scan every tenant/dataset/signal
+    /// WAL for unprocessed entries.
+    pub async fn all_wals(&self) -> Vec<(WalKey, Arc<Wal>)> {
+        self.wals
+            .lock()
+            .await
+            .iter()
+            .map(|(key, wal)| (key.clone(), wal.clone()))
+            .collect()
+    }
+
+    /// Discover WAL directories left on disk by previous runs and open them
+    ///
+    /// WALs are created lazily on first write, so after a restart a WAL with
+    /// pending entries would not be in the cache until new traffic arrives
+    /// for that tenant/dataset/signal — and entries from the previous run
+    /// would never be retried. This scans the base WAL directories for
+    /// `{tenant}/{dataset}/{signal}` layouts and opens each one.
+    ///
+    /// Returns the number of newly opened WAL instances.
+    pub async fn discover_existing_wals(&self) -> Result<usize, anyhow::Error> {
+        let mut base_dirs = Vec::new();
+        for config in [&self.traces_config, &self.logs_config, &self.metrics_config] {
+            if !base_dirs.contains(&config.wal_dir) {
+                base_dirs.push(config.wal_dir.clone());
+            }
+        }
+
+        let mut opened = 0;
+        for base_dir in base_dirs {
+            if !base_dir.is_dir() {
+                continue;
+            }
+            for (tenant, dataset, signal) in Self::scan_wal_layout(&base_dir).await? {
+                let already_cached = {
+                    let wals = self.wals.lock().await;
+                    wals.contains_key(&(tenant.clone(), dataset.clone(), signal.clone()))
+                };
+                if already_cached {
+                    continue;
+                }
+                match self.get_wal(&tenant, &dataset, &signal).await {
+                    Ok(_) => {
+                        opened += 1;
+                        log::info!(
+                            "Discovered existing WAL for tenant='{tenant}', dataset='{dataset}', signal='{signal}'"
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to open discovered WAL for tenant='{tenant}', dataset='{dataset}', signal='{signal}': {e}"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(opened)
+    }
+
+    /// Scan a base WAL directory for `{tenant}/{dataset}/{signal}` triples
+    /// that contain WAL segment files.
+    async fn scan_wal_layout(
+        base_dir: &std::path::Path,
+    ) -> Result<Vec<(String, String, String)>, anyhow::Error> {
+        const SIGNALS: [&str; 3] = ["traces", "logs", "metrics"];
+        let mut found = Vec::new();
+
+        let mut tenants = tokio::fs::read_dir(base_dir).await?;
+        while let Some(tenant_entry) = tenants.next_entry().await? {
+            if !tenant_entry.file_type().await?.is_dir() {
+                continue;
+            }
+            let Some(tenant) = tenant_entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+
+            let mut datasets = tokio::fs::read_dir(tenant_entry.path()).await?;
+            while let Some(dataset_entry) = datasets.next_entry().await? {
+                if !dataset_entry.file_type().await?.is_dir() {
+                    continue;
+                }
+                let Some(dataset) = dataset_entry.file_name().to_str().map(String::from) else {
+                    continue;
+                };
+
+                for signal in SIGNALS {
+                    let signal_dir = dataset_entry.path().join(signal);
+                    if !signal_dir.is_dir() {
+                        continue;
+                    }
+                    // Only open directories that actually contain WAL segments
+                    let mut has_segments = false;
+                    let mut files = tokio::fs::read_dir(&signal_dir).await?;
+                    while let Some(file) = files.next_entry().await? {
+                        if let Some(name) = file.file_name().to_str()
+                            && name.starts_with("wal-")
+                            && name.ends_with(".log")
+                        {
+                            has_segments = true;
+                            break;
+                        }
+                    }
+                    if has_segments {
+                        found.push((tenant.clone(), dataset.clone(), signal.to_string()));
+                    }
+                }
+            }
+        }
+
+        Ok(found)
     }
 
     /// Clear all cached WAL instances

--- a/src/acceptor/src/handler/wal_retry.rs
+++ b/src/acceptor/src/handler/wal_retry.rs
@@ -1,0 +1,303 @@
+//! # WAL Retry Consumer
+//!
+//! Background consumer that replays unprocessed acceptor WAL entries.
+//!
+//! The hot path (OTLP/Prometheus handlers) appends to the WAL, forwards the
+//! batch to a writer via Flight, and marks the entry processed on success.
+//! When the forward fails (writer down, slow, restarting, catalog
+//! unreachable), the entry stays unprocessed in the WAL. Without a retry
+//! consumer those entries were never re-forwarded and their segments never
+//! reclaimed.
+//!
+//! `WalRetryConsumer` closes that gap: on an interval it scans every WAL
+//! managed by the [`WalManager`], re-forwards unprocessed entries older than
+//! a minimum age (so it does not race in-flight hot-path forwards), and
+//! marks them processed on success so segment cleanup can reclaim disk.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use common::flight::transport::InMemoryFlightTransport;
+use common::wal::{WalOperation, bytes_to_record_batch};
+
+use super::WalManager;
+use super::forward::forward_batch_to_writer;
+
+/// How often the retry consumer scans for unprocessed entries.
+pub const DEFAULT_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Minimum age an unprocessed entry must reach before it is retried.
+///
+/// This keeps the consumer from racing the hot path, which forwards the
+/// entry inline right after appending it.
+pub const DEFAULT_MIN_ENTRY_AGE: Duration = Duration::from_secs(30);
+
+/// Outcome of a single retry pass, for logging and tests.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RetryStats {
+    /// Entries successfully re-forwarded and marked processed
+    pub retried: usize,
+    /// Entries that could not be re-forwarded this pass
+    pub failed: usize,
+}
+
+/// Background consumer that re-forwards unprocessed WAL entries to a writer.
+pub struct WalRetryConsumer {
+    wal_manager: Arc<WalManager>,
+    flight_transport: Arc<InMemoryFlightTransport>,
+    interval: Duration,
+    min_entry_age: Duration,
+}
+
+impl WalRetryConsumer {
+    pub fn new(
+        wal_manager: Arc<WalManager>,
+        flight_transport: Arc<InMemoryFlightTransport>,
+    ) -> Self {
+        Self {
+            wal_manager,
+            flight_transport,
+            interval: DEFAULT_RETRY_INTERVAL,
+            min_entry_age: DEFAULT_MIN_ENTRY_AGE,
+        }
+    }
+
+    /// Override scan interval and minimum entry age (used by tests).
+    pub fn with_timing(mut self, interval: Duration, min_entry_age: Duration) -> Self {
+        self.interval = interval;
+        self.min_entry_age = min_entry_age;
+        self
+    }
+
+    /// Spawn the retry loop as a background task.
+    pub fn spawn(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(self.interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            loop {
+                ticker.tick().await;
+
+                match self.run_once().await {
+                    Ok(stats) if stats.retried > 0 || stats.failed > 0 => {
+                        tracing::info!(
+                            retried = stats.retried,
+                            failed = stats.failed,
+                            "WAL retry pass completed"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::error!(error = %e, "WAL retry pass failed");
+                    }
+                }
+            }
+        })
+    }
+
+    /// Run a single retry pass over all managed WALs.
+    ///
+    /// Forward failures for one WAL abort the rest of that WAL's entries for
+    /// this pass (the writer is likely unavailable) but other WALs are still
+    /// attempted.
+    pub async fn run_once(&self) -> anyhow::Result<RetryStats> {
+        let mut stats = RetryStats::default();
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+        for ((tenant, dataset, signal), wal) in self.wal_manager.all_wals().await {
+            let entries = match wal.get_unprocessed_entries().await {
+                Ok(entries) => entries,
+                Err(e) => {
+                    tracing::warn!(
+                        tenant_id = %tenant,
+                        dataset_id = %dataset,
+                        signal = %signal,
+                        error = %e,
+                        "Failed to list unprocessed WAL entries"
+                    );
+                    continue;
+                }
+            };
+
+            for entry in entries {
+                if matches!(entry.operation, WalOperation::Flush) {
+                    continue;
+                }
+                if now.saturating_sub(entry.timestamp) < self.min_entry_age.as_secs() {
+                    continue;
+                }
+
+                let batch = match wal.read_entry_data(&entry).await {
+                    Ok(data) => match bytes_to_record_batch(&data) {
+                        Ok(batch) => batch,
+                        Err(e) => {
+                            tracing::warn!(
+                                entry_id = %entry.id,
+                                error = %e,
+                                "Failed to deserialize WAL entry data; skipping"
+                            );
+                            stats.failed += 1;
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            entry_id = %entry.id,
+                            error = %e,
+                            "Failed to read WAL entry data; skipping"
+                        );
+                        stats.failed += 1;
+                        continue;
+                    }
+                };
+
+                match forward_batch_to_writer(
+                    &self.flight_transport,
+                    batch,
+                    entry.metadata.as_deref(),
+                )
+                .await
+                {
+                    Ok(()) => {
+                        if let Err(e) = wal.mark_processed(entry.id).await {
+                            tracing::warn!(
+                                entry_id = %entry.id,
+                                error = %e,
+                                "Re-forwarded WAL entry but failed to mark it processed"
+                            );
+                        }
+                        stats.retried += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            tenant_id = %tenant,
+                            dataset_id = %dataset,
+                            signal = %signal,
+                            entry_id = %entry.id,
+                            error = %e,
+                            "Failed to re-forward WAL entry; writer may be unavailable"
+                        );
+                        stats.failed += 1;
+                        // Writer is likely down — don't hammer it with the
+                        // remaining entries of this WAL in the same pass.
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+    use common::wal::WalConfig;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn test_config(base_dir: &Path) -> WalConfig {
+        let mut config = WalConfig::with_defaults(base_dir.to_path_buf());
+        config.max_segment_size = 1024 * 1024;
+        config.max_buffer_entries = 100;
+        config.flush_interval_secs = 3600;
+        config
+    }
+
+    fn test_manager(base_dir: &Path) -> WalManager {
+        WalManager::new(
+            test_config(base_dir),
+            test_config(base_dir),
+            test_config(base_dir),
+        )
+    }
+
+    async fn test_transport() -> Arc<InMemoryFlightTransport> {
+        let bootstrap = ServiceBootstrap::new_for_test(ServiceType::Acceptor, "127.0.0.1:0")
+            .await
+            .unwrap();
+        Arc::new(InMemoryFlightTransport::new(bootstrap))
+    }
+
+    async fn append_entry(manager: &WalManager) {
+        let wal = manager
+            .get_wal("acme", "production", "traces")
+            .await
+            .unwrap();
+        wal.append(WalOperation::WriteTraces, b"not-a-batch".to_vec(), None)
+            .await
+            .unwrap();
+        wal.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_once_skips_entries_younger_than_min_age() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = Arc::new(test_manager(temp_dir.path()));
+        append_entry(&manager).await;
+
+        let consumer = WalRetryConsumer::new(manager.clone(), test_transport().await)
+            .with_timing(Duration::from_secs(1), Duration::from_secs(3600));
+
+        let stats = consumer.run_once().await.unwrap();
+        assert_eq!(stats, RetryStats::default());
+
+        // Entry must still be pending
+        let wal = manager
+            .get_wal("acme", "production", "traces")
+            .await
+            .unwrap();
+        assert_eq!(wal.get_unprocessed_entries().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_once_counts_failures_and_keeps_entries_pending() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = Arc::new(test_manager(temp_dir.path()));
+        append_entry(&manager).await;
+
+        // No storage service is registered, so the forward must fail and the
+        // entry must remain unprocessed for a later pass.
+        let consumer = WalRetryConsumer::new(manager.clone(), test_transport().await)
+            .with_timing(Duration::from_secs(1), Duration::ZERO);
+
+        let stats = consumer.run_once().await.unwrap();
+        assert_eq!(stats.retried, 0);
+        assert_eq!(stats.failed, 1);
+
+        let wal = manager
+            .get_wal("acme", "production", "traces")
+            .await
+            .unwrap();
+        assert_eq!(wal.get_unprocessed_entries().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn discovery_surfaces_wals_from_previous_run() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Simulate a previous acceptor run that left an unprocessed entry
+        {
+            let manager = test_manager(temp_dir.path());
+            append_entry(&manager).await;
+        }
+
+        // Fresh manager (fresh process): cache is empty until discovery runs
+        let manager = Arc::new(test_manager(temp_dir.path()));
+        assert_eq!(manager.wal_count().await, 0);
+
+        let discovered = manager.discover_existing_wals().await.unwrap();
+        assert_eq!(discovered, 1);
+        assert_eq!(manager.wal_count().await, 1);
+
+        let wals = manager.all_wals().await;
+        assert_eq!(wals.len(), 1);
+        let ((tenant, dataset, signal), wal) = &wals[0];
+        assert_eq!(tenant, "acme");
+        assert_eq!(dataset, "production");
+        assert_eq!(signal, "traces");
+        assert_eq!(wal.get_unprocessed_entries().await.unwrap().len(), 1);
+    }
+}

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -32,11 +32,11 @@ use common::flight::transport::InMemoryFlightTransport;
 // WAL for durability
 use common::wal::WalConfig;
 
-use crate::handler::WalManager;
 use crate::handler::otlp_grpc::TraceHandler;
 use crate::handler::otlp_log_handler::LogHandler;
 use crate::handler::otlp_metrics_handler::MetricsHandler;
 use crate::handler::{PrometheusHandler, PrometheusHandlerState};
+use crate::handler::{WalManager, WalRetryConsumer};
 use crate::middleware::auth_middleware;
 use crate::middleware::grpc_auth::grpc_auth_interceptor;
 use crate::services::{
@@ -149,6 +149,24 @@ pub async fn init_acceptor_resources(
         wal_dir = %wal_dir.display(),
         "Initialized WalManager for multi-tenant WAL isolation"
     );
+
+    // Open WALs left on disk by previous runs so their unprocessed entries
+    // get retried even before new traffic arrives for those tenants.
+    match wal_manager.discover_existing_wals().await {
+        Ok(discovered) if discovered > 0 => {
+            tracing::info!(discovered, "Discovered existing WALs from previous runs");
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to discover existing WALs");
+        }
+    }
+
+    // Background retry consumer: re-forwards unprocessed WAL entries whose
+    // inline forward to the writer failed, and marks them processed so
+    // segments can be reclaimed.
+    WalRetryConsumer::new(wal_manager.clone(), flight_transport.clone()).spawn();
+    tracing::info!("Started WAL retry consumer");
 
     // Create Authenticator for multi-tenant authentication
     let authenticator = Arc::new(Authenticator::new(auth_config, catalog));


### PR DESCRIPTION
## Summary

Implements the missing acceptor-side WAL retry mechanism (#549), part of hardening epic #563.

The acceptor's `WalManager` only ever started a background *flush* task. The code comments claiming *"data remains in WAL for retry by background processor"* referred to a processor that did not exist: entries whose inline Flight forward to the writer failed were never retried, and since segments are only reclaimed once fully processed, they accumulated on disk forever.

### Changes

- **`WalRetryConsumer`** — interval-driven background task (10s) that scans every WAL managed by `WalManager`, re-forwards unprocessed entries older than a minimum age (30s, to avoid racing in-flight hot-path forwards), and marks them processed on success so segment cleanup can reclaim disk. A forward failure aborts the rest of that WAL's entries for the pass (writer likely down) but other WALs are still attempted.
- **`WalManager::discover_existing_wals`** — scans the on-disk `{tenant}/{dataset}/{signal}` layout at startup and opens WALs left by previous runs, so their pending entries are retried even before new traffic arrives for those tenants.
- **`forward_batch_to_writer`** — the four near-identical ~60-line inline forward blocks (traces, logs, metrics, Prometheus) are deduplicated into one shared helper used by both the hot path and the retry consumer (second commit, behavior-preserving).
- Wired up in `init_acceptor_resources`, so both standalone acceptor and monolithic mode get the consumer.

### Notes

- Multi-segment retry correctness (entries in rotated-out segments) additionally depends on #573.
- This is the prerequisite for fixing the acceptor false-ACK issue (#543): early ACK after WAL flush is only defensible once unprocessed entries are actually retried. That fix lands separately.

### Tests

- `run_once_skips_entries_younger_than_min_age`
- `run_once_counts_failures_and_keeps_entries_pending` — no storage service registered: entry must remain unprocessed for a later pass
- `discovery_surfaces_wals_from_previous_run` — fresh manager on an existing WAL dir finds and opens the WAL with its pending entry

Closes #549
Part of #563