### PR TITLE
fix(writer): idempotent WAL-to-Iceberg commits — no duplicate rows on crash replay

### DIFF
--- a/src/common/src/wal/mod.rs
+++ b/src/common/src/wal/mod.rs
@@ -494,6 +494,10 @@ pub struct Wal {
     cleanup_handle: Option<tokio::task::JoinHandle<()>>,
     /// All segments including current (for cleanup operations)
     segments: Arc<Mutex<Vec<Arc<Mutex<WalSegment>>>>>,
+    /// Stable identity of this WAL directory, persisted in `writer.id`.
+    /// Survives restarts so downstream consumers can key idempotency
+    /// markers to the WAL whose entries they process.
+    writer_id: String,
 }
 
 impl Wal {
@@ -515,6 +519,8 @@ impl Wal {
         }
 
         create_dir_all(&config.wal_dir).await?;
+
+        let writer_id = Self::load_or_create_writer_id(&config.wal_dir).await?;
 
         // Find all segment IDs
         let mut segment_ids = Vec::new();
@@ -569,9 +575,47 @@ impl Wal {
             flush_handle: None,
             cleanup_handle: None,
             segments: Arc::new(Mutex::new(all_segments)),
+            writer_id,
         };
 
         Ok(wal)
+    }
+
+    /// Stable identity of this WAL directory (see the `writer_id` field).
+    pub fn writer_id(&self) -> &str {
+        &self.writer_id
+    }
+
+    /// Load the persisted writer id from `writer.id`, creating (and
+    /// fsyncing) it on first use. The id shares the WAL directory's
+    /// lifetime: if the directory is wiped, the entries the id guarded
+    /// are gone with it, so a fresh id is correct.
+    async fn load_or_create_writer_id(wal_dir: &Path) -> Result<String> {
+        let path = wal_dir.join("writer.id");
+        match tokio::fs::read_to_string(&path).await {
+            Ok(contents) => {
+                let id = contents.trim().to_string();
+                if !id.is_empty() {
+                    return Ok(id);
+                }
+                // Empty file (e.g. crash between create and write): regenerate
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).context("Failed to read WAL writer.id");
+            }
+        }
+
+        let id = Uuid::new_v4().simple().to_string();
+        let mut file = File::create(&path)
+            .await
+            .context("Failed to create WAL writer.id")?;
+        file.write_all(id.as_bytes()).await?;
+        file.flush().await?;
+        file.sync_all()
+            .await
+            .context("Failed to fsync WAL writer.id")?;
+        Ok(id)
     }
 
     /// Start background flush task
@@ -1020,6 +1064,7 @@ impl Wal {
         let current_segment = self.current_segment.clone();
         let next_segment_id = self.next_segment_id.clone();
         let segments = self.segments.clone();
+        let writer_id = self.writer_id.clone();
 
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
@@ -1038,6 +1083,7 @@ impl Wal {
                     flush_handle: None,
                     cleanup_handle: None,
                     segments: segments.clone(),
+                    writer_id: writer_id.clone(),
                 };
 
                 if let Err(e) = wal.cleanup().await {
@@ -1086,6 +1132,41 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn writer_id_is_stable_across_reopen() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            max_segment_size: 1024,
+            max_buffer_entries: 10,
+            flush_interval_secs: 1,
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            retention_secs: 3600,
+            cleanup_interval_secs: 300,
+            compaction_threshold: 0.5,
+        };
+
+        let wal = Wal::new(config.clone()).await.unwrap();
+        let first_id = wal.writer_id().to_string();
+        assert!(!first_id.is_empty());
+        drop(wal);
+
+        let reopened = Wal::new(config.clone()).await.unwrap();
+        assert_eq!(reopened.writer_id(), first_id);
+        drop(reopened);
+
+        // A different WAL directory gets a different identity
+        let other_dir = TempDir::new().unwrap();
+        let other = Wal::new(WalConfig {
+            wal_dir: other_dir.path().to_path_buf(),
+            ..config
+        })
+        .await
+        .unwrap();
+        assert_ne!(other.writer_id(), first_id);
+    }
 
     #[tokio::test]
     async fn test_wal_basic_operations() {

--- a/src/writer/src/processor.rs
+++ b/src/writer/src/processor.rs
@@ -1,5 +1,5 @@
 use crate::storage::IcebergTableWriter;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use common::CatalogManager;
 use common::wal::{Wal, WalEntry, bytes_to_record_batch};
 use datafusion::arrow::array::RecordBatch;
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{Duration, interval};
 use uuid::Uuid;
+
+/// Maximum WAL entries committed per Iceberg transaction. Bounds the size
+/// of the idempotency marker written with each commit (one uuid per entry).
+const MAX_ENTRIES_PER_COMMIT: usize = 1024;
 
 /// WAL processor that reads entries and writes them to Iceberg tables
 /// Replaces the direct Parquet writing approach with transaction-based Iceberg writes
@@ -82,19 +86,21 @@ impl WalProcessor {
                 .push((entry.id, batch));
         }
 
-        // Process each group using batch writes
+        // Process each group using batch writes. Marking happens inside
+        // process_batch_for_table, interleaved with commits to preserve
+        // the idempotency-marker invariant.
         for ((tenant_id, dataset_id, table_name), entries) in grouped_entries {
             match self
                 .process_batch_for_table(&tenant_id, &dataset_id, &table_name, entries)
                 .await
             {
                 Ok(processed_ids) => {
-                    // Mark all entries as processed
-                    for entry_id in processed_ids {
-                        if let Err(e) = self.wal.mark_processed(entry_id).await {
-                            tracing::warn!(entry_id = %entry_id, error = %e, "Failed to mark WAL entry as processed");
-                        }
-                    }
+                    tracing::debug!(
+                        entry_count = processed_ids.len(),
+                        tenant_id = %tenant_id,
+                        table_name = %table_name,
+                        "Processed and marked entries for table"
+                    );
                 }
                 Err(e) => {
                     tracing::error!(tenant_id = %tenant_id, table_name = %table_name, error = %e, "Failed to process batch for table");
@@ -137,25 +143,63 @@ impl WalProcessor {
             self.table_writers.insert(writer_key.clone(), writer);
         }
 
+        let wal = self.wal.clone();
+        let wal_writer_id = wal.writer_id().to_string();
         let writer = self
             .table_writers
             .get_mut(&writer_key)
             .ok_or_else(|| anyhow::anyhow!("Failed to get table writer for {}", writer_key))?;
 
-        // Extract batches and IDs
-        let (entry_ids, batches): (Vec<Uuid>, Vec<RecordBatch>) = entries.into_iter().unzip();
+        // Step 1: dedupe against the idempotency marker. Ids recorded
+        // there were committed to Iceberg but never marked processed
+        // (crash between commit and index write, or a failed mark).
+        // Re-inserting them would duplicate rows — mark them durably
+        // instead, and do it BEFORE any new commit replaces the marker.
+        // A mark failure aborts the whole group for the same reason.
+        let committed = writer.load_committed_marker(&wal_writer_id).await?;
+        let mut processed_ids = Vec::new();
+        let mut fresh = Vec::new();
+        for (entry_id, batch) in entries {
+            if committed.contains(&entry_id) {
+                wal.mark_processed(entry_id).await.with_context(|| {
+                    format!("Failed to mark already-committed WAL entry {entry_id} as processed")
+                })?;
+                tracing::info!(
+                    entry_id = %entry_id,
+                    table_name = %table_name,
+                    "Skipping re-insert of WAL entry already committed to Iceberg"
+                );
+                processed_ids.push(entry_id);
+            } else {
+                fresh.push((entry_id, batch));
+            }
+        }
 
-        // Write all batches in a single transaction
-        writer.write_batches(batches).await?;
+        // Step 2: commit fresh entries in bounded chunks, marking each
+        // chunk before the next commit so at most one commit's ids are
+        // ever unmarked — which is exactly what the marker covers.
+        let mut fresh_iter = fresh.into_iter().peekable();
+        while fresh_iter.peek().is_some() {
+            let chunk: Vec<(Uuid, RecordBatch)> =
+                fresh_iter.by_ref().take(MAX_ENTRIES_PER_COMMIT).collect();
+            let chunk_ids: Vec<Uuid> = chunk.iter().map(|(id, _)| *id).collect();
 
-        tracing::debug!(
-            entry_count = entry_ids.len(),
-            tenant_id = %tenant_id,
-            table_name = %table_name,
-            "Successfully processed entries for table"
-        );
+            writer
+                .append_batches_with_marker(&wal_writer_id, chunk)
+                .await?;
 
-        Ok(entry_ids)
+            for entry_id in &chunk_ids {
+                // On failure the entry stays unprocessed but its id is in
+                // the marker, so the next tick re-marks instead of
+                // re-inserting.
+                wal.mark_processed(*entry_id).await.with_context(|| {
+                    format!("Failed to mark WAL entry {entry_id} as processed after commit")
+                })?;
+            }
+            processed_ids.extend(chunk_ids);
+        }
+
+        Ok(processed_ids)
     }
 
     /// Determine which tenant, dataset, and table an entry should go to
@@ -262,7 +306,6 @@ impl WalProcessor {
             .await
         {
             Ok(_) => {
-                self.wal.mark_processed(entry_id).await?;
                 tracing::debug!(entry_id = %entry_id, "Successfully processed single WAL entry");
                 Ok(())
             }

--- a/src/writer/src/storage/iceberg.rs
+++ b/src/writer/src/storage/iceberg.rs
@@ -8,14 +8,18 @@ use anyhow::Result;
 use common::CatalogManager;
 
 use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::SessionConfig;
 use datafusion_iceberg::DataFusionTable;
+use iceberg_rust::arrow::write::write_parquet_partitioned;
 use iceberg_rust::catalog::Catalog as IcebergRustCatalog;
 use iceberg_rust::catalog::identifier::Identifier;
+use iceberg_rust::catalog::tabular::Tabular;
 use iceberg_rust::table::Table;
 use object_store::ObjectStore;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use uuid;
@@ -106,7 +110,6 @@ impl Default for BatchOptimizationConfig {
 /// Iceberg table writer that replaces direct Parquet file writing
 /// Provides ACID transactions and proper metadata tracking
 pub struct IcebergTableWriter {
-    #[allow(dead_code)] // Will be used for future operations
     catalog: Arc<dyn IcebergRustCatalog>,
     table: Table,
     #[allow(dead_code)] // Will be used for data writing
@@ -1014,6 +1017,241 @@ impl IcebergTableWriter {
     pub fn batch_config(&self) -> &BatchOptimizationConfig {
         &self.batch_config
     }
+
+    /// Reload the table from the catalog, bypassing any cached handle,
+    /// so marker reads and the next commit are based on current metadata.
+    async fn reload_table(&mut self) -> Result<()> {
+        let ident = self.table.identifier().clone();
+        let tabular = self
+            .catalog
+            .clone()
+            .load_tabular(&ident)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to reload Iceberg table {ident}: {e}"))?;
+        match tabular {
+            Tabular::Table(table) => {
+                self.table = table;
+                Ok(())
+            }
+            _ => Err(anyhow::anyhow!(
+                "Expected table but found different tabular type for {ident}"
+            )),
+        }
+    }
+
+    /// Parse this WAL writer's idempotency marker from the (in-memory)
+    /// table properties.
+    fn read_marker(&self, wal_writer_id: &str) -> HashSet<uuid::Uuid> {
+        self.table
+            .metadata()
+            .properties
+            .get(&wal_marker_key(wal_writer_id))
+            .map(|value| decode_marker_ids(value))
+            .unwrap_or_default()
+    }
+
+    /// Reload the table and return the WAL entry ids recorded by the most
+    /// recent marker commit for `wal_writer_id`. Ids present here are
+    /// durably committed to Iceberg even if the WAL never marked them
+    /// processed (crash between commit and index write).
+    pub async fn load_committed_marker(
+        &mut self,
+        wal_writer_id: &str,
+    ) -> Result<HashSet<uuid::Uuid>> {
+        self.reload_table().await?;
+        Ok(self.read_marker(wal_writer_id))
+    }
+
+    /// Atomically append `entries`' batches and record their WAL entry ids
+    /// as this writer's idempotency marker — data files and marker ride in
+    /// ONE Iceberg commit (a single catalog CAS), so replay after a crash
+    /// can always tell whether the data landed.
+    ///
+    /// Contract for callers: dedupe `entries` against
+    /// [`Self::load_committed_marker`] and durably mark any previously
+    /// committed ids processed BEFORE calling this — the commit REPLACES
+    /// the marker, discarding the evidence for earlier commits.
+    ///
+    /// Commit outcomes are verified against the catalog rather than
+    /// trusted: an `Err` can follow a commit that actually landed
+    /// (ambiguous failure), and the sql catalog can lose a CAS silently.
+    /// After every attempt the table is reloaded and the marker checked —
+    /// only the marker decides success, so retries can never double-append.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            tenant_id = %self.tenant_id,
+            dataset_id = %self.dataset_id,
+            entry_count = entries.len()
+        )
+    )]
+    pub async fn append_batches_with_marker(
+        &mut self,
+        wal_writer_id: &str,
+        entries: Vec<(uuid::Uuid, RecordBatch)>,
+    ) -> Result<()> {
+        let (ids, batches): (Vec<uuid::Uuid>, Vec<RecordBatch>) = entries.into_iter().unzip();
+
+        // The Parquet writer requires batches in the table's exact Arrow
+        // schema (derived from the Iceberg schema, e.g. microsecond
+        // timestamps), so coerce after the wire→storage transformation.
+        let target_schema: ArrowSchemaRef = Arc::new(
+            self.table
+                .current_schema(None)
+                .map_err(|e| anyhow::anyhow!("Failed to get current Iceberg schema: {e}"))?
+                .fields()
+                .try_into()
+                .map_err(|e: iceberg_rust::spec::error::Error| {
+                    anyhow::anyhow!("Failed to convert Iceberg schema to Arrow: {e}")
+                })?,
+        );
+
+        let mut transformed = Vec::new();
+        for batch in batches {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            let batch = self.apply_schema_transformation_if_needed(batch)?;
+            transformed.push(coerce_batch_to_schema(batch, &target_schema)?);
+        }
+        if transformed.is_empty() {
+            // Nothing to append: the ids can be marked processed without
+            // a commit, and replaying them is a no-op either way.
+            return Ok(());
+        }
+        let total_rows: usize = transformed.iter().map(|b| b.num_rows()).sum();
+
+        let stream = futures::stream::iter(transformed.into_iter().map(Ok));
+        let files = write_parquet_partitioned(&self.table, stream, None)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to write Parquet files for Iceberg table {}: {e}",
+                    self.table.identifier()
+                )
+            })?;
+        if files.is_empty() {
+            return Err(anyhow::anyhow!(
+                "write_parquet_partitioned produced no data files for {total_rows} rows"
+            ));
+        }
+
+        let marker_key = wal_marker_key(wal_writer_id);
+        let marker_value = encode_marker_ids(&ids);
+        let id_set: HashSet<uuid::Uuid> = ids.iter().copied().collect();
+
+        let mut attempt = 0;
+        let mut delay = self.retry_config.initial_delay;
+        loop {
+            attempt += 1;
+            let commit_result = self
+                .table
+                .new_transaction(None)
+                .append_data(files.clone())
+                .update_properties(vec![(marker_key.clone(), marker_value.clone())])
+                .commit()
+                .await;
+
+            // The catalog is the source of truth for whether the commit
+            // landed, regardless of what commit() returned.
+            self.reload_table().await?;
+            if self.read_marker(wal_writer_id) == id_set {
+                if let Err(e) = commit_result {
+                    log::warn!(
+                        "Iceberg commit reported an error but the marker landed \
+                         (treating as success): {e}"
+                    );
+                }
+                log::info!(
+                    "Committed {} rows in {} data files to Iceberg table {} (attempt {attempt})",
+                    total_rows,
+                    files.len(),
+                    self.table.identifier()
+                );
+                return Ok(());
+            }
+
+            let error = match commit_result {
+                Ok(()) => anyhow::anyhow!(
+                    "Iceberg commit reported success but the marker is absent \
+                     (catalog CAS silently lost)"
+                ),
+                Err(e) => anyhow::anyhow!("Iceberg commit failed: {e}"),
+            };
+            if attempt >= self.retry_config.max_attempts {
+                return Err(error.context(format!(
+                    "Failed to commit {} entries to Iceberg table {} after {attempt} attempts",
+                    id_set.len(),
+                    self.table.identifier()
+                )));
+            }
+            log::warn!(
+                "Commit attempt {attempt} for Iceberg table {} did not land: {error}. \
+                 Retrying in {delay:?}",
+                self.table.identifier()
+            );
+            tokio::time::sleep(delay).await;
+            delay = std::cmp::min(
+                self.retry_config.max_delay,
+                Duration::from_secs_f64(delay.as_secs_f64() * self.retry_config.backoff_multiplier),
+            );
+        }
+    }
+}
+
+/// Prefix for the per-WAL idempotency marker stored in Iceberg table
+/// properties. The full key is `signaldb.wal.committed.<wal-writer-id>`,
+/// so concurrent writer nodes (distinct WAL directories) never clobber
+/// each other's markers.
+pub const WAL_MARKER_PREFIX: &str = "signaldb.wal.committed.";
+
+fn wal_marker_key(wal_writer_id: &str) -> String {
+    format!("{WAL_MARKER_PREFIX}{wal_writer_id}")
+}
+
+fn encode_marker_ids(ids: &[uuid::Uuid]) -> String {
+    ids.iter()
+        .map(|id| id.simple().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn decode_marker_ids(value: &str) -> HashSet<uuid::Uuid> {
+    value
+        .split(',')
+        .filter_map(|part| uuid::Uuid::parse_str(part.trim()).ok())
+        .collect()
+}
+
+/// Project and cast a batch onto the table's Arrow schema (columns matched
+/// by name). Extra batch columns are dropped; missing columns are an error,
+/// as is a null in a column the table declares non-nullable.
+fn coerce_batch_to_schema(batch: RecordBatch, target: &ArrowSchemaRef) -> Result<RecordBatch> {
+    let mut columns = Vec::with_capacity(target.fields().len());
+    for field in target.fields() {
+        let index = batch.schema().index_of(field.name()).map_err(|_| {
+            anyhow::anyhow!(
+                "Batch is missing column '{}' required by the table schema",
+                field.name()
+            )
+        })?;
+        let column = batch.column(index);
+        let column = if column.data_type() == field.data_type() {
+            column.clone()
+        } else {
+            datafusion::arrow::compute::cast(column, field.data_type()).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to cast column '{}' from {:?} to {:?}: {e}",
+                    field.name(),
+                    column.data_type(),
+                    field.data_type()
+                )
+            })?
+        };
+        columns.push(column);
+    }
+    RecordBatch::try_new(target.clone(), columns)
+        .map_err(|e| anyhow::anyhow!("Failed to build coerced batch: {e}"))
 }
 
 #[cfg(test)]
@@ -1036,6 +1274,32 @@ mod tests {
         };
 
         CatalogManager::new(config).await.unwrap()
+    }
+
+    #[test]
+    fn marker_ids_round_trip() {
+        let ids = vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()];
+        let encoded = encode_marker_ids(&ids);
+        let decoded = decode_marker_ids(&encoded);
+        assert_eq!(decoded, ids.iter().copied().collect::<HashSet<_>>());
+    }
+
+    #[test]
+    fn marker_decode_tolerates_garbage() {
+        let id = uuid::Uuid::new_v4();
+        let value = format!("not-a-uuid,{},", id.simple());
+        let decoded = decode_marker_ids(&value);
+        assert_eq!(decoded, HashSet::from([id]));
+        assert!(decode_marker_ids("").is_empty());
+    }
+
+    #[test]
+    fn marker_key_is_namespaced_per_writer() {
+        assert_eq!(
+            wal_marker_key("abc123"),
+            "signaldb.wal.committed.abc123".to_string()
+        );
+        assert_ne!(wal_marker_key("writer-a"), wal_marker_key("writer-b"));
     }
 
     #[tokio::test]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -67,6 +67,10 @@ name = "iceberg_integration"
 path = "tests/writer/iceberg_integration.rs"
 
 [[test]]
+name = "wal_replay_idempotency"
+path = "tests/writer/wal_replay_idempotency.rs"
+
+[[test]]
 name = "flight_rpc_tests"
 path = "tests/e2e/flight_rpc_tests.rs"
 

--- a/tests-integration/tests/writer/wal_replay_idempotency.rs
+++ b/tests-integration/tests/writer/wal_replay_idempotency.rs
@@ -1,0 +1,287 @@
+//! Regression tests for issue #546: at-least-once WAL processing must not
+//! duplicate rows in Iceberg when entries are replayed after a crash
+//! between the Iceberg commit and the WAL index write.
+//!
+//! The crash is simulated by deleting the WAL `.index` files after a
+//! successful processing pass — exactly the state a process death leaves
+//! behind when the commit landed but `mark_processed` never persisted —
+//! then reprocessing with a fresh WAL and processor.
+
+use anyhow::Result;
+use common::CatalogManager;
+use common::iceberg::names::build_table_identifier;
+use common::wal::{Wal, WalConfig, WalOperation, record_batch_to_bytes};
+use datafusion::arrow::array::{
+    Array, Date32Array, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray,
+    TimestampNanosecondArray,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use datafusion::prelude::SessionContext;
+use datafusion_iceberg::DataFusionTable;
+use iceberg_rust::catalog::tabular::Tabular;
+use object_store::memory::InMemory;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::tempdir;
+use writer::WalProcessor;
+
+/// Build a batch in the metrics_gauge storage schema.
+fn metrics_gauge_batch(values: &[f64]) -> Result<RecordBatch> {
+    let n = values.len();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new(
+            "start_timestamp",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        ),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("metric_description", DataType::Utf8, true),
+        Field::new("metric_unit", DataType::Utf8, true),
+        Field::new("value", DataType::Float64, false),
+        Field::new("flags", DataType::Int32, true),
+        Field::new("resource_schema_url", DataType::Utf8, true),
+        Field::new("resource_attributes", DataType::Utf8, true),
+        Field::new("scope_name", DataType::Utf8, true),
+        Field::new("scope_version", DataType::Utf8, true),
+        Field::new("scope_schema_url", DataType::Utf8, true),
+        Field::new("scope_attributes", DataType::Utf8, true),
+        Field::new("scope_dropped_attr_count", DataType::Int32, true),
+        Field::new("attributes", DataType::Utf8, true),
+        Field::new("exemplars", DataType::Utf8, true),
+        Field::new("date_day", DataType::Date32, false),
+        Field::new("hour", DataType::Int32, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(TimestampNanosecondArray::from(
+                (0..n).map(|i| 1_000_000_000 + i as i64).collect::<Vec<_>>(),
+            )),
+            Arc::new(TimestampNanosecondArray::from(vec![None::<i64>; n])),
+            Arc::new(StringArray::from(vec!["test-service"; n])),
+            Arc::new(StringArray::from(vec!["cpu.usage"; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![Some("%"); n])),
+            Arc::new(Float64Array::from(values.to_vec())),
+            Arc::new(Int32Array::from(vec![None::<i32>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(Int32Array::from(vec![None::<i32>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(Date32Array::from(vec![19000; n])),
+            Arc::new(Int32Array::from(vec![10; n])),
+        ],
+    )?;
+    Ok(batch)
+}
+
+/// Count rows in the table by loading it fresh from the catalog (bypassing
+/// any cached handle) and running SELECT COUNT(*).
+async fn count_rows(catalog_manager: &CatalogManager, table_name: &str) -> Result<i64> {
+    let ident = build_table_identifier("default", "default", table_name);
+    let tabular = catalog_manager
+        .catalog()
+        .load_tabular(&ident)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to load table {ident}: {e}"))?;
+    let table = match tabular {
+        Tabular::Table(table) => table,
+        _ => anyhow::bail!("Expected a table for {ident}"),
+    };
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", Arc::new(DataFusionTable::from(table)))?;
+    let batches = ctx.sql("SELECT COUNT(*) FROM t").await?.collect().await?;
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("COUNT(*) should be Int64")
+        .value(0);
+    Ok(count)
+}
+
+/// Delete the WAL index files, simulating a crash where the Iceberg commit
+/// landed but the processed-index write did not.
+async fn drop_wal_indexes(wal_dir: &Path) -> Result<()> {
+    let mut deleted = 0;
+    let mut dir = tokio::fs::read_dir(wal_dir).await?;
+    while let Some(entry) = dir.next_entry().await? {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.ends_with(".index"))
+        {
+            tokio::fs::remove_file(entry.path()).await?;
+            deleted += 1;
+        }
+    }
+    anyhow::ensure!(deleted > 0, "expected at least one WAL index file");
+    Ok(())
+}
+
+#[tokio::test]
+async fn replay_after_crash_does_not_duplicate_rows() -> Result<()> {
+    let wal_dir = tempdir()?;
+    let wal_config = WalConfig::with_defaults(wal_dir.path().to_path_buf());
+    let catalog_manager = Arc::new(CatalogManager::new_in_memory().await?);
+    let object_store = Arc::new(InMemory::new());
+
+    // Ingest two entries and process them normally.
+    let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+    let batch1 = metrics_gauge_batch(&[1.0, 2.0, 3.0])?;
+    let batch2 = metrics_gauge_batch(&[4.0, 5.0])?;
+    wal.append(
+        WalOperation::WriteMetrics,
+        record_batch_to_bytes(&batch1)?,
+        None,
+    )
+    .await?;
+    wal.append(
+        WalOperation::WriteMetrics,
+        record_batch_to_bytes(&batch2)?,
+        None,
+    )
+    .await?;
+    wal.flush().await?;
+
+    let mut processor =
+        WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+    processor.process_pending_entries().await?;
+    assert!(
+        wal.get_unprocessed_entries().await?.is_empty(),
+        "all entries should be marked processed after the first pass"
+    );
+    assert_eq!(count_rows(&catalog_manager, "metrics_gauge").await?, 5);
+
+    // Simulate the crash: the commit landed, the index write did not.
+    processor.shutdown().await?;
+    drop(processor);
+    drop(wal);
+    drop_wal_indexes(wal_dir.path()).await?;
+
+    // Restart: entries load as unprocessed and are replayed.
+    let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+    let replayed = wal.get_unprocessed_entries().await?;
+    assert_eq!(replayed.len(), 2, "index loss must resurface the entries");
+
+    let mut processor =
+        WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+    processor.process_pending_entries().await?;
+
+    // The idempotency marker must prevent re-inserting the committed rows.
+    assert_eq!(
+        count_rows(&catalog_manager, "metrics_gauge").await?,
+        5,
+        "replay after crash must not duplicate rows"
+    );
+    assert!(
+        wal.get_unprocessed_entries().await?.is_empty(),
+        "replayed entries should be re-marked processed"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mixed_replay_commits_only_new_entries() -> Result<()> {
+    let wal_dir = tempdir()?;
+    let wal_config = WalConfig::with_defaults(wal_dir.path().to_path_buf());
+    let catalog_manager = Arc::new(CatalogManager::new_in_memory().await?);
+    let object_store = Arc::new(InMemory::new());
+
+    let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+    let batch1 = metrics_gauge_batch(&[1.0, 2.0])?;
+    wal.append(
+        WalOperation::WriteMetrics,
+        record_batch_to_bytes(&batch1)?,
+        None,
+    )
+    .await?;
+    wal.flush().await?;
+
+    let mut processor =
+        WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+    processor.process_pending_entries().await?;
+    assert_eq!(count_rows(&catalog_manager, "metrics_gauge").await?, 2);
+    processor.shutdown().await?;
+    drop(processor);
+    drop(wal);
+    drop_wal_indexes(wal_dir.path()).await?;
+
+    // Restart with the old entry resurfaced AND a new entry appended: the
+    // old one must be skipped, the new one committed.
+    let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+    let batch2 = metrics_gauge_batch(&[3.0, 4.0, 5.0])?;
+    wal.append(
+        WalOperation::WriteMetrics,
+        record_batch_to_bytes(&batch2)?,
+        None,
+    )
+    .await?;
+    wal.flush().await?;
+    assert_eq!(wal.get_unprocessed_entries().await?.len(), 2);
+
+    let mut processor =
+        WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+    processor.process_pending_entries().await?;
+
+    assert_eq!(
+        count_rows(&catalog_manager, "metrics_gauge").await?,
+        5,
+        "old entry must be deduplicated, new entry committed"
+    );
+    assert!(wal.get_unprocessed_entries().await?.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn processing_is_idempotent_across_repeated_replays() -> Result<()> {
+    let wal_dir = tempdir()?;
+    let wal_config = WalConfig::with_defaults(wal_dir.path().to_path_buf());
+    let catalog_manager = Arc::new(CatalogManager::new_in_memory().await?);
+    let object_store = Arc::new(InMemory::new());
+
+    let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+    let batch = metrics_gauge_batch(&[1.0])?;
+    wal.append(
+        WalOperation::WriteMetrics,
+        record_batch_to_bytes(&batch)?,
+        None,
+    )
+    .await?;
+    wal.flush().await?;
+
+    let mut processor =
+        WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+    processor.process_pending_entries().await?;
+    processor.shutdown().await?;
+    drop(processor);
+    drop(wal);
+
+    // Crash-replay twice in a row: still exactly one row.
+    for _ in 0..2 {
+        drop_wal_indexes(wal_dir.path()).await?;
+        let wal = Arc::new(Wal::new(wal_config.clone()).await?);
+        let mut processor =
+            WalProcessor::new(wal.clone(), catalog_manager.clone(), object_store.clone());
+        processor.process_pending_entries().await?;
+        assert_eq!(count_rows(&catalog_manager, "metrics_gauge").await?, 1);
+        processor.shutdown().await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes the at-least-once duplication bug from #546 (epic #563): the writer committed a batch to Iceberg and *then* marked the WAL entry processed as two non-atomic steps. A crash (or failed mark) between them resurfaced the entry as unprocessed and the next tick re-INSERTed the same batch — duplicate rows. The retry wrapper had the same always-on hazard: it blindly re-ran INSERTs whose outcome was ambiguous.

### Design

The WAL processor now commits through a direct iceberg-rust transaction instead of per-batch DataFusion SQL INSERTs: batches are transformed (wire→storage), coerced to the table's Arrow schema, written with `write_parquet_partitioned`, and committed in **one Iceberg transaction that carries both the data files and an idempotency marker** — the WAL entry UUIDs, stored as a table property keyed by a persistent per-WAL-directory writer identity (`signaldb.wal.committed.<writer-id>`). `append_data` + `update_properties` merge into a single catalog CAS, so data and marker land atomically and replay can always tell whether an entry's data was committed.

Invariants that make this exactly-once:

- **Dedup before insert**: before any commit the processor reloads the table (bypassing cached handles, cf. #537), marks any marker-listed entries processed, and only then commits fresh entries — the marker always covers every committed-but-possibly-unmarked id, and marking failures abort the group instead of falling through to a re-insert.
- **Verify, don't trust**: after every commit attempt the table is reloaded from the catalog and the marker checked. An `Err` from a commit that actually landed is treated as success; an `Ok` whose CAS was silently lost (cf. #538) is retried. Retries can never double-append because only the marker decides.
- **Bounded marker**: fresh entries commit in chunks of ≤1024, each chunk marked before the next commit, and each writer node has its own marker key (WAL-directory-scoped UUID), so concurrent writers never clobber each other's evidence.

The existing SQL-transaction machinery in `IcebergTableWriter` is untouched for other callers.

### Tests

- New `wal_replay_idempotency` integration suite simulates the exact crash (delete WAL `.index` files after a successful pass, reprocess with fresh WAL + processor):
  - replay after crash → row count unchanged, entries re-marked
  - mixed replay (resurfaced old + genuinely new entries) → only new rows committed
  - repeated crash replays → still exactly one row
- Unit tests: marker codec round-trip/garbage tolerance, per-writer key namespacing, writer-id stability across WAL reopen.
- `cargo clippy --workspace --all-targets --all-features` clean; existing `common` WAL, `writer`, and `iceberg_integration` suites all pass; `cargo machete` clean.

Closes #546
Part of #563