### PR TITLE
feat(flight): close out Flight port authentication (#544)

### DIFF
--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -16,10 +16,12 @@ enabled = true  # Set to false to disable authentication (dev/testing only)
 # admin_api_key = "sk-admin-your-secret-key-here"
 
 # Shared secret for service-to-service Arrow Flight calls (router -> querier,
-# acceptor -> writer). When set, the Flight ports (50051/50053/50054) require
-# every call to present either this key or a valid tenant API key; tenant
-# callers are then scoped to their own tenant. When unset, the Flight ports
-# are UNAUTHENTICATED and must be restricted to a trusted network.
+# acceptor -> writer). When set, the Flight ports (writer 50051, router 50053,
+# querier 50054, compactor 50055) require every call to present either this
+# key or a valid tenant API key; tenant callers are then scoped to their own
+# tenant, and the writer/compactor ports accept the internal key only. When
+# unset, the Flight ports are UNAUTHENTICATED and must be restricted to a
+# trusted network.
 # All SignalDB services must share the same value.
 # internal_service_key = "sk-internal-your-secret-key-here"
 

--- a/src/common/src/flight/auth.rs
+++ b/src/common/src/flight/auth.rs
@@ -1,6 +1,7 @@
 //! # Flight Authentication
 //!
-//! Authentication for the Arrow Flight ports (router, querier).
+//! Authentication for the Arrow Flight ports (router, querier, writer,
+//! compactor).
 //!
 //! The Flight servers are reachable over the network, and the querier
 //! executes SQL against a session where every tenant catalog is registered.

--- a/src/compactor/src/main.rs
+++ b/src/compactor/src/main.rs
@@ -185,15 +185,43 @@ async fn main() -> Result<()> {
         lease_manager.clone(),
         compaction_metrics.clone(),
     );
+    // The compactor's Flight surface is operator/service-to-service only
+    // (do_action can trigger compaction cycles and exposes tenant lease
+    // metadata): when the internal key is configured, tenant API keys are
+    // rejected outright.
+    let flight_auth = config
+        .auth
+        .internal_service_key
+        .clone()
+        .map(common::flight::auth::FlightAuthInterceptor::internal_only);
+    if flight_auth.is_none() {
+        tracing::warn!(
+            "Flight port is UNAUTHENTICATED ([auth].internal_service_key is not set); \
+             it must be restricted to a trusted network"
+        );
+    }
     let flight_task = {
         tokio::spawn(async move {
             tracing::info!("Starting Compactor Flight service on {flight_addr}");
-            match Server::builder()
-                .add_service(FlightServiceServer::new(flight_service))
-                .serve(flight_addr)
-                .await
-            {
-                Ok(_) => tracing::info!("Compactor Flight service stopped"),
+            let serve = match flight_auth {
+                Some(interceptor) => {
+                    Server::builder()
+                        .add_service(FlightServiceServer::with_interceptor(
+                            flight_service,
+                            move |req| interceptor.intercept(req),
+                        ))
+                        .serve(flight_addr)
+                        .await
+                }
+                None => {
+                    Server::builder()
+                        .add_service(FlightServiceServer::new(flight_service))
+                        .serve(flight_addr)
+                        .await
+                }
+            };
+            match serve {
+                Ok(()) => tracing::info!("Compactor Flight service stopped"),
                 Err(e) => tracing::error!("Compactor Flight service error: {e}"),
             }
         })

--- a/src/router/src/endpoints/flight.rs
+++ b/src/router/src/endpoints/flight.rs
@@ -263,7 +263,9 @@ impl<S: RouterState> FlightService for SignalDBFlightService<S> {
         &self,
         _request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        // Simple handshake implementation - no authentication for now
+        // Authentication happens per-request in the FlightAuthInterceptor
+        // installed at server construction; the handshake carries no
+        // credentials and just confirms protocol compatibility.
         let response = HandshakeResponse {
             protocol_version: 0,
             payload: Bytes::new(),


### PR DESCRIPTION
## Summary

Closes the remaining gaps from #544 after the main implementation landed in #579 (interceptor + internal service key) and #577 (per-request tenant-scoped SessionContext):

- **Compactor Flight port (50055) is now authenticated.** It was the last Flight server built without the `FlightAuthInterceptor`; its `do_action` surface (`compact_now`, `compact_dry_run`, `compact_status`) let anyone who could reach the port trigger compaction cycles and read tenant/dataset lease metadata. It now uses `internal_only` mode like the writer: internal service key required when configured, loud UNAUTHENTICATED startup warning otherwise.
- **Documented the hard requirement** the issue asked for: `signaldb.dist.toml` now lists all four Flight ports (writer 50051, router 50053, querier 50054, compactor 50055) and states that with the key unset they are unauthenticated and must be network-isolated.
- Removed the stale "no authentication for now" comment in the router handshake, which predated the interceptor.

Monolithic mode needs no change — it registers the compactor with a `compactor:none` sentinel and exposes no compactor Flight endpoint.

## Deferred

Default-deny (refusing to start with tenants configured but no internal key) is deliberately left to #553, where the dead `[auth] enabled` flag gets real semantics — gating Flight fail-fast on a flag that currently does nothing would be misleading.

## Testing

- `cargo clippy -p compactor -p router -p common --all-targets --all-features` clean
- `cargo test -p common --lib flight::auth` — 6/6 interceptor tests pass
- `cargo machete --with-metadata` clean

Closes #544
Part of #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional authentication for the compactor’s Flight service using a shared internal service key.
  * Flight requests can authenticate with either the shared service key or a valid tenant API key.
  * Added warnings when Flight authentication is disabled, recommending trusted-network access.

* **Documentation**
  * Clarified Flight authentication coverage and handshake behavior across supported services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->