### PR TITLE
fix(acceptor): reject OTLP exports that are not durably accepted

### DIFF
--- a/src/acceptor/src/handler/otlp_grpc.rs
+++ b/src/acceptor/src/handler/otlp_grpc.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context;
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_traces_to_arrow;
 use common::flight::transport::InMemoryFlightTransport;
@@ -40,11 +41,12 @@ impl MockTraceHandler {
         &self,
         _tenant_context: &TenantContext,
         request: ExportTraceServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         self.handle_grpc_otlp_traces_calls
             .lock()
             .await
             .push(request);
+        Ok(())
     }
 
     pub fn expect_handle_grpc_otlp_traces(&mut self) -> &mut Self {
@@ -64,6 +66,14 @@ impl TraceHandler {
         }
     }
 
+    /// Handle an OTLP trace export.
+    ///
+    /// Returns `Ok(())` once the data is durably accepted: written and
+    /// flushed to the WAL. A failed Flight forward after that point is not
+    /// an error — the WAL retry consumer re-forwards the entry.
+    ///
+    /// Any failure before WAL durability is returned as an error so the
+    /// service layer can reject the export and the client retries.
     #[tracing::instrument(
         skip_all,
         fields(
@@ -75,7 +85,7 @@ impl TraceHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportTraceServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         tracing::info!(
             tenant_id = %tenant_context.tenant_id,
             dataset_id = %tenant_context.dataset_id,
@@ -83,7 +93,7 @@ impl TraceHandler {
         );
 
         // Get tenant/dataset-specific WAL
-        let wal = match self
+        let wal = self
             .wal_manager
             .get_wal(
                 &tenant_context.tenant_id,
@@ -91,18 +101,7 @@ impl TraceHandler {
                 "traces",
             )
             .await
-        {
-            Ok(wal) => wal,
-            Err(e) => {
-                tracing::error!(
-                    tenant_id = %tenant_context.tenant_id,
-                    dataset_id = %tenant_context.dataset_id,
-                    error = %e,
-                    "Failed to get WAL"
-                );
-                return;
-            }
-        };
+            .context("Failed to get WAL")?;
 
         // Convert OTLP traces to Arrow RecordBatch
         let record_batch = otlp_traces_to_arrow(&request);
@@ -123,30 +122,16 @@ impl TraceHandler {
         }
         let metadata_str = serde_json::to_string(&metadata).ok();
 
-        let batch_bytes = match record_batch_to_bytes(&record_batch) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to serialize record batch");
-                return;
-            }
-        };
+        let batch_bytes =
+            record_batch_to_bytes(&record_batch).context("Failed to serialize record batch")?;
 
-        let wal_entry_id = match wal
+        let wal_entry_id = wal
             .append(WalOperation::WriteTraces, batch_bytes.clone(), metadata_str)
             .await
-        {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to write traces to WAL");
-                return;
-            }
-        };
+            .context("Failed to write traces to WAL")?;
 
         // Flush WAL to ensure durability
-        if let Err(e) = wal.flush().await {
-            tracing::error!(error = %e, "Failed to flush WAL");
-            return;
-        }
+        wal.flush().await.context("Failed to flush WAL")?;
 
         tracing::debug!(entry_id = %wal_entry_id, "Traces written to WAL");
 
@@ -169,5 +154,9 @@ impl TraceHandler {
                 tracing::error!(error = %e, "Failed to forward traces - data remains in WAL for retry");
             }
         }
+
+        // Data is durable in the WAL at this point; forward failures are
+        // recovered by the retry consumer, so the export is acknowledged.
+        Ok(())
     }
 }

--- a/src/acceptor/src/handler/otlp_log_handler.rs
+++ b/src/acceptor/src/handler/otlp_log_handler.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context;
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_logs_to_arrow;
 use common::flight::transport::InMemoryFlightTransport;
@@ -40,8 +41,9 @@ impl MockLogHandler {
         &self,
         _tenant_context: &TenantContext,
         request: ExportLogsServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         self.handle_grpc_otlp_logs_calls.lock().await.push(request);
+        Ok(())
     }
 
     pub fn expect_handle_grpc_otlp_logs(&mut self) -> &mut Self {
@@ -61,6 +63,11 @@ impl LogHandler {
         }
     }
 
+    /// Handle an OTLP logs export.
+    ///
+    /// Returns `Ok(())` once the data is durably accepted: written and
+    /// flushed to the WAL. A failed Flight forward after that point is not
+    /// an error — the WAL retry consumer re-forwards the entry.
     #[tracing::instrument(
         skip_all,
         fields(
@@ -72,7 +79,7 @@ impl LogHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportLogsServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         tracing::info!(
             tenant_id = %tenant_context.tenant_id,
             dataset_id = %tenant_context.dataset_id,
@@ -80,7 +87,7 @@ impl LogHandler {
         );
 
         // Get tenant/dataset-specific WAL
-        let wal = match self
+        let wal = self
             .wal_manager
             .get_wal(
                 &tenant_context.tenant_id,
@@ -88,18 +95,7 @@ impl LogHandler {
                 "logs",
             )
             .await
-        {
-            Ok(wal) => wal,
-            Err(e) => {
-                tracing::error!(
-                    tenant_id = %tenant_context.tenant_id,
-                    dataset_id = %tenant_context.dataset_id,
-                    error = %e,
-                    "Failed to get WAL"
-                );
-                return;
-            }
-        };
+            .context("Failed to get WAL")?;
 
         // Convert OTLP logs to Arrow RecordBatch
         let record_batch = otlp_logs_to_arrow(&request);
@@ -124,30 +120,16 @@ impl LogHandler {
         let metadata_str = serde_json::to_string(&metadata).ok();
 
         // Step 1: Write to WAL first for durability
-        let batch_bytes = match record_batch_to_bytes(&record_batch) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to serialize record batch");
-                return;
-            }
-        };
+        let batch_bytes =
+            record_batch_to_bytes(&record_batch).context("Failed to serialize record batch")?;
 
-        let wal_entry_id = match wal
+        let wal_entry_id = wal
             .append(WalOperation::WriteLogs, batch_bytes.clone(), metadata_str)
             .await
-        {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to write logs to WAL");
-                return;
-            }
-        };
+            .context("Failed to write logs to WAL")?;
 
         // Flush WAL to ensure durability
-        if let Err(e) = wal.flush().await {
-            tracing::error!(error = %e, "Failed to flush WAL");
-            return;
-        }
+        wal.flush().await.context("Failed to flush WAL")?;
 
         tracing::debug!(entry_id = %wal_entry_id, "Logs written to WAL");
 
@@ -170,5 +152,9 @@ impl LogHandler {
                 tracing::error!(error = %e, "Failed to forward logs - data remains in WAL for retry");
             }
         }
+
+        // Data is durable in the WAL at this point; forward failures are
+        // recovered by the retry consumer, so the export is acknowledged.
+        Ok(())
     }
 }

--- a/src/acceptor/src/handler/otlp_metrics_handler.rs
+++ b/src/acceptor/src/handler/otlp_metrics_handler.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context;
 use common::auth::TenantContext;
 use common::flight::conversion::otlp_metrics_to_arrow;
 use common::flight::transport::InMemoryFlightTransport;
@@ -41,11 +42,12 @@ impl MockMetricsHandler {
         &self,
         _tenant_context: &TenantContext,
         request: ExportMetricsServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         self.handle_grpc_otlp_metrics_calls
             .lock()
             .await
             .push(request);
+        Ok(())
     }
 
     pub fn expect_handle_grpc_otlp_metrics(&mut self) -> &mut Self {
@@ -235,6 +237,16 @@ impl MetricsHandler {
         result
     }
 
+    /// Handle an OTLP metrics export.
+    ///
+    /// Returns `Ok(())` once every metric-type partition is durably
+    /// accepted: written and flushed to the WAL. Failed Flight forwards
+    /// after that point are not errors — the WAL retry consumer re-forwards
+    /// those entries.
+    ///
+    /// If any partition fails before WAL durability, an error is returned
+    /// so the client retries the export. Retrying partitions that did reach
+    /// the WAL produces duplicates (at-least-once semantics).
     #[tracing::instrument(
         skip_all,
         fields(
@@ -246,7 +258,7 @@ impl MetricsHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportMetricsServiceRequest,
-    ) {
+    ) -> anyhow::Result<()> {
         tracing::info!(
             tenant_id = %tenant_context.tenant_id,
             dataset_id = %tenant_context.dataset_id,
@@ -254,7 +266,7 @@ impl MetricsHandler {
         );
 
         // Get tenant/dataset-specific WAL
-        let wal = match self
+        let wal = self
             .wal_manager
             .get_wal(
                 &tenant_context.tenant_id,
@@ -262,26 +274,18 @@ impl MetricsHandler {
                 "metrics",
             )
             .await
-        {
-            Ok(wal) => wal,
-            Err(e) => {
-                tracing::error!(
-                    tenant_id = %tenant_context.tenant_id,
-                    dataset_id = %tenant_context.dataset_id,
-                    error = %e,
-                    "Failed to get WAL"
-                );
-                return;
-            }
-        };
+            .context("Failed to get WAL")?;
 
         // Partition metrics by type to prevent schema conflicts
         let partitions = Self::partition_metrics_by_type(&request);
 
         if partitions.is_empty() {
             tracing::warn!("No metrics found in request");
-            return;
+            return Ok(());
         }
+
+        // Metric types that failed before reaching WAL durability
+        let mut undurable: Vec<String> = Vec::new();
 
         tracing::info!(
             partition_count = partitions.len(),
@@ -304,6 +308,7 @@ impl MetricsHandler {
                 Ok(bytes) => bytes,
                 Err(e) => {
                     tracing::error!(metric_type = %metric_type, error = %e, "Failed to serialize record batch");
+                    undurable.push(metric_type.clone());
                     continue;
                 }
             };
@@ -339,12 +344,14 @@ impl MetricsHandler {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::error!(metric_type = %metric_type, error = %e, "Failed to write metrics to WAL");
+                    undurable.push(metric_type.clone());
                     continue;
                 }
             };
 
             if let Err(e) = wal.flush().await {
                 tracing::error!(metric_type = %metric_type, error = %e, "Failed to flush WAL");
+                undurable.push(metric_type.clone());
                 continue;
             }
 
@@ -401,7 +408,15 @@ impl MetricsHandler {
             }
         }
 
+        if !undurable.is_empty() {
+            anyhow::bail!(
+                "Failed to durably accept metrics for types: {}",
+                undurable.join(", ")
+            );
+        }
+
         tracing::info!("Completed processing metrics request for all types");
+        Ok(())
     }
 }
 

--- a/src/acceptor/src/services/otlp_log_service.rs
+++ b/src/acceptor/src/services/otlp_log_service.rs
@@ -13,7 +13,7 @@ pub trait LogHandlerTrait {
         &self,
         tenant_context: &TenantContext,
         request: ExportLogsServiceRequest,
-    );
+    ) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -22,8 +22,8 @@ impl LogHandlerTrait for LogHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportLogsServiceRequest,
-    ) {
-        self.handle_grpc_otlp_logs(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_logs(tenant_context, request).await
     }
 }
 
@@ -61,10 +61,21 @@ impl<H: LogHandlerTrait + Send + Sync + 'static> LogsService for LogAcceptorServ
         let handle = self
             .handler
             .handle_grpc_otlp_logs(&tenant_context, request_inner);
-        if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
-            common::self_monitoring::suppress_self_telemetry(handle).await;
-        } else {
-            handle.await;
+        let result =
+            if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
+                common::self_monitoring::suppress_self_telemetry(handle).await
+            } else {
+                handle.await
+            };
+
+        // Reject the export if the data was not durably accepted, so the
+        // client retries instead of dropping its copy (OTLP treats
+        // UNAVAILABLE as retryable).
+        if let Err(e) = result {
+            tracing::error!(error = %e, "Failed to durably accept logs export");
+            return Err(Status::unavailable(format!(
+                "failed to durably accept logs export: {e:#}"
+            )));
         }
 
         // Anti-loop guard: _system traffic is SignalDB's own telemetry and
@@ -103,8 +114,8 @@ impl LogHandlerTrait for crate::handler::otlp_log_handler::MockLogHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportLogsServiceRequest,
-    ) {
-        self.handle_grpc_otlp_logs(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_logs(tenant_context, request).await
     }
 }
 

--- a/src/acceptor/src/services/otlp_metric_service.rs
+++ b/src/acceptor/src/services/otlp_metric_service.rs
@@ -14,7 +14,7 @@ pub trait MetricsHandlerTrait {
         &self,
         tenant_context: &TenantContext,
         request: ExportMetricsServiceRequest,
-    );
+    ) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -23,8 +23,8 @@ impl MetricsHandlerTrait for MetricsHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportMetricsServiceRequest,
-    ) {
-        self.handle_grpc_otlp_metrics(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_metrics(tenant_context, request).await
     }
 }
 
@@ -62,10 +62,21 @@ impl<H: MetricsHandlerTrait + Send + Sync + 'static> MetricsService for MetricsA
         let handle = self
             .handler
             .handle_grpc_otlp_metrics(&tenant_context, request_inner);
-        if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
-            common::self_monitoring::suppress_self_telemetry(handle).await;
-        } else {
-            handle.await;
+        let result =
+            if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
+                common::self_monitoring::suppress_self_telemetry(handle).await
+            } else {
+                handle.await
+            };
+
+        // Reject the export if the data was not durably accepted, so the
+        // client retries instead of dropping its copy (OTLP treats
+        // UNAVAILABLE as retryable).
+        if let Err(e) = result {
+            tracing::error!(error = %e, "Failed to durably accept metrics export");
+            return Err(Status::unavailable(format!(
+                "failed to durably accept metrics export: {e:#}"
+            )));
         }
 
         // Anti-loop guard: _system traffic is SignalDB's own telemetry and
@@ -104,8 +115,8 @@ impl MetricsHandlerTrait for crate::handler::otlp_metrics_handler::MockMetricsHa
         &self,
         tenant_context: &TenantContext,
         request: ExportMetricsServiceRequest,
-    ) {
-        self.handle_grpc_otlp_metrics(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_metrics(tenant_context, request).await
     }
 }
 

--- a/src/acceptor/src/services/otlp_trace_service.rs
+++ b/src/acceptor/src/services/otlp_trace_service.rs
@@ -13,7 +13,7 @@ pub trait TraceHandlerTrait {
         &self,
         tenant_context: &TenantContext,
         request: ExportTraceServiceRequest,
-    );
+    ) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -22,8 +22,8 @@ impl TraceHandlerTrait for TraceHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportTraceServiceRequest,
-    ) {
-        self.handle_grpc_otlp_traces(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_traces(tenant_context, request).await
     }
 }
 
@@ -61,10 +61,21 @@ impl<H: TraceHandlerTrait + Send + Sync + 'static> TraceService for TraceAccepto
         let handle = self
             .handler
             .handle_grpc_otlp_traces(&tenant_context, request_inner);
-        if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
-            common::self_monitoring::suppress_self_telemetry(handle).await;
-        } else {
-            handle.await;
+        let result =
+            if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
+                common::self_monitoring::suppress_self_telemetry(handle).await
+            } else {
+                handle.await
+            };
+
+        // Reject the export if the data was not durably accepted, so the
+        // client retries instead of dropping its copy (OTLP treats
+        // UNAVAILABLE as retryable).
+        if let Err(e) = result {
+            tracing::error!(error = %e, "Failed to durably accept trace export");
+            return Err(Status::unavailable(format!(
+                "failed to durably accept trace export: {e:#}"
+            )));
         }
 
         // Anti-loop guard: _system traffic is SignalDB's own telemetry and
@@ -103,8 +114,8 @@ impl TraceHandlerTrait for crate::handler::otlp_grpc::MockTraceHandler {
         &self,
         tenant_context: &TenantContext,
         request: ExportTraceServiceRequest,
-    ) {
-        self.handle_grpc_otlp_traces(tenant_context, request).await;
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_traces(tenant_context, request).await
     }
 }
 
@@ -117,6 +128,47 @@ mod tests {
         resource::v1::Resource,
         trace::v1::{ResourceSpans, ScopeSpans, Span, Status as SpanStatus, span::SpanKind},
     };
+
+    /// Handler that always fails before WAL durability
+    struct FailingTraceHandler;
+
+    #[async_trait::async_trait]
+    impl TraceHandlerTrait for FailingTraceHandler {
+        async fn handle_grpc_otlp_traces(
+            &self,
+            _tenant_context: &TenantContext,
+            _request: ExportTraceServiceRequest,
+        ) -> anyhow::Result<()> {
+            anyhow::bail!("WAL unavailable")
+        }
+    }
+
+    fn test_tenant_context() -> TenantContext {
+        TenantContext {
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            tenant_slug: "test-tenant".to_string(),
+            dataset_slug: "test-dataset".to_string(),
+            api_key_name: Some("test-key".to_string()),
+            source: common::auth::TenantSource::Config,
+        }
+    }
+
+    #[tokio::test]
+    async fn export_rejects_with_unavailable_when_write_path_fails() {
+        let service = TraceAcceptorService::new(FailingTraceHandler);
+
+        let mut tonic_request = Request::new(ExportTraceServiceRequest::default());
+        tonic_request.extensions_mut().insert(test_tenant_context());
+
+        let status = service
+            .export(tonic_request)
+            .await
+            .expect_err("export must fail when data is not durably accepted");
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert!(status.message().contains("durably accept"));
+    }
 
     #[tokio::test]
     async fn test_trace_acceptor_service() {

--- a/tests-integration/tests/e2e/end_to_end_logs_metrics_tests.rs
+++ b/tests-integration/tests/e2e/end_to_end_logs_metrics_tests.rs
@@ -375,7 +375,8 @@ async fn test_logs_ingestion_and_persistence() {
     services
         .log_handler
         .handle_grpc_otlp_logs(&tenant_context, log_request)
-        .await;
+        .await
+        .expect("logs export must be durably accepted");
 
     let locations = wait_for_object_locations(&services.object_store, Duration::from_secs(20)).await;
     assert!(!locations.is_empty(), "expected persisted objects for logs");
@@ -394,7 +395,8 @@ async fn test_metrics_gauge_ingestion_and_persistence() {
     services
         .metrics_handler
         .handle_grpc_otlp_metrics(&tenant_context, metrics_request)
-        .await;
+        .await
+        .expect("metrics export must be durably accepted");
 
     let locations = wait_for_object_locations(&services.object_store, Duration::from_secs(20)).await;
     assert!(
@@ -414,7 +416,8 @@ async fn test_metrics_mixed_types_ingestion() {
     services
         .metrics_handler
         .handle_grpc_otlp_metrics(&tenant_context, metrics_request)
-        .await;
+        .await
+        .expect("metrics export must be durably accepted");
 
     let locations = wait_for_object_locations_all(
         &services.object_store,


### PR DESCRIPTION
## Summary

Fixes the highest-severity write-path issue from hardening epic #563: the acceptor returned `200/OK` to OTLP clients unconditionally, even when nothing was stored (#543).

`TraceAcceptorService::export` (and the logs/metrics equivalents) always returned `Ok(ExportResponse::default())`; the handlers returned `()` and only logged WAL failures. Clients treated the export as durable and dropped their copy — silent data loss whenever the WAL couldn't be initialized, appended, or flushed.

### New contract

- **ACK = durable**: an export is acknowledged only after the entry is written *and flushed* to the WAL.
- Failures before that point map to gRPC **`UNAVAILABLE`**, which OTLP clients treat as retryable.
- A failed Flight forward *after* WAL durability is not an error: the WAL retry consumer (#574) re-forwards the entry. That PR is the prerequisite that makes early ACK honest, which is why this PR is stacked on it.
- Metrics: the export is acknowledged only when **every** metric-type partition reached WAL durability; otherwise the whole request is rejected. Retries then produce at-least-once duplicates for partitions that were already durable — tracked separately in #546.

The Prometheus remote_write path already propagated errors properly and is unchanged.

### Tests

- `export_rejects_with_unavailable_when_write_path_fails` — a handler failing before durability must surface as `UNAVAILABLE` with a meaningful message.
- Existing success-path service tests updated to the `Result` signatures.

Stacked on #574 (retry consumer). 

Fixes #543
Part of #563