### PR TITLE
feat(querier): enforce resource limits on query execution

### DIFF
--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -156,6 +156,29 @@ max_buffer_entries = 1000
 flush_interval = "30s"
 max_buffer_size_bytes = 134217728     # 128MB
 
+[querier]
+# Querier resource limits — bound what a single query (or tenant) can do
+# to the shared querier process.
+#
+# Maximum memory for query execution, in MiB. When unset the memory pool
+# is UNBOUNDED (a startup warning is logged) and one heavy query can OOM
+# the process. Strongly recommended in production.
+# memory_limit_mb = 4096
+#
+# Fraction of memory_limit_mb usable by query operators before they
+# spill to disk or fail (0.0-1.0).
+memory_pool_fraction = 0.8
+#
+# Wall-clock timeout per Flight query.
+query_timeout = "60s"
+#
+# Row cap for raw SQL queries received over Flight.
+max_sql_rows = 1000000
+#
+# Upper bound for the client-supplied `limit` on /api/search (trace
+# count; the span fetch limit is 50x this value).
+max_search_limit = 1000
+
 [compactor]
 # Compactor Service Configuration
 # The compactor manages the complete data lifecycle with three phases:

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -696,6 +696,9 @@ pub struct Configuration {
     /// Compactor configuration
     #[serde(default)]
     pub compactor: CompactorConfig,
+    /// Querier resource limits
+    #[serde(default)]
+    pub querier: QuerierConfig,
 }
 
 impl Default for Configuration {
@@ -717,6 +720,42 @@ impl Default for Configuration {
             self_monitoring: SelfMonitoringConfig::default(),
             profiling: ProfilingConfig::default(),
             compactor: CompactorConfig::default(),
+            querier: QuerierConfig::default(),
+        }
+    }
+}
+
+/// Resource limits for the querier service.
+///
+/// The querier executes client-controlled queries in a shared process;
+/// without limits a single query can exhaust process memory or run
+/// unbounded. See `[querier]` in `signaldb.dist.toml`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct QuerierConfig {
+    /// Maximum memory the query engine may use, in MiB. When unset the
+    /// memory pool is unbounded and the querier logs a startup warning.
+    pub memory_limit_mb: Option<u64>,
+    /// Fraction of `memory_limit_mb` usable by query operators before
+    /// they spill or fail (0.0–1.0).
+    pub memory_pool_fraction: f64,
+    /// Wall-clock timeout applied to each Flight query.
+    #[serde(with = "humantime_serde")]
+    pub query_timeout: Duration,
+    /// Row cap applied to raw SQL queries received over Flight.
+    pub max_sql_rows: usize,
+    /// Upper bound for the client-supplied `limit` on trace search.
+    pub max_search_limit: usize,
+}
+
+impl Default for QuerierConfig {
+    fn default() -> Self {
+        Self {
+            memory_limit_mb: None,
+            memory_pool_fraction: 0.8,
+            query_timeout: Duration::from_secs(60),
+            max_sql_rows: 1_000_000,
+            max_search_limit: 1_000,
         }
     }
 }
@@ -911,6 +950,41 @@ mod tests {
         assert_eq!(discovery.heartbeat_interval, Duration::from_secs(30));
         assert_eq!(discovery.poll_interval, Duration::from_secs(60));
         assert_eq!(discovery.ttl, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn querier_limits_default_and_parse_from_toml() {
+        // Defaults: unbounded memory (with warning at startup), bounded
+        // timeout/rows/limit.
+        let config = Configuration::default();
+        assert_eq!(config.querier.memory_limit_mb, None);
+        assert_eq!(config.querier.query_timeout, Duration::from_secs(60));
+        assert_eq!(config.querier.max_sql_rows, 1_000_000);
+        assert_eq!(config.querier.max_search_limit, 1_000);
+
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "signaldb.toml",
+                r#"
+                [querier]
+                memory_limit_mb = 512
+                memory_pool_fraction = 0.5
+                query_timeout = "5s"
+                max_sql_rows = 1000
+                max_search_limit = 50
+                "#,
+            )?;
+            let config: Configuration = Figment::new()
+                .merge(Serialized::defaults(Configuration::default()))
+                .merge(figment::providers::Toml::file("signaldb.toml"))
+                .extract()?;
+            assert_eq!(config.querier.memory_limit_mb, Some(512));
+            assert_eq!(config.querier.memory_pool_fraction, 0.5);
+            assert_eq!(config.querier.query_timeout, Duration::from_secs(5));
+            assert_eq!(config.querier.max_sql_rows, 1000);
+            assert_eq!(config.querier.max_search_limit, 50);
+            Ok(())
+        });
     }
 
     #[test]

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -7,6 +7,7 @@ use arrow_flight::{
 };
 use bytes::Bytes;
 use common::CatalogManager;
+use common::config::QuerierConfig;
 use common::flight::schema::{FlightSchemas, create_span_batch_schema};
 use common::flight::transport::InMemoryFlightTransport;
 use common::storage::create_object_store_from_dsn;
@@ -14,6 +15,8 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::prelude::SessionConfig;
 use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use object_store::ObjectStore;
@@ -166,15 +169,62 @@ pub struct QuerierFlightService {
     trace_service: TraceService,
     #[allow(dead_code)]
     iceberg_catalog: Option<Arc<dyn iceberg_rust::catalog::Catalog>>,
+    limits: QuerierConfig,
+}
+
+/// Build a SessionContext whose RuntimeEnv enforces the configured memory
+/// limit (spilling operators use the default disk manager). Falls back to
+/// an unlimited default context if the runtime cannot be built, which is
+/// logged as an error and practically cannot happen with default settings.
+fn session_context_with_limits(limits: &QuerierConfig) -> SessionContext {
+    let mut builder = RuntimeEnvBuilder::new();
+    match limits.memory_limit_mb {
+        Some(mb) => {
+            builder =
+                builder.with_memory_limit((mb as usize) * 1024 * 1024, limits.memory_pool_fraction);
+            tracing::info!(
+                memory_limit_mb = mb,
+                memory_pool_fraction = limits.memory_pool_fraction,
+                "Querier memory pool configured"
+            );
+        }
+        None => {
+            tracing::warn!(
+                "Querier memory is UNBOUNDED ([querier].memory_limit_mb is not set); \
+                 a single heavy query can exhaust process memory"
+            );
+        }
+    }
+    match builder.build() {
+        Ok(runtime_env) => {
+            SessionContext::new_with_config_rt(SessionConfig::new(), Arc::new(runtime_env))
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "Failed to build limited RuntimeEnv; falling back to unlimited defaults"
+            );
+            SessionContext::new()
+        }
+    }
 }
 
 impl QuerierFlightService {
-    /// Create a new QuerierFlightService
+    /// Create a new QuerierFlightService with default resource limits
     pub fn new(
         object_store: Arc<dyn ObjectStore>,
         flight_transport: Arc<InMemoryFlightTransport>,
     ) -> Self {
-        let session_ctx = Arc::new(SessionContext::new());
+        Self::new_with_limits(object_store, flight_transport, QuerierConfig::default())
+    }
+
+    /// Create a new QuerierFlightService with explicit resource limits
+    pub fn new_with_limits(
+        object_store: Arc<dyn ObjectStore>,
+        flight_transport: Arc<InMemoryFlightTransport>,
+        limits: QuerierConfig,
+    ) -> Self {
+        let session_ctx = Arc::new(session_context_with_limits(&limits));
 
         // Register object store with DataFusion for querying Parquet files
         // This allows querying files like: SELECT * FROM 'batch/file.parquet'
@@ -184,7 +234,8 @@ impl QuerierFlightService {
             .register_object_store(&url, object_store.clone());
 
         // Create trace service for specialized trace queries
-        let trace_service = TraceService::new(session_ctx.as_ref().clone(), "traces".to_string());
+        let trace_service = TraceService::new(session_ctx.as_ref().clone(), "traces".to_string())
+            .with_max_search_limit(limits.max_search_limit);
 
         Self {
             object_store,
@@ -193,6 +244,7 @@ impl QuerierFlightService {
             session_ctx,
             trace_service,
             iceberg_catalog: None,
+            limits,
         }
     }
 
@@ -203,8 +255,9 @@ impl QuerierFlightService {
     pub async fn new_with_catalog_manager(
         flight_transport: Arc<InMemoryFlightTransport>,
         catalog_manager: Arc<CatalogManager>,
+        limits: QuerierConfig,
     ) -> anyhow::Result<Self> {
-        let session_ctx = Arc::new(SessionContext::new());
+        let session_ctx = Arc::new(session_context_with_limits(&limits));
 
         // Track registered storage URLs to avoid duplicates
         let mut registered_urls: HashSet<String> = HashSet::new();
@@ -272,7 +325,8 @@ impl QuerierFlightService {
         }
 
         // Create trace service for specialized trace queries
-        let trace_service = TraceService::new(session_ctx.as_ref().clone(), "traces".to_string());
+        let trace_service = TraceService::new(session_ctx.as_ref().clone(), "traces".to_string())
+            .with_max_search_limit(limits.max_search_limit);
 
         Ok(Self {
             object_store,
@@ -281,6 +335,7 @@ impl QuerierFlightService {
             session_ctx,
             trace_service,
             iceberg_catalog: Some(iceberg_catalog),
+            limits,
         })
     }
 
@@ -464,6 +519,10 @@ impl QuerierFlightService {
         tracing::info!(sql = %sql, "Executing query");
 
         let df = ctx.sql(sql).await?;
+        // Cap the number of rows a raw SQL query can materialize; the
+        // client controls the SQL, so an unbounded SELECT could otherwise
+        // buffer arbitrarily many rows in memory.
+        let df = df.limit(0, Some(self.limits.max_sql_rows))?;
         let batches = df.collect().await?;
 
         Ok(batches)
@@ -638,7 +697,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::SqlQuery { .. } => "sql",
             };
             let query_start = std::time::Instant::now();
-            let batches_result: Result<Vec<_>, Status> = async {
+            let query_future = async {
                 Ok(match ticket_request {
                     TicketRequest::FindTrace {
                         tenant_slug,
@@ -760,8 +819,17 @@ impl FlightService for QuerierFlightService {
                             .map_err(|e| Status::internal(format!("Query execution failed: {e}")))?
                     }
                 })
-            }
-            .await;
+            };
+            // Bound every query's wall-clock time so a heavy scan cannot
+            // occupy the querier indefinitely.
+            let batches_result: Result<Vec<_>, Status> =
+                match tokio::time::timeout(self.limits.query_timeout, query_future).await {
+                    Ok(result) => result,
+                    Err(_) => Err(Status::deadline_exceeded(format!(
+                        "query exceeded the configured timeout of {:?}",
+                        self.limits.query_timeout
+                    ))),
+                };
 
             let app_metrics = common::self_monitoring::app_metrics();
             let query_attrs = [opentelemetry::KeyValue::new("query_type", query_type)];
@@ -901,6 +969,93 @@ mod tests {
             .execute_query(&service.session_ctx, "SELECT 1 as test_col")
             .await;
         assert!(result.is_ok());
+    }
+
+    async fn make_service_with_limits(limits: QuerierConfig) -> QuerierFlightService {
+        let object_store = Arc::new(InMemory::new());
+
+        let config = Configuration {
+            database: DatabaseConfig {
+                dsn: "sqlite::memory:".to_string(),
+            },
+            discovery: Some(DiscoveryConfig {
+                dsn: "sqlite::memory:".to_string(),
+                heartbeat_interval: Duration::from_secs(5),
+                poll_interval: Duration::from_secs(10),
+                ttl: Duration::from_secs(60),
+            }),
+            ..Default::default()
+        };
+
+        let bootstrap =
+            ServiceBootstrap::new(config, ServiceType::Querier, "localhost:50054".to_string())
+                .await
+                .unwrap();
+
+        let flight_transport = Arc::new(InMemoryFlightTransport::new(bootstrap));
+        QuerierFlightService::new_with_limits(object_store, flight_transport, limits)
+    }
+
+    #[tokio::test]
+    async fn sql_row_cap_bounds_raw_sql_results() {
+        let service = make_service_with_limits(QuerierConfig {
+            max_sql_rows: 10,
+            ..QuerierConfig::default()
+        })
+        .await;
+
+        let batches = service
+            .execute_query(
+                &service.session_ctx,
+                "SELECT * FROM generate_series(1, 1000)",
+            )
+            .await
+            .unwrap();
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 10, "raw SQL results must be capped at max_sql_rows");
+    }
+
+    #[test]
+    fn memory_pool_is_bounded_when_configured() {
+        use datafusion::execution::memory_pool::MemoryConsumer;
+
+        let ctx = session_context_with_limits(&QuerierConfig {
+            memory_limit_mb: Some(1),
+            memory_pool_fraction: 1.0,
+            ..QuerierConfig::default()
+        });
+        let reservation = MemoryConsumer::new("test").register(&ctx.runtime_env().memory_pool);
+        assert!(
+            reservation.try_grow(10 * 1024 * 1024).is_err(),
+            "allocations beyond the configured limit must be refused"
+        );
+
+        // Without a configured limit the pool is unbounded (legacy behavior).
+        let ctx = session_context_with_limits(&QuerierConfig::default());
+        let reservation = MemoryConsumer::new("test").register(&ctx.runtime_env().memory_pool);
+        assert!(reservation.try_grow(10 * 1024 * 1024).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn query_timeout_returns_deadline_exceeded() {
+        let service = make_service_with_limits(QuerierConfig {
+            query_timeout: Duration::from_millis(50),
+            ..QuerierConfig::default()
+        })
+        .await;
+
+        // A cross join over 1e10 combinations cannot finish in 50ms.
+        let ticket = Ticket {
+            ticket: Bytes::from(
+                "SELECT count(*) FROM generate_series(1, 100000000) t1(a) \
+                 CROSS JOIN generate_series(1, 100) t2(b)",
+            ),
+        };
+        let status = match service.do_get(Request::new(ticket)).await {
+            Ok(_) => panic!("query must be aborted by the timeout"),
+            Err(status) => status,
+        };
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
     }
 
     async fn make_service() -> QuerierFlightService {

--- a/src/querier/src/main.rs
+++ b/src/querier/src/main.rs
@@ -129,10 +129,20 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Create Flight query service with CatalogManager for per-tenant catalog support
-    let flight_service =
-        QuerierFlightService::new_with_catalog_manager(flight_transport.clone(), catalog_manager)
-            .await
-            .context("Failed to create querier flight service with CatalogManager")?;
+    tracing::info!(
+        memory_limit_mb = ?config.querier.memory_limit_mb,
+        query_timeout = ?config.querier.query_timeout,
+        max_sql_rows = config.querier.max_sql_rows,
+        max_search_limit = config.querier.max_search_limit,
+        "Querier resource limits"
+    );
+    let flight_service = QuerierFlightService::new_with_catalog_manager(
+        flight_transport.clone(),
+        catalog_manager,
+        config.querier.clone(),
+    )
+    .await
+    .context("Failed to create querier flight service with CatalogManager")?;
     tracing::info!(address = %flight_addr, "Starting Flight query service");
     let flight_auth = config.auth.internal_service_key.clone().map(|key| {
         let authenticator = Arc::new(common::auth::Authenticator::new(

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -48,6 +48,8 @@ pub struct TraceService {
     // skip debug on session_context
     session_context: Arc<SessionContext>,
     traces_path: String,
+    /// Upper bound for the client-supplied `limit` (trace count) on search.
+    max_search_limit: usize,
 }
 
 impl Debug for TraceService {
@@ -55,6 +57,7 @@ impl Debug for TraceService {
         f.debug_struct("TraceService")
             .field("session_context", &"set")
             .field("traces_path", &self.traces_path)
+            .field("max_search_limit", &self.max_search_limit)
             .finish()
     }
 }
@@ -64,6 +67,7 @@ impl Clone for TraceService {
         Self {
             session_context: Arc::clone(&self.session_context),
             traces_path: self.traces_path.clone(),
+            max_search_limit: self.max_search_limit,
         }
     }
 }
@@ -74,7 +78,14 @@ impl TraceService {
         Self {
             session_context: Arc::new(session_context),
             traces_path,
+            max_search_limit: common::config::QuerierConfig::default().max_search_limit,
         }
+    }
+
+    /// Override the clamp applied to client-supplied search limits.
+    pub fn with_max_search_limit(mut self, max_search_limit: usize) -> Self {
+        self.max_search_limit = max_search_limit;
+        self
     }
 
     /// Find a trace by ID with tenant isolation
@@ -423,18 +434,7 @@ impl TraceService {
 
         // Apply limit — we query for more spans than the requested trace count because
         // each trace typically contains many spans. This estimate avoids truncating traces.
-        const SPANS_PER_TRACE_ESTIMATE: usize = 50;
-        let raw_limit = query.limit.unwrap_or(20);
-        let limit: usize = usize::try_from(raw_limit).map_err(|_| {
-            QuerierError::InvalidInput(format!(
-                "Invalid limit '{raw_limit}': must be a non-negative integer"
-            ))
-        })?;
-        let span_limit = limit.checked_mul(SPANS_PER_TRACE_ESTIMATE).ok_or_else(|| {
-            QuerierError::InvalidInput(format!(
-                "Limit {limit} * {SPANS_PER_TRACE_ESTIMATE} overflows"
-            ))
-        })?;
+        let (limit, span_limit) = clamped_limits(query.limit, self.max_search_limit)?;
         df = df.limit(0, Some(span_limit)).map_err(|e| {
             log::error!("Failed to apply limit: {e}");
             QuerierError::QueryFailed(e)
@@ -969,10 +969,68 @@ impl TraceQuerier for TraceService {
     }
 }
 
+/// Each trace typically contains many spans, so search fetches more spans
+/// than the requested trace count to avoid truncating traces.
+const SPANS_PER_TRACE_ESTIMATE: usize = 50;
+
+/// Compute the effective (trace, span-row) limits for a search: validate
+/// the client-supplied trace `limit`, clamp it to `max_search_limit` (the
+/// client fully controls the value, so without a clamp `limit=40000000`
+/// would materialize ~2e9 rows), and scale by the spans-per-trace estimate.
+fn clamped_limits(
+    client_limit: Option<i32>,
+    max_search_limit: usize,
+) -> Result<(usize, usize), QuerierError> {
+    let raw_limit = client_limit.unwrap_or(20);
+    let limit: usize = usize::try_from(raw_limit).map_err(|_| {
+        QuerierError::InvalidInput(format!(
+            "Invalid limit '{raw_limit}': must be a non-negative integer"
+        ))
+    })?;
+    let limit = if limit > max_search_limit {
+        log::warn!(
+            "Clamping client-supplied search limit {limit} to the configured maximum {max_search_limit}"
+        );
+        max_search_limit
+    } else {
+        limit
+    };
+    let span_limit = limit.checked_mul(SPANS_PER_TRACE_ESTIMATE).ok_or_else(|| {
+        QuerierError::InvalidInput(format!(
+            "Limit {limit} * {SPANS_PER_TRACE_ESTIMATE} overflows"
+        ))
+    })?;
+    Ok((limit, span_limit))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use datafusion::prelude::SessionContext;
+
+    #[test]
+    fn span_limit_uses_default_when_absent() {
+        assert_eq!(clamped_limits(None, 1000).unwrap(), (20, 20 * 50));
+    }
+
+    #[test]
+    fn span_limit_respects_client_limit_below_max() {
+        assert_eq!(clamped_limits(Some(100), 1000).unwrap(), (100, 100 * 50));
+    }
+
+    #[test]
+    fn span_limit_clamps_excessive_client_limit() {
+        // The issue's example: limit=40000000 must not produce ~2e9 rows.
+        assert_eq!(
+            clamped_limits(Some(40_000_000), 1000).unwrap(),
+            (1000, 50_000)
+        );
+    }
+
+    #[test]
+    fn span_limit_rejects_negative_limit() {
+        assert!(clamped_limits(Some(-1), 1000).is_err());
+    }
 
     #[tokio::test]
     #[ignore = "Superseded by integration tests in tests-integration/tests/router_tempo_endpoints.rs. \

--- a/src/signaldb-bin/src/main.rs
+++ b/src/signaldb-bin/src/main.rs
@@ -220,6 +220,7 @@ async fn main() -> Result<()> {
     let querier_flight_service = QuerierFlightService::new_with_catalog_manager(
         querier_flight_transport.clone(),
         catalog_manager.clone(),
+        config.querier.clone(),
     )
     .await
     .context("Failed to create querier flight service")?;

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -185,11 +185,14 @@ async fn setup_test_services() -> TestServices {
     }
 
     // Start querier service with per-tenant catalog registration
-    let querier_service =
-        QuerierFlightService::new_with_catalog_manager(flight_transport.clone(), catalog_manager)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create querier service: {}", e))
-            .unwrap();
+    let querier_service = QuerierFlightService::new_with_catalog_manager(
+        flight_transport.clone(),
+        catalog_manager,
+        common::config::QuerierConfig::default(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create querier service: {}", e))
+    .unwrap();
     let querier_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let querier_addr = querier_listener.local_addr().unwrap();
     drop(querier_listener);
@@ -927,11 +930,14 @@ async fn setup_multi_tenant_test_services() -> TestServices {
     }
 
     // Start querier service with per-tenant catalog registration
-    let querier_service =
-        QuerierFlightService::new_with_catalog_manager(flight_transport.clone(), catalog_manager)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create querier service: {}", e))
-            .unwrap();
+    let querier_service = QuerierFlightService::new_with_catalog_manager(
+        flight_transport.clone(),
+        catalog_manager,
+        common::config::QuerierConfig::default(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create querier service: {}", e))
+    .unwrap();
     let querier_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let querier_addr = querier_listener.local_addr().unwrap();
     drop(querier_listener);


### PR DESCRIPTION
## Summary

Closes #550 (epic #563): the querier ran client-controlled queries with no guard rails — unbounded memory pool, no per-query timeout, no cap on raw SQL results, and a client-supplied `/api/search` limit multiplied by 50 with no upper clamp (`limit=40000000` → ~2e9 rows materialized via `collect()`). One query or tenant could OOM the shared process.

### Design

New `[querier]` config section (wired into the dedicated querier and monolithic mode, documented in `signaldb.dist.toml`):

- **`memory_limit_mb` / `memory_pool_fraction`** — the shared `SessionContext` is built on a `RuntimeEnv` with a bounded memory pool (`RuntimeEnvBuilder::with_memory_limit`). Per-request tenant sessions (from #577) share the `RuntimeEnv` through the cloned state's Arcs, so a single pool caps **all** concurrent queries globally. Unset keeps the legacy unbounded behavior with a loud startup warning, mirroring the Flight-auth opt-in pattern.
- **`query_timeout`** (default 60s) — every Flight `do_get` (SQL, find_trace, search) is wrapped in one wall-clock timeout and aborts with `DeadlineExceeded`.
- **`max_sql_rows`** (default 1M) — raw SQL Flight queries get `df.limit(0, Some(n))` applied before `collect()`.
- **`max_search_limit`** (default 1000) — the client-supplied trace-search limit is clamped (with a warning log) before the 50× span-estimate multiplication; negative limits still rejected.

Streaming results over Flight instead of `collect()` is intentionally left out — it's a larger structural change and the memory pool now bounds the damage; noted on the issue's "Expected" list as future work.

### Tests

- Memory pool: allocations beyond the configured limit are refused; default config stays unbounded (legacy).
- Timeout: a 1e10-row cross join under a 50ms timeout returns `DeadlineExceeded` through `do_get`.
- Row cap: `SELECT * FROM generate_series(1,1000)` with `max_sql_rows=10` returns exactly 10 rows.
- Clamp: default/normal/excessive (`40000000` → clamped to 1000)/negative limits.
- Config: `[querier]` TOML round-trip + defaults.
- Full `cargo clippy --workspace --all-targets --all-features` clean, querier suite 53/53, config suite 34/34, `router_tempo_endpoints` 9/9.

Closes #550
Part of #563