### PR TITLE
feat(flight): authenticate Flight ports via internal service key

### DIFF
--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -15,6 +15,14 @@ enabled = true  # Set to false to disable authentication (dev/testing only)
 # Generate a strong random key for production use
 # admin_api_key = "sk-admin-your-secret-key-here"
 
+# Shared secret for service-to-service Arrow Flight calls (router -> querier,
+# acceptor -> writer). When set, the Flight ports (50051/50053/50054) require
+# every call to present either this key or a valid tenant API key; tenant
+# callers are then scoped to their own tenant. When unset, the Flight ports
+# are UNAUTHENTICATED and must be restricted to a trusted network.
+# All SignalDB services must share the same value.
+# internal_service_key = "sk-internal-your-secret-key-here"
+
 # Tenant definitions with API keys and datasets
 # Each tenant is isolated with separate WAL paths and Iceberg catalogs
 

--- a/src/acceptor/src/handler/forward.rs
+++ b/src/acceptor/src/handler/forward.rs
@@ -42,8 +42,14 @@ pub async fn forward_batch_to_writer(
         first.app_metadata = Bytes::from(metadata_json.as_bytes().to_vec());
     }
 
+    let mut request = tonic::Request::new(stream::iter(flight_data));
+    // Authenticate to the writer when service-to-service auth is configured
+    if let Some(key) = flight_transport.internal_service_key() {
+        common::flight::auth::attach_internal_auth(&mut request, key);
+    }
+
     let response = client
-        .do_put(stream::iter(flight_data))
+        .do_put(request)
         .await
         .context("Flight do_put failed")?;
 

--- a/src/acceptor/src/middleware/auth.rs
+++ b/src/acceptor/src/middleware/auth.rs
@@ -410,6 +410,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/acceptor/src/middleware/grpc_auth.rs
+++ b/src/acceptor/src/middleware/grpc_auth.rs
@@ -301,6 +301,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 
@@ -331,6 +332,7 @@ mod tests {
             enabled: true,
             tenants: vec![],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 
@@ -350,6 +352,7 @@ mod tests {
             enabled: true,
             tenants: vec![],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/common/src/auth/authenticator.rs
+++ b/src/common/src/auth/authenticator.rs
@@ -273,6 +273,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
 
         let authenticator = Authenticator::new(auth_config, catalog);
@@ -307,6 +308,7 @@ mod tests {
             enabled: true,
             tenants: vec![],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -341,6 +343,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -377,6 +380,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -407,6 +411,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -323,6 +323,7 @@ mod tests {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/common/src/catalog_manager.rs
+++ b/src/common/src/catalog_manager.rs
@@ -219,6 +219,7 @@ mod tests {
                     },
                 ],
                 admin_api_key: None,
+                internal_service_key: None,
             },
             storage: StorageConfig {
                 dsn: "memory://".to_string(),

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -536,6 +536,15 @@ pub struct AuthConfig {
     /// Admin API key for management endpoints
     #[serde(default)]
     pub admin_api_key: Option<String>,
+    /// Shared secret for service-to-service Flight calls.
+    ///
+    /// When set, the router and querier Flight servers require every call
+    /// to present either this key (trusted internal caller) or a valid
+    /// tenant API key (scoped to that tenant). When unset, the Flight ports
+    /// accept unauthenticated calls and MUST be restricted to a trusted
+    /// network.
+    #[serde(default)]
+    pub internal_service_key: Option<String>,
 }
 
 fn default_self_monitoring_endpoint() -> String {

--- a/src/common/src/flight/auth.rs
+++ b/src/common/src/flight/auth.rs
@@ -27,9 +27,7 @@ use std::sync::Arc;
 
 use tonic::{Request, Status};
 
-use crate::auth::{
-    Authenticator, TenantContext, validate_dataset_id, validate_tenant_id,
-};
+use crate::auth::{Authenticator, validate_dataset_id, validate_tenant_id};
 
 /// Request-extension marker for callers that presented the internal
 /// service key. Such callers are trusted to specify tenant scoping
@@ -40,14 +38,25 @@ pub struct InternalService;
 /// Interceptor enforcing authentication on Flight servers.
 #[derive(Clone)]
 pub struct FlightAuthInterceptor {
-    authenticator: Arc<Authenticator>,
+    /// When None, only the internal service key is accepted (used by the
+    /// writer, whose Flight surface is not meant for tenant clients).
+    authenticator: Option<Arc<Authenticator>>,
     internal_key: String,
 }
 
 impl FlightAuthInterceptor {
+    /// Accept the internal service key or tenant API keys.
     pub fn new(authenticator: Arc<Authenticator>, internal_key: String) -> Self {
         Self {
-            authenticator,
+            authenticator: Some(authenticator),
+            internal_key,
+        }
+    }
+
+    /// Accept only the internal service key.
+    pub fn internal_only(internal_key: String) -> Self {
+        Self {
+            authenticator: None,
             internal_key,
         }
     }
@@ -83,6 +92,12 @@ impl FlightAuthInterceptor {
         }
 
         // Tenant caller: same header contract as the OTLP gRPC ingest path
+        let Some(authenticator) = &self.authenticator else {
+            return Err(Status::permission_denied(
+                "this Flight endpoint accepts only internal service callers",
+            ));
+        };
+
         let tenant_id_raw = metadata
             .get("x-tenant-id")
             .ok_or_else(|| Status::unauthenticated("Missing x-tenant-id metadata"))?
@@ -99,7 +114,7 @@ impl FlightAuthInterceptor {
         };
 
         let api_key = bearer.to_string();
-        let authenticator = self.authenticator.clone();
+        let authenticator = authenticator.clone();
         let tenant_context = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 authenticator
@@ -149,6 +164,7 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::TenantContext;
     use crate::catalog::Catalog;
     use crate::config::{ApiKeyConfig, AuthConfig, DatasetConfig, TenantConfig};
     use tonic::metadata::MetadataValue;
@@ -235,6 +251,31 @@ mod tests {
 
         let status = interceptor.intercept(request).unwrap_err();
         assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn internal_only_rejects_tenant_keys() {
+        let interceptor = FlightAuthInterceptor::internal_only("internal-secret".to_string());
+
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer tenant-key-123"),
+        );
+        request
+            .metadata_mut()
+            .insert("x-tenant-id", MetadataValue::from_static("acme"));
+
+        let status = interceptor.intercept(request).unwrap_err();
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+
+        // The internal key still works
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer internal-secret"),
+        );
+        assert!(interceptor.intercept(request).is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/common/src/flight/auth.rs
+++ b/src/common/src/flight/auth.rs
@@ -1,0 +1,249 @@
+//! # Flight Authentication
+//!
+//! Authentication for the Arrow Flight ports (router, querier).
+//!
+//! The Flight servers are reachable over the network, and the querier
+//! executes SQL against a session where every tenant catalog is registered.
+//! Without authentication, anyone who can reach the port can read any
+//! tenant's data.
+//!
+//! [`FlightAuthInterceptor`] enforces two caller classes:
+//!
+//! - **Internal services** present the shared `[auth].internal_service_key`
+//!   as a Bearer token. They are trusted to act on behalf of any tenant
+//!   (the router queries the querier on behalf of HTTP-authenticated
+//!   tenants), marked via the [`InternalService`] request extension.
+//! - **Tenants** present their own API key plus `x-tenant-id` /
+//!   `x-dataset-id`, validated by the [`Authenticator`]. The resulting
+//!   [`TenantContext`] is inserted into request extensions and servers must
+//!   scope all work to it.
+//!
+//! The interceptor is only installed when `internal_service_key` is
+//! configured; otherwise the Flight ports remain unauthenticated for
+//! backward compatibility and servers log a prominent warning that the
+//! ports must be network-isolated.
+
+use std::sync::Arc;
+
+use tonic::{Request, Status};
+
+use crate::auth::{
+    Authenticator, TenantContext, validate_dataset_id, validate_tenant_id,
+};
+
+/// Request-extension marker for callers that presented the internal
+/// service key. Such callers are trusted to specify tenant scoping
+/// themselves (e.g. in ticket contents).
+#[derive(Clone, Copy, Debug)]
+pub struct InternalService;
+
+/// Interceptor enforcing authentication on Flight servers.
+#[derive(Clone)]
+pub struct FlightAuthInterceptor {
+    authenticator: Arc<Authenticator>,
+    internal_key: String,
+}
+
+impl FlightAuthInterceptor {
+    pub fn new(authenticator: Arc<Authenticator>, internal_key: String) -> Self {
+        Self {
+            authenticator,
+            internal_key,
+        }
+    }
+
+    /// Intercept a Flight request.
+    ///
+    /// Requires a `Bearer` token: either the internal service key
+    /// (inserts [`InternalService`]) or a tenant API key together with
+    /// `x-tenant-id` (inserts [`TenantContext`]).
+    ///
+    /// Note: interceptors are synchronous, so tenant authentication
+    /// bridges to async via `block_in_place` — requires a multi-threaded
+    /// tokio runtime.
+    #[allow(clippy::result_large_err)]
+    pub fn intercept<T>(&self, mut request: Request<T>) -> Result<Request<T>, Status> {
+        let metadata = request.metadata();
+
+        let auth_header = metadata
+            .get("authorization")
+            .ok_or_else(|| Status::unauthenticated("Missing authorization metadata"))?
+            .to_str()
+            .map_err(|_| Status::unauthenticated("Invalid authorization metadata"))?;
+
+        let bearer = auth_header
+            .strip_prefix("Bearer ")
+            .or_else(|| auth_header.strip_prefix("bearer "))
+            .ok_or_else(|| Status::unauthenticated("Authorization must use Bearer scheme"))?;
+
+        // Internal service caller
+        if constant_time_eq(bearer.as_bytes(), self.internal_key.as_bytes()) {
+            request.extensions_mut().insert(InternalService);
+            return Ok(request);
+        }
+
+        // Tenant caller: same header contract as the OTLP gRPC ingest path
+        let tenant_id_raw = metadata
+            .get("x-tenant-id")
+            .ok_or_else(|| Status::unauthenticated("Missing x-tenant-id metadata"))?
+            .to_str()
+            .map_err(|_| Status::invalid_argument("Invalid x-tenant-id metadata"))?;
+        let tenant_id =
+            validate_tenant_id(tenant_id_raw).map_err(|e| Status::invalid_argument(e.message))?;
+
+        let dataset_id = match metadata.get("x-dataset-id").and_then(|v| v.to_str().ok()) {
+            Some(id) => {
+                Some(validate_dataset_id(id).map_err(|e| Status::invalid_argument(e.message))?)
+            }
+            None => None,
+        };
+
+        let api_key = bearer.to_string();
+        let authenticator = self.authenticator.clone();
+        let tenant_context = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                authenticator
+                    .authenticate(&api_key, &tenant_id, dataset_id.as_deref())
+                    .await
+            })
+        })
+        .map_err(|err| {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                error = %err.message,
+                "Flight authentication failed"
+            );
+            match err.status_code {
+                400 => Status::invalid_argument(err.message),
+                401 => Status::unauthenticated(err.message),
+                403 => Status::permission_denied(err.message),
+                _ => Status::internal("Authentication error"),
+            }
+        })?;
+
+        request.extensions_mut().insert(tenant_context);
+        Ok(request)
+    }
+}
+
+/// Attach the internal service key as Bearer auth to an outbound request.
+pub fn attach_internal_auth<T>(request: &mut Request<T>, internal_key: &str) {
+    match format!("Bearer {internal_key}").parse() {
+        Ok(value) => {
+            request.metadata_mut().insert("authorization", value);
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Internal service key is not a valid header value");
+        }
+    }
+}
+
+/// Constant-time byte comparison to avoid leaking key prefixes via timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::Catalog;
+    use crate::config::{ApiKeyConfig, AuthConfig, DatasetConfig, TenantConfig};
+    use tonic::metadata::MetadataValue;
+
+    async fn interceptor() -> FlightAuthInterceptor {
+        let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
+        let auth_config = AuthConfig {
+            enabled: true,
+            tenants: vec![TenantConfig {
+                id: "acme".to_string(),
+                slug: "acme".to_string(),
+                name: "Acme Corp".to_string(),
+                default_dataset: Some("production".to_string()),
+                datasets: vec![DatasetConfig {
+                    id: "production".to_string(),
+                    slug: "production".to_string(),
+                    is_default: true,
+                    storage: None,
+                }],
+                api_keys: vec![ApiKeyConfig {
+                    key: "tenant-key-123".to_string(),
+                    name: Some("test".to_string()),
+                }],
+                schema_config: None,
+            }],
+            admin_api_key: None,
+            internal_service_key: Some("internal-secret".to_string()),
+        };
+        let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+        FlightAuthInterceptor::new(authenticator, "internal-secret".to_string())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn internal_key_is_accepted_and_marked() {
+        let interceptor = interceptor().await;
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer internal-secret"),
+        );
+
+        let request = interceptor.intercept(request).unwrap();
+        assert!(request.extensions().get::<InternalService>().is_some());
+        assert!(request.extensions().get::<TenantContext>().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tenant_key_yields_tenant_context() {
+        let interceptor = interceptor().await;
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer tenant-key-123"),
+        );
+        request
+            .metadata_mut()
+            .insert("x-tenant-id", MetadataValue::from_static("acme"));
+
+        let request = interceptor.intercept(request).unwrap();
+        assert!(request.extensions().get::<InternalService>().is_none());
+        let ctx = request.extensions().get::<TenantContext>().unwrap();
+        assert_eq!(ctx.tenant_slug, "acme");
+        assert_eq!(ctx.dataset_slug, "production");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn missing_authorization_is_rejected() {
+        let interceptor = interceptor().await;
+        let status = interceptor.intercept(Request::new(())).unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wrong_tenant_key_is_rejected() {
+        let interceptor = interceptor().await;
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::from_static("Bearer wrong-key"),
+        );
+        request
+            .metadata_mut()
+            .insert("x-tenant-id", MetadataValue::from_static("acme"));
+
+        let status = interceptor.intercept(request).unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attach_internal_auth_round_trips() {
+        let interceptor = interceptor().await;
+        let mut request = Request::new(());
+        attach_internal_auth(&mut request, "internal-secret");
+
+        let request = interceptor.intercept(request).unwrap();
+        assert!(request.extensions().get::<InternalService>().is_some());
+    }
+}

--- a/src/common/src/flight/mod.rs
+++ b/src/common/src/flight/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod conversion;
 pub mod schema;
 pub mod trace_context;

--- a/src/common/src/flight/transport.rs
+++ b/src/common/src/flight/transport.rs
@@ -117,6 +117,12 @@ impl InMemoryFlightTransport {
         }
     }
 
+    /// The configured internal service key for authenticating outbound
+    /// Flight calls to other SignalDB services, if any.
+    pub fn internal_service_key(&self) -> Option<&str> {
+        self.bootstrap.config().auth.internal_service_key.as_deref()
+    }
+
     /// Register a Flight service with the catalog-based transport
     /// Note: Services are now registered automatically through ServiceBootstrap
     /// This method is kept for backward compatibility but now just returns the bootstrap service ID

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -595,6 +595,13 @@ impl FlightService for QuerierFlightService {
         common::flight::trace_context::set_parent_from_request(&span, &request);
         async move {
             let metadata = request.metadata().clone();
+            // Tenant-scoped caller identity, inserted by the Flight auth
+            // interceptor. None for internal-service callers and for
+            // deployments without Flight auth configured.
+            let caller_tenant = request
+                .extensions()
+                .get::<common::auth::TenantContext>()
+                .cloned();
             let ticket = request.into_inner();
             let ticket_content = String::from_utf8(ticket.ticket.to_vec())
                 .map_err(|e| Status::invalid_argument(format!("Invalid ticket: {e}")))?;
@@ -603,6 +610,28 @@ impl FlightService for QuerierFlightService {
 
             // Parse ticket to determine request type
             let ticket_request = self.parse_ticket(&ticket_content)?;
+
+            // Tenant-scoped callers may only touch their own tenant's data,
+            // regardless of what the ticket claims.
+            if let Some(ctx) = &caller_tenant {
+                let ticket_tenant = match &ticket_request {
+                    TicketRequest::FindTrace { tenant_slug, .. }
+                    | TicketRequest::SearchTraces { tenant_slug, .. } => Some(tenant_slug),
+                    TicketRequest::SqlQuery { .. } => None,
+                };
+                if let Some(ticket_tenant) = ticket_tenant
+                    && ticket_tenant != &ctx.tenant_slug
+                {
+                    tracing::warn!(
+                        caller_tenant = %ctx.tenant_slug,
+                        ticket_tenant = %ticket_tenant,
+                        "Rejecting cross-tenant Flight ticket"
+                    );
+                    return Err(Status::permission_denied(
+                        "ticket tenant does not match authenticated tenant",
+                    ));
+                }
+            }
             let query_type = match &ticket_request {
                 TicketRequest::FindTrace { .. } => "trace_by_id",
                 TicketRequest::SearchTraces { .. } => "trace_search",
@@ -693,14 +722,25 @@ impl FlightService for QuerierFlightService {
                         }
                     }
                     TicketRequest::SqlQuery { sql } => {
-                        let tenant_slug = metadata
-                            .get("x-tenant-id")
-                            .and_then(|v| v.to_str().ok())
-                            .map(|s| s.to_string());
-                        let dataset_slug = metadata
-                            .get("x-dataset-id")
-                            .and_then(|v| v.to_str().ok())
-                            .map(|s| s.to_string());
+                        // Tenant-scoped callers are pinned to their
+                        // authenticated tenant/dataset; only internal or
+                        // unauthenticated callers may scope via headers.
+                        let (tenant_slug, dataset_slug) = match &caller_tenant {
+                            Some(ctx) => (
+                                Some(ctx.tenant_slug.clone()),
+                                Some(ctx.dataset_slug.clone()),
+                            ),
+                            None => (
+                                metadata
+                                    .get("x-tenant-id")
+                                    .and_then(|v| v.to_str().ok())
+                                    .map(|s| s.to_string()),
+                                metadata
+                                    .get("x-dataset-id")
+                                    .and_then(|v| v.to_str().ok())
+                                    .map(|s| s.to_string()),
+                            ),
+                        };
 
                         tracing::info!(
                             tenant_id = ?tenant_slug,
@@ -970,5 +1010,59 @@ mod tests {
             state.config().options().catalog.default_catalog,
             "datafusion"
         );
+    }
+
+    #[tokio::test]
+    async fn tenant_scoped_caller_cannot_use_cross_tenant_ticket() {
+        let service = make_service().await;
+
+        // Authenticated as tenant_a, but the ticket names tenant_b
+        let mut request = Request::new(Ticket::new("find_trace:tenant_b:prod:abc123"));
+        request
+            .extensions_mut()
+            .insert(common::auth::TenantContext::new(
+                "tenant_a".to_string(),
+                "prod".to_string(),
+                "tenant_a".to_string(),
+                "prod".to_string(),
+                None,
+                common::auth::TenantSource::Config,
+            ));
+
+        match service.do_get(request).await {
+            Ok(_) => panic!("cross-tenant ticket must be rejected"),
+            Err(status) => assert_eq!(status.code(), tonic::Code::PermissionDenied),
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_scoped_caller_may_use_own_tenant_ticket() {
+        let service = make_service().await;
+
+        // Same tenant in context and ticket: passes authorization and
+        // proceeds to execution (no data registered, so an empty result or
+        // a non-permission error are both acceptable here)
+        let mut request = Request::new(Ticket::new("find_trace:tenant_a:prod:abc123"));
+        request
+            .extensions_mut()
+            .insert(common::auth::TenantContext::new(
+                "tenant_a".to_string(),
+                "prod".to_string(),
+                "tenant_a".to_string(),
+                "prod".to_string(),
+                None,
+                common::auth::TenantSource::Config,
+            ));
+
+        match service.do_get(request).await {
+            Ok(_) => {}
+            Err(status) => {
+                assert_ne!(
+                    status.code(),
+                    tonic::Code::PermissionDenied,
+                    "same-tenant ticket must not be rejected for authorization"
+                );
+            }
+        }
     }
 }

--- a/src/querier/src/main.rs
+++ b/src/querier/src/main.rs
@@ -101,6 +101,10 @@ async fn main() -> anyhow::Result<()> {
             .await
             .context("Failed to initialize service bootstrap")?;
 
+    // Keep a handle on the SQL catalog for Flight authentication before the
+    // bootstrap moves into the transport
+    let sql_catalog = Arc::new(service_bootstrap.catalog().clone());
+
     // Create Flight transport and register this querier's Flight service
     let flight_transport = Arc::new(InMemoryFlightTransport::new(service_bootstrap));
 
@@ -130,12 +134,43 @@ async fn main() -> anyhow::Result<()> {
             .await
             .context("Failed to create querier flight service with CatalogManager")?;
     tracing::info!(address = %flight_addr, "Starting Flight query service");
+    let flight_auth = config.auth.internal_service_key.clone().map(|key| {
+        let authenticator = Arc::new(common::auth::Authenticator::new(
+            config.auth.clone(),
+            sql_catalog,
+        ));
+        common::flight::auth::FlightAuthInterceptor::new(authenticator, key)
+    });
+    if flight_auth.is_none() {
+        tracing::warn!(
+            "Flight port is UNAUTHENTICATED ([auth].internal_service_key is not set); \
+             it must be restricted to a trusted network"
+        );
+    }
     let flight_handle = tokio::spawn(async move {
-        Server::builder()
-            .add_service(FlightServiceServer::new(flight_service))
-            .serve(flight_addr)
-            .await
-            .unwrap();
+        let builder = Server::builder();
+        let serve = match flight_auth {
+            Some(interceptor) => {
+                let mut builder = builder;
+                builder
+                    .add_service(FlightServiceServer::with_interceptor(
+                        flight_service,
+                        move |req| interceptor.intercept(req),
+                    ))
+                    .serve(flight_addr)
+                    .await
+            }
+            None => {
+                let mut builder = builder;
+                builder
+                    .add_service(FlightServiceServer::new(flight_service))
+                    .serve(flight_addr)
+                    .await
+            }
+        };
+        if let Err(e) = serve {
+            tracing::error!(error = %e, "Flight server exited with error");
+        }
     });
 
     // Await shutdown signal

--- a/src/router/src/endpoints/tempo.rs
+++ b/src/router/src/endpoints/tempo.rs
@@ -560,6 +560,9 @@ pub async fn query_single_trace<S: RouterState>(
     ));
     let mut flight_request = tonic::Request::new(ticket);
     common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
 
     match client.do_get(flight_request).await {
         Ok(response) => {
@@ -653,6 +656,9 @@ pub async fn search<S: RouterState>(
     ));
     let mut flight_request = tonic::Request::new(ticket);
     common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
 
     match client.do_get(flight_request).await {
         Ok(response) => {

--- a/src/router/src/main.rs
+++ b/src/router/src/main.rs
@@ -145,17 +145,42 @@ async fn main() -> Result<()> {
     });
 
     // Start Flight service
+    let flight_auth = state.config().auth.internal_service_key.clone().map(|key| {
+        common::flight::auth::FlightAuthInterceptor::new(state.authenticator().clone(), key)
+    });
+    if flight_auth.is_none() {
+        tracing::warn!(
+            "Flight port is UNAUTHENTICATED ([auth].internal_service_key is not set); \
+             it must be restricted to a trusted network"
+        );
+    }
     let flight_service = create_flight_service(state);
     let flight_handle = tokio::spawn(async move {
         tracing::info!(address = %flight_addr, "Starting Flight service");
 
-        match Server::builder()
-            .add_service(
-                arrow_flight::flight_service_server::FlightServiceServer::new(flight_service),
-            )
-            .serve(flight_addr)
-            .await
-        {
+        let serve =
+            match flight_auth {
+                Some(interceptor) => Server::builder()
+                    .add_service(
+                        arrow_flight::flight_service_server::FlightServiceServer::with_interceptor(
+                            flight_service,
+                            move |req| interceptor.intercept(req),
+                        ),
+                    )
+                    .serve(flight_addr)
+                    .await,
+                None => {
+                    Server::builder()
+                        .add_service(
+                            arrow_flight::flight_service_server::FlightServiceServer::new(
+                                flight_service,
+                            ),
+                        )
+                        .serve(flight_addr)
+                        .await
+                }
+            };
+        match serve {
             Ok(_) => tracing::info!("Flight service stopped"),
             Err(e) => tracing::error!(error = %e, "Flight service error"),
         }

--- a/src/signaldb-bin/src/main.rs
+++ b/src/signaldb-bin/src/main.rs
@@ -367,43 +367,94 @@ async fn main() -> Result<()> {
             .expect("HTTP router error");
     });
 
+    // Flight authentication (shared across the router/querier/writer
+    // Flight servers when [auth].internal_service_key is configured)
+    let internal_service_key = config.auth.internal_service_key.clone();
+    if internal_service_key.is_none() {
+        log::warn!(
+            "Flight ports are UNAUTHENTICATED ([auth].internal_service_key is not set); \
+             they must be restricted to a trusted network"
+        );
+    }
+    let tenant_flight_auth = internal_service_key.clone().map(|key| {
+        common::flight::auth::FlightAuthInterceptor::new(
+            Arc::clone(&acceptor_resources.authenticator),
+            key,
+        )
+    });
+    let internal_flight_auth =
+        internal_service_key.map(common::flight::auth::FlightAuthInterceptor::internal_only);
+
     // Start Router Flight service
     let flight_service = create_flight_service(state);
     let flight_addr = SocketAddr::from(([0, 0, 0, 0], 50053));
+    let router_flight_auth = tenant_flight_auth.clone();
     let flight_handle = tokio::spawn(async move {
         log::info!("Starting Router Flight service on {flight_addr}");
 
-        match Server::builder()
-            .add_service(
-                arrow_flight::flight_service_server::FlightServiceServer::new(flight_service),
-            )
-            .serve_with_shutdown(flight_addr, async {
-                router_flight_shutdown_rx.await.ok();
-                log::info!("Router Flight service shutting down gracefully");
-            })
-            .await
-        {
+        let shutdown = async {
+            router_flight_shutdown_rx.await.ok();
+            log::info!("Router Flight service shutting down gracefully");
+        };
+        let serve =
+            match router_flight_auth {
+                Some(interceptor) => Server::builder()
+                    .add_service(
+                        arrow_flight::flight_service_server::FlightServiceServer::with_interceptor(
+                            flight_service,
+                            move |req| interceptor.intercept(req),
+                        ),
+                    )
+                    .serve_with_shutdown(flight_addr, shutdown)
+                    .await,
+                None => {
+                    Server::builder()
+                        .add_service(
+                            arrow_flight::flight_service_server::FlightServiceServer::new(
+                                flight_service,
+                            ),
+                        )
+                        .serve_with_shutdown(flight_addr, shutdown)
+                        .await
+                }
+            };
+        match serve {
             Ok(_) => log::info!("Router Flight service stopped"),
             Err(e) => log::error!("Router Flight service error: {e}"),
         }
     });
 
-    // Start Writer Flight service
+    // Start Writer Flight service (internal callers only)
     let writer_flight_handle = tokio::spawn(async move {
         log::info!("Starting Writer Flight service on {writer_flight_addr}");
 
-        match Server::builder()
-            .add_service(
-                arrow_flight::flight_service_server::FlightServiceServer::new(
-                    writer_flight_service,
-                ),
-            )
-            .serve_with_shutdown(writer_flight_addr, async {
-                writer_flight_shutdown_rx.await.ok();
-                log::info!("Writer Flight service shutting down gracefully");
-            })
-            .await
-        {
+        let shutdown = async {
+            writer_flight_shutdown_rx.await.ok();
+            log::info!("Writer Flight service shutting down gracefully");
+        };
+        let serve =
+            match internal_flight_auth {
+                Some(interceptor) => Server::builder()
+                    .add_service(
+                        arrow_flight::flight_service_server::FlightServiceServer::with_interceptor(
+                            writer_flight_service,
+                            move |req| interceptor.intercept(req),
+                        ),
+                    )
+                    .serve_with_shutdown(writer_flight_addr, shutdown)
+                    .await,
+                None => {
+                    Server::builder()
+                        .add_service(
+                            arrow_flight::flight_service_server::FlightServiceServer::new(
+                                writer_flight_service,
+                            ),
+                        )
+                        .serve_with_shutdown(writer_flight_addr, shutdown)
+                        .await
+                }
+            };
+        match serve {
             Ok(_) => log::info!("Writer Flight service stopped"),
             Err(e) => log::error!("Writer Flight service error: {e}"),
         }
@@ -413,18 +464,33 @@ async fn main() -> Result<()> {
     let querier_flight_handle = tokio::spawn(async move {
         log::info!("Starting Querier Flight service on {querier_flight_addr}");
 
-        match Server::builder()
-            .add_service(
-                arrow_flight::flight_service_server::FlightServiceServer::new(
-                    querier_flight_service,
-                ),
-            )
-            .serve_with_shutdown(querier_flight_addr, async {
-                querier_flight_shutdown_rx.await.ok();
-                log::info!("Querier Flight service shutting down gracefully");
-            })
-            .await
-        {
+        let shutdown = async {
+            querier_flight_shutdown_rx.await.ok();
+            log::info!("Querier Flight service shutting down gracefully");
+        };
+        let serve =
+            match tenant_flight_auth {
+                Some(interceptor) => Server::builder()
+                    .add_service(
+                        arrow_flight::flight_service_server::FlightServiceServer::with_interceptor(
+                            querier_flight_service,
+                            move |req| interceptor.intercept(req),
+                        ),
+                    )
+                    .serve_with_shutdown(querier_flight_addr, shutdown)
+                    .await,
+                None => {
+                    Server::builder()
+                        .add_service(
+                            arrow_flight::flight_service_server::FlightServiceServer::new(
+                                querier_flight_service,
+                            ),
+                        )
+                        .serve_with_shutdown(querier_flight_addr, shutdown)
+                        .await
+                }
+            };
+        match serve {
             Ok(_) => log::info!("Querier Flight service stopped"),
             Err(e) => log::error!("Querier Flight service error: {e}"),
         }

--- a/src/writer/src/main.rs
+++ b/src/writer/src/main.rs
@@ -163,12 +163,40 @@ async fn main() -> anyhow::Result<()> {
     let writer_bg_handle = flight_service.start_background_processing();
 
     tracing::info!(address = %flight_addr, "Starting Flight ingest service");
+    // The writer's Flight surface is service-to-service only: when the
+    // internal key is configured, tenant API keys are rejected outright.
+    let flight_auth = config
+        .auth
+        .internal_service_key
+        .clone()
+        .map(common::flight::auth::FlightAuthInterceptor::internal_only);
+    if flight_auth.is_none() {
+        tracing::warn!(
+            "Flight port is UNAUTHENTICATED ([auth].internal_service_key is not set); \
+             it must be restricted to a trusted network"
+        );
+    }
     let flight_handle = tokio::spawn(async move {
-        Server::builder()
-            .add_service(FlightServiceServer::new(flight_service))
-            .serve(flight_addr)
-            .await
-            .unwrap();
+        let serve = match flight_auth {
+            Some(interceptor) => {
+                Server::builder()
+                    .add_service(FlightServiceServer::with_interceptor(
+                        flight_service,
+                        move |req| interceptor.intercept(req),
+                    ))
+                    .serve(flight_addr)
+                    .await
+            }
+            None => {
+                Server::builder()
+                    .add_service(FlightServiceServer::new(flight_service))
+                    .serve(flight_addr)
+                    .await
+            }
+        };
+        if let Err(e) = serve {
+            tracing::error!(error = %e, "Flight server exited with error");
+        }
     });
 
     // Await shutdown signal

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -113,6 +113,7 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
     config.auth = common::config::AuthConfig {
         enabled: true,
         admin_api_key: None,
+        internal_service_key: None,
         tenants: vec![common::config::TenantConfig {
             id: "test-tenant".to_string(),
             slug: "test-tenant".to_string(),

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -106,6 +106,7 @@ async fn setup_test_services() -> TestServices {
             schema_config: None,
         }],
         admin_api_key: None,
+        internal_service_key: None,
     };
 
     let wal_config = WalConfig {
@@ -723,6 +724,7 @@ async fn test_tempo_v2_trace_endpoint() {
             schema_config: None,
         }],
         admin_api_key: None,
+        internal_service_key: None,
     };
     let state = InMemoryStateImpl::new(catalog, config);
 
@@ -833,6 +835,7 @@ async fn setup_multi_tenant_test_services() -> TestServices {
             },
         ],
         admin_api_key: None,
+        internal_service_key: None,
     };
 
     // Create WAL configs for both tenants

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -149,6 +149,7 @@ async fn test_iceberg_namespace_slug_based() -> Result<()> {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         },
         ..Default::default()
     };
@@ -309,6 +310,7 @@ async fn test_write_and_query_with_slugs() -> Result<()> {
                 schema_config: None,
             }],
             admin_api_key: None,
+            internal_service_key: None,
         },
         ..Default::default()
     };


### PR DESCRIPTION
## Summary

Addresses the P0 isolation breach in #544 (epic #563): the router (:50053), querier (:50054), and writer (:50051) Flight servers accepted unauthenticated calls, and the querier executes SQL against a session where every tenant catalog is registered — anyone who could reach the port could read any tenant's data.

### Design

New `[auth].internal_service_key` (shared secret, same value on all services). When set:

- **Router & querier Flight servers** require a Bearer token: either the internal key (trusted service-to-service caller, e.g. router→querier on behalf of an HTTP-authenticated tenant) or a **tenant API key** + `x-tenant-id`, validated by the existing `Authenticator`.
- **Tenant-scoped callers are pinned to their tenant**: `find_trace`/`search_traces` tickets naming another tenant are rejected with `PermissionDenied`, and SQL queries execute against the authenticated tenant/dataset regardless of what headers claim.
- **Writer Flight server is internal-only**: tenant keys are rejected outright (its `do_put` trusts app_metadata tenant routing, so tenant-facing access would allow cross-tenant writes).
- Outbound wiring: router attaches the key to its querier calls; the router Flight proxy keeps forwarding external callers' credentials so the querier re-authenticates them; the acceptor attaches the key on writer forwards (hot path + WAL retry consumer).
- Monolithic mode wires all three servers from the shared config.

When the key is **unset**, behavior is unchanged (backward compatible) and every server logs a prominent startup warning that its Flight port is unauthenticated and must be network-isolated — the fallback the issue explicitly allows, now made loud.

Key comparison is constant-time.

### Tests

- Interceptor: internal key accepted/marked, tenant key → TenantContext, wrong key rejected, missing auth rejected, internal-only mode rejects tenant keys, attach helper round-trips.
- Querier: cross-tenant ticket rejected with PermissionDenied; same-tenant ticket passes authorization.

### Notes

- Interceptors are sync, so tenant auth uses the same `block_in_place` bridge as the existing OTLP gRPC interceptor — noted in #556 as a follow-up perf concern.
- `signaldb.dist.toml` documents the new key.

Refs #544 (remaining: decide whether to require the key in production deployments / default-deny)
Part of #563