### PR TITLE
feat(compactor): enforce retention for real — partition drops and snapshot expiration

### DIFF
--- a/src/compactor/src/iceberg/partition.rs
+++ b/src/compactor/src/iceberg/partition.rs
@@ -193,57 +193,6 @@ impl PartitionManager {
         Ok(partitions)
     }
 
-    /// Generate SQL to drop a partition
-    ///
-    /// Returns the ALTER TABLE statement to drop the specified partition.
-    ///
-    /// # Arguments
-    /// * `table_name` - Fully qualified table name (e.g., "tenant.dataset.traces")
-    /// * `hour_value` - Partition hour value (e.g., "2024-01-15-10")
-    pub fn generate_partition_drop_sql(
-        &self,
-        table_name: &str,
-        hour_value: &str,
-    ) -> Result<String> {
-        // Validate the hour format first
-        self.validate_partition_hour(hour_value)?;
-
-        // SAFETY: Validate table_name to prevent SQL injection
-        // Only allow alphanumeric characters, underscores, and dots for qualified names
-        if !table_name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
-        {
-            return Err(anyhow::anyhow!(
-                "Invalid table name '{}': must contain only alphanumeric characters, underscores, and dots",
-                table_name
-            ));
-        }
-
-        // Generate the DROP PARTITION statement
-        // Note: Syntax may vary by query engine (DataFusion, Spark, etc.)
-        let sql = format!(
-            "ALTER TABLE {} DROP PARTITION (hour = '{}')",
-            table_name, hour_value
-        );
-
-        Ok(sql)
-    }
-
-    /// Generate SQL to drop multiple partitions
-    ///
-    /// Returns a vector of ALTER TABLE statements, one per partition.
-    pub fn generate_partition_drop_sql_batch(
-        &self,
-        table_name: &str,
-        hour_values: &[String],
-    ) -> Result<Vec<String>> {
-        hour_values
-            .iter()
-            .map(|hour| self.generate_partition_drop_sql(table_name, hour))
-            .collect()
-    }
-
     /// Filter partitions older than cutoff
     pub fn filter_partitions_older_than(
         &self,
@@ -311,40 +260,6 @@ mod tests {
 
         assert!(manager.validate_partition_hour("2024-01-15-10").is_ok());
         assert!(manager.validate_partition_hour("2024-13-15-10").is_err());
-    }
-
-    #[test]
-    fn test_generate_partition_drop_sql() {
-        let manager = PartitionManager::new();
-
-        let sql = manager
-            .generate_partition_drop_sql("tenant.dataset.traces", "2024-01-15-10")
-            .unwrap();
-
-        assert!(sql.contains("ALTER TABLE"));
-        assert!(sql.contains("DROP PARTITION"));
-        assert!(sql.contains("hour = '2024-01-15-10'"));
-    }
-
-    #[test]
-    fn test_generate_partition_drop_sql_batch() {
-        let manager = PartitionManager::new();
-
-        let hours = vec![
-            "2024-01-15-10".to_string(),
-            "2024-01-15-11".to_string(),
-            "2024-01-15-12".to_string(),
-        ];
-
-        let sqls = manager
-            .generate_partition_drop_sql_batch("tenant.dataset.traces", &hours)
-            .unwrap();
-
-        assert_eq!(sqls.len(), 3);
-        for sql in sqls {
-            assert!(sql.contains("ALTER TABLE"));
-            assert!(sql.contains("DROP PARTITION"));
-        }
     }
 
     #[test]

--- a/src/compactor/src/retention/enforcer.rs
+++ b/src/compactor/src/retention/enforcer.rs
@@ -9,17 +9,25 @@
 //! - Grace period prevents premature deletion
 //! - Dry-run mode for testing without actual deletion
 //! - Comprehensive logging and metrics for auditing
-//! - Transactional partition drops via Iceberg
+//! - Transactional partition drops via Iceberg: one CAS-guarded and
+//!   post-verified `replace` commit removes every data file in the
+//!   expired partitions (the same model the compaction executor uses);
+//!   physical file deletion stays with the orphan cleaner
+//! - Snapshot expiration is metadata-only (`RemoveSnapshots`); the
+//!   orphan cleaner remains the sole deletion authority
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use datafusion::prelude::SessionContext;
+use futures::StreamExt;
+use iceberg_rust::spec::manifest::Status;
+use std::collections::HashSet;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use common::CatalogManager;
 
-use crate::iceberg::{ManifestReader, PartitionInfo, PartitionManager, SnapshotManager};
+use crate::commit::{IcebergCommitter, is_conflict_error};
+use crate::iceberg::{ManifestReader, PartitionManager, SnapshotManager};
 use crate::retention::config::RetentionConfig;
 use crate::retention::policy::RetentionPolicyResolver;
 
@@ -241,9 +249,10 @@ impl RetentionEnforcer {
             .await
             .context("Failed to drop expired partitions")?;
 
-        // Step 2: Expire old snapshots (keep N most recent)
+        // Step 2: Expire old snapshots (keep N most recent). Loads the
+        // table fresh internally — step 1 may have advanced the snapshot.
         let snapshots_expired = self
-            .expire_old_snapshots(tenant_id, dataset_id, table_name, &table)
+            .expire_old_snapshots(tenant_id, dataset_id, table_name)
             .await
             .context("Failed to expire old snapshots")?;
 
@@ -367,98 +376,179 @@ impl RetentionEnforcer {
             ));
         }
 
-        // Actually drop partitions
-        let ctx = self
-            .create_datafusion_context(tenant_id, dataset_id)
-            .await?;
+        // Actually drop partitions: one replace commit removes every data
+        // file in the expired partitions. Retried on CAS conflicts with
+        // concurrent compaction/ingest commits.
+        let expired_hours: HashSet<String> = expired_partitions
+            .iter()
+            .filter_map(|p| p.partition_values.get("timestamp_hour").cloned())
+            .collect();
 
-        let mut dropped_count = 0;
-        let mut bytes_reclaimed = 0u64;
-
-        for partition in &expired_partitions {
+        const MAX_ATTEMPTS: usize = 3;
+        let mut attempt = 0;
+        let (dropped_partitions, dropped_files, bytes_reclaimed) = loop {
+            attempt += 1;
             match self
-                .drop_partition(&ctx, table_name, partition)
+                .try_drop_partitions_once(tenant_id, dataset_id, table_name, &expired_hours)
                 .await
-                .with_context(|| {
-                    format!("Failed to drop partition {:?}", partition.get_hour_value())
-                }) {
-                Ok(_) => {
-                    info!(
-                        tenant_id = %tenant_id,
-                        dataset_id = %dataset_id,
-                        table_name = %table_name,
-                        partition_hour = ?partition.get_hour_value(),
-                        file_count = partition.file_count,
-                        size_bytes = partition.total_size_bytes,
-                        "Partition dropped successfully"
-                    );
-
-                    dropped_count += 1;
-
-                    // Only accumulate bytes after successful drop
-                    if let Some(size) = partition.total_size_bytes {
-                        bytes_reclaimed += size;
-                    }
-
-                    self.metrics.record_partitions_dropped(1);
-                }
-                Err(e) => {
+            {
+                Ok(result) => break result,
+                Err(e) if is_conflict_error(&e) && attempt < MAX_ATTEMPTS => {
                     warn!(
                         tenant_id = %tenant_id,
                         dataset_id = %dataset_id,
                         table_name = %table_name,
-                        partition_hour = ?partition.get_hour_value(),
+                        attempt,
                         error = %e,
-                        "Failed to drop partition"
+                        "Partition drop hit a snapshot conflict; retrying against fresh metadata"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(200 * attempt as u64))
+                        .await;
+                }
+                Err(e) => return Err(e).context("Failed to commit partition drop"),
+            }
+        };
+
+        if dropped_partitions > 0 {
+            info!(
+                tenant_id = %tenant_id,
+                dataset_id = %dataset_id,
+                table_name = %table_name,
+                dropped_partitions,
+                dropped_files,
+                bytes_reclaimed,
+                "Dropped expired partitions"
+            );
+            self.metrics.record_partitions_dropped(dropped_partitions);
+        }
+
+        Ok((all_partitions.len(), dropped_partitions, bytes_reclaimed))
+    }
+
+    /// One attempt at dropping the expired partitions: load the table
+    /// fresh, split the live data files into kept vs expired by their
+    /// `timestamp_hour=<N>` partition value, and commit a CAS-guarded,
+    /// post-verified `replace` with only the kept files. Physical file
+    /// deletion is left to the orphan cleaner.
+    ///
+    /// Returns (partitions_dropped, files_dropped, bytes_reclaimed).
+    async fn try_drop_partitions_once(
+        &self,
+        tenant_id: &str,
+        dataset_id: &str,
+        table_name: &str,
+        expired_hours: &HashSet<String>,
+    ) -> Result<(usize, usize, u64)> {
+        let table_identifier = self
+            .catalog_manager
+            .build_table_identifier(tenant_id, dataset_id, table_name);
+        let tabular = self
+            .catalog_manager
+            .catalog()
+            .load_tabular(&table_identifier)
+            .await
+            .with_context(|| format!("Failed to load table {table_name} for partition drop"))?;
+        let table = match tabular {
+            iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
+            _ => anyhow::bail!("Expected table but got view for {table_name}"),
+        };
+        let original_snapshot_id = table.metadata().current_snapshot_id;
+
+        let manifests = table
+            .manifests(None, None)
+            .await
+            .context("Failed to read manifest list for partition drop")?;
+        if manifests.is_empty() {
+            return Ok((0, 0, 0));
+        }
+        let file_iter = table
+            .datafiles(&manifests, None, (None, None))
+            .await
+            .context("Failed to read data files for partition drop")?;
+
+        let mut kept_files = Vec::new();
+        let mut dropped_hours: HashSet<String> = HashSet::new();
+        let mut dropped_files = 0usize;
+        let mut dropped_bytes = 0u64;
+
+        let mut file_iter = std::pin::pin!(file_iter);
+        while let Some(result) = file_iter.next().await {
+            let (_, entry) = result.context("Failed to read manifest entry")?;
+            if *entry.status() == Status::Deleted {
+                continue;
+            }
+            let data_file = entry.data_file();
+            let partition_hour = data_file
+                .file_path()
+                .split('/')
+                .find(|component| component.starts_with("timestamp_hour="))
+                .and_then(|component| component.strip_prefix("timestamp_hour="));
+
+            match partition_hour {
+                Some(hour) if expired_hours.contains(hour) => {
+                    dropped_hours.insert(hour.to_string());
+                    dropped_files += 1;
+                    dropped_bytes += *data_file.file_size_in_bytes() as u64;
+                    debug!(
+                        file_path = %data_file.file_path(),
+                        partition_hour = %hour,
+                        "Dropping expired data file"
                     );
                 }
+                _ => kept_files.push(data_file.clone()),
             }
         }
 
-        Ok((all_partitions.len(), dropped_count, bytes_reclaimed))
+        if dropped_files == 0 {
+            // Nothing left to drop (e.g. a concurrent compaction already
+            // rewrote the expired partitions away).
+            return Ok((0, 0, 0));
+        }
+
+        let committer = IcebergCommitter::new(self.catalog_manager.clone());
+        committer
+            .commit_compaction(
+                tenant_id,
+                dataset_id,
+                table_name,
+                original_snapshot_id,
+                kept_files,
+            )
+            .await
+            .context("Failed to commit partition-drop replace snapshot")?;
+
+        Ok((dropped_hours.len(), dropped_files, dropped_bytes))
     }
 
-    /// Drop a single partition using DataFusion
-    async fn drop_partition(
-        &self,
-        ctx: &SessionContext,
-        table_name: &str,
-        partition: &PartitionInfo,
-    ) -> Result<()> {
-        let hour_value = partition
-            .get_hour_value()
-            .ok_or_else(|| anyhow::anyhow!("Partition has no hour value"))?;
-
-        let sql = self
-            .partition_manager
-            .generate_partition_drop_sql(table_name, hour_value)?;
-
-        info!(
-            table_name = %table_name,
-            partition_hour = ?partition.get_hour_value(),
-            sql = %sql,
-            "Executing partition drop"
-        );
-
-        ctx.sql(&sql)
-            .await
-            .context("Failed to execute DROP PARTITION SQL")?
-            .collect()
-            .await
-            .context("Failed to collect DROP PARTITION results")?;
-
-        Ok(())
-    }
-
-    /// Expire old snapshots, keeping N most recent
+    /// Expire old snapshots, keeping N most recent.
+    ///
+    /// Loads the table fresh (the partition-drop step may have advanced
+    /// the snapshot) and commits a metadata-only `RemoveSnapshots` update.
+    /// Data files referenced only by expired snapshots become orphans and
+    /// are reclaimed by the orphan cleaner after its grace period — that
+    /// grace window is also what protects in-flight queries, since
+    /// queriers do not pin snapshots.
     async fn expire_old_snapshots(
         &self,
         tenant_id: &str,
         dataset_id: &str,
         table_name: &str,
-        table: &iceberg_rust::table::Table,
     ) -> Result<usize> {
         let snapshots_to_keep = self.config.snapshots_to_keep.unwrap_or(10);
+
+        let table_identifier = self
+            .catalog_manager
+            .build_table_identifier(tenant_id, dataset_id, table_name);
+        let tabular = self
+            .catalog_manager
+            .catalog()
+            .load_tabular(&table_identifier)
+            .await
+            .with_context(|| format!("Failed to load table {table_name} for snapshot expiry"))?;
+        let mut table = match tabular {
+            iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
+            _ => anyhow::bail!("Expected table but got view for {table_name}"),
+        };
 
         info!(
             tenant_id = %tenant_id,
@@ -470,7 +560,7 @@ impl RetentionEnforcer {
 
         let snapshots_to_expire = self
             .snapshot_manager
-            .get_snapshots_to_expire(table, snapshots_to_keep)
+            .get_snapshots_to_expire(&table, snapshots_to_keep)
             .context("Failed to get snapshots to expire")?;
 
         if snapshots_to_expire.is_empty() {
@@ -516,54 +606,67 @@ impl RetentionEnforcer {
             return Ok(snapshots_to_expire.len());
         }
 
-        // In a real implementation, we would call Iceberg's expire_snapshots API here
-        // For now, we log a warning that this is not yet implemented
-        warn!(
+        // Metadata-only expiration: a RemoveSnapshots update through the
+        // catalog CAS. retain_ref_snapshots keeps branch/tag-referenced
+        // snapshots; the current snapshot is never expired by iceberg-rust.
+        // clean_orphan_files is deliberately false — physical reclamation
+        // is the orphan cleaner's job (and the flag is a no-op in this
+        // iceberg-rust revision anyway).
+        let expired_count = snapshots_to_expire.len();
+        table
+            .new_transaction(None)
+            .expire_snapshots(None, Some(snapshots_to_keep), false, true, false)
+            .commit()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to commit snapshot expiration: {e}"))?;
+
+        info!(
             tenant_id = %tenant_id,
             dataset_id = %dataset_id,
             table_name = %table_name,
-            "Snapshot expiration not yet implemented in iceberg-rust"
+            snapshots_expired = expired_count,
+            snapshots_to_keep,
+            "Expired old snapshots"
         );
+        self.metrics.record_snapshots_expired(expired_count);
 
-        // Do not record metrics for unimplemented functionality
-        // self.metrics.record_snapshots_expired(...) will be called once implemented
-
-        Ok(0) // Return 0 until actually implemented
+        Ok(expired_count)
     }
 
-    /// Get all tables for a tenant/dataset with their signal types
+    /// Get all signal tables for a tenant/dataset by listing the catalog
+    /// namespace, so retention only touches tables that actually exist.
     async fn get_tables(
         &self,
-        _tenant_id: &str,
-        _dataset_id: &str,
+        tenant_id: &str,
+        dataset_id: &str,
     ) -> Result<Vec<(String, SignalType)>> {
-        // In a real implementation, we would list tables from the catalog
-        // For now, we return the standard signal tables
-        let tables = vec![
-            ("traces".to_string(), SignalType::Traces),
-            ("logs".to_string(), SignalType::Logs),
-            ("metrics_gauge".to_string(), SignalType::Metrics),
-            ("metrics_counter".to_string(), SignalType::Metrics),
-            ("metrics_histogram".to_string(), SignalType::Metrics),
-        ];
+        let namespace = self
+            .catalog_manager
+            .build_namespace(tenant_id, dataset_id)
+            .context("Failed to build namespace for table listing")?;
+        let identifiers = self
+            .catalog_manager
+            .catalog()
+            .list_tabulars(&namespace)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to list tables in {namespace:?}: {e}"))?;
+
+        let mut tables: Vec<(String, SignalType)> = identifiers
+            .iter()
+            .filter_map(|identifier| {
+                let name = identifier.name();
+                let signal_type = match name {
+                    "traces" => SignalType::Traces,
+                    "logs" => SignalType::Logs,
+                    n if n.starts_with("metrics") => SignalType::Metrics,
+                    _ => return None,
+                };
+                Some((name.to_string(), signal_type))
+            })
+            .collect();
+        tables.sort_by(|a, b| a.0.cmp(&b.0));
 
         Ok(tables)
-    }
-
-    /// Create a DataFusion context for executing SQL
-    async fn create_datafusion_context(
-        &self,
-        _tenant_id: &str,
-        _dataset_id: &str,
-    ) -> Result<SessionContext> {
-        // Create a new DataFusion session context
-        // In a real implementation, we would configure it with the catalog
-        let _ctx = SessionContext::new();
-
-        // TODO: Register tables with the catalog
-        anyhow::bail!(
-            "SQL execution not available until tables are registered in DataFusion context"
-        )
     }
 
     /// Get the policy resolver for testing
@@ -617,19 +720,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_tables() {
+    async fn get_tables_lists_only_existing_tables() {
         let config = create_test_config();
         let catalog_manager = Arc::new(CatalogManager::new_in_memory().await.unwrap());
         let metrics = RetentionMetrics::new_mock();
 
-        let enforcer = RetentionEnforcer::new(catalog_manager, config, metrics).unwrap();
+        let enforcer = RetentionEnforcer::new(catalog_manager.clone(), config, metrics).unwrap();
 
+        // Nothing in the catalog: no phantom tables to enforce on.
         let tables = enforcer
             .get_tables("test_tenant", "test_dataset")
             .await
             .unwrap();
-        assert_eq!(tables.len(), 5);
-        assert!(tables.iter().any(|(name, _)| name == "traces"));
-        assert!(tables.iter().any(|(name, _)| name == "logs"));
+        assert!(
+            tables.is_empty(),
+            "Empty catalog must yield no tables, got {tables:?}"
+        );
+
+        // A created table shows up with its signal type.
+        catalog_manager
+            .ensure_table("test_tenant", "test_dataset", "traces")
+            .await
+            .unwrap();
+        let tables = enforcer
+            .get_tables("test_tenant", "test_dataset")
+            .await
+            .unwrap();
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].0, "traces");
+        assert_eq!(tables[0].1, SignalType::Traces);
     }
 }

--- a/tests-integration/tests/compactor/partition_drop.rs
+++ b/tests-integration/tests/compactor/partition_drop.rs
@@ -83,22 +83,25 @@ async fn test_partition_drop_removes_old_partitions() -> Result<()> {
         result.total_partitions_dropped
     );
 
-    // Enforcement ran to completion (enforce_retention returned Ok).
-    // Individual table errors are expected in non-dry-run mode because:
-    //   - traces: create_datafusion_context is a placeholder that always bails
-    //   - logs/metrics_*: only the traces table was created in this test
-    // The enforcement cycle iterated all tables and recorded per-table outcomes.
-    log::info!(
-        "Enforcement completed: processed={}, errors={}: {:?}",
-        result.tables_processed,
-        result.errors.len(),
+    // Real enforcement: only tables that exist are processed, no errors,
+    // and the expired partitions are actually dropped.
+    assert!(
+        result.errors.is_empty(),
+        "Enforcement must not error: {:?}",
         result.errors
     );
+    assert_eq!(
+        result.tables_processed, 1,
+        "Only the traces table exists in this test"
+    );
     assert!(
-        result.tables_processed + result.errors.len() >= 5,
-        "Expected all 5 tables to be attempted (processed + errors), got processed={} errors={}",
-        result.tables_processed,
-        result.errors.len()
+        result.total_partitions_dropped >= 1,
+        "Expected at least one expired partition to be dropped, got {}",
+        result.total_partitions_dropped
+    );
+    assert!(
+        result.total_bytes_reclaimed > 0,
+        "Dropped partitions must account reclaimed bytes"
     );
 
     // Calculate expected partitions to drop
@@ -157,6 +160,24 @@ async fn test_partition_drop_removes_old_partitions() -> Result<()> {
             .flatten()
             .is_some(),
         "Table should have a current snapshot after enforcement"
+    );
+
+    // The expired partitions must be gone from the live snapshot.
+    let partition_manager = compactor::iceberg::PartitionManager::new();
+    let partitions_after = partition_manager.list_partitions(&table_after).await?;
+    let cutoff_dt = chrono::DateTime::<chrono::Utc>::from_timestamp(cutoff_timestamp / 1000, 0)
+        .expect("valid cutoff");
+    let still_expired: Vec<_> = partitions_after
+        .iter()
+        .filter(|p| p.is_older_than(&cutoff_dt))
+        .collect();
+    assert!(
+        still_expired.is_empty(),
+        "No expired partitions may survive enforcement: {still_expired:?}"
+    );
+    assert!(
+        !partitions_after.is_empty(),
+        "Recent partitions must survive enforcement"
     );
 
     log::info!(
@@ -230,6 +251,15 @@ async fn test_partition_drop_respects_grace_period() -> Result<()> {
     log::info!(
         "With grace period - partitions dropped: {}",
         result.total_partitions_dropped
+    );
+    assert!(
+        result.errors.is_empty(),
+        "Enforcement must not error: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.total_partitions_dropped, 0,
+        "Grace period must protect the boundary partition from being dropped"
     );
 
     // The partition at 3h 1min ago should be protected by the grace period
@@ -328,6 +358,19 @@ async fn test_partition_drop_handles_mixed_signal_types() -> Result<()> {
         "Mixed signal types - tables processed: {}, total partitions dropped: {}",
         result.tables_processed,
         result.total_partitions_dropped
+    );
+    assert!(
+        result.errors.is_empty(),
+        "Enforcement must not error: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.tables_processed, 3,
+        "traces, logs, and metrics_gauge exist in this test"
+    );
+    assert!(
+        result.total_partitions_dropped >= 1,
+        "Expired partitions must actually be dropped across signal types"
     );
 
     // Assert: Verify correct partitions would be dropped per signal type
@@ -473,9 +516,15 @@ async fn test_partition_drop_preserves_partition_metadata() -> Result<()> {
         snapshot_after.as_ref().map(|s| s.snapshot_id())
     );
 
-    // Note: In actual implementation with partition drops, a new snapshot would be created
-    // For now, we verify the table metadata is still accessible
+    // A real partition drop commits a new replace snapshot.
     assert!(!table_after.metadata().snapshots.is_empty());
+    if result.total_partitions_dropped > 0 {
+        assert_ne!(
+            snapshot_before.as_ref().map(|s| s.snapshot_id()),
+            snapshot_after.as_ref().map(|s| s.snapshot_id()),
+            "Dropping partitions must advance the snapshot"
+        );
+    }
 
     // Verify table is still readable
     let metadata = table_after.metadata();

--- a/tests-integration/tests/compactor/snapshot_expiration.rs
+++ b/tests-integration/tests/compactor/snapshot_expiration.rs
@@ -373,3 +373,114 @@ async fn test_snapshot_expiration_preserves_current_snapshot() -> Result<()> {
 
     Ok(())
 }
+
+/// Test: enforce_retention actually expires snapshots (issue #539)
+///
+/// Runs the real (non-dry-run) enforcement path and verifies snapshots
+/// are removed from table metadata, the current snapshot survives, and
+/// the table remains readable.
+#[tokio::test]
+async fn test_enforce_retention_expires_snapshots_for_real() -> Result<()> {
+    use compactor::retention::config::RetentionConfig;
+    use compactor::retention::enforcer::RetentionEnforcer;
+    use compactor::retention::metrics::RetentionMetrics;
+    use std::collections::HashMap;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let ctx = RetentionTestContext::new_in_memory().await?;
+    let tenant_id = "test-tenant";
+    let dataset_id = "test-dataset";
+    let table_name = "traces";
+    let mut writer = ctx.create_table(tenant_id, dataset_id, table_name).await?;
+
+    // 10 writes -> 10 snapshots, all with recent data (nothing to drop
+    // partition-wise: retention window comfortably covers the data).
+    let config = DataGeneratorConfig {
+        partition_count: 1,
+        files_per_partition: 1,
+        rows_per_file: 10,
+        base_timestamp: chrono::Utc::now().timestamp_millis() - (60 * 60 * 1000),
+        partition_granularity: PartitionGranularity::Hour,
+    };
+    for _ in 0..10 {
+        generators::generate_traces(&mut writer, &config).await?;
+    }
+
+    let table_identifier = ctx
+        .catalog_manager()
+        .build_table_identifier(tenant_id, dataset_id, table_name);
+    let load_table = || async {
+        let tabular = ctx
+            .catalog_manager()
+            .catalog()
+            .load_tabular(&table_identifier)
+            .await
+            .context("Failed to load table")?;
+        match tabular {
+            Tabular::Table(t) => Ok(t),
+            _ => anyhow::bail!("Expected table but got view"),
+        }
+    };
+
+    let snapshot_manager = SnapshotManager::new();
+    let table_before = load_table().await?;
+    assert_eq!(snapshot_manager.list_snapshots(&table_before)?.len(), 10);
+    let current_before = table_before.metadata().current_snapshot_id;
+
+    let retention_config = RetentionConfig {
+        enabled: true,
+        retention_check_interval: std::time::Duration::from_secs(3600),
+        traces: std::time::Duration::from_secs(30 * 24 * 3600),
+        logs: std::time::Duration::from_secs(30 * 24 * 3600),
+        metrics: std::time::Duration::from_secs(30 * 24 * 3600),
+        tenant_overrides: HashMap::new(),
+        grace_period: std::time::Duration::from_secs(0),
+        timezone: "UTC".to_string(),
+        dry_run: false,
+        snapshots_to_keep: Some(3),
+    };
+    let enforcer = RetentionEnforcer::new(
+        ctx.catalog_manager().clone(),
+        retention_config,
+        RetentionMetrics::new(),
+    )?;
+
+    let result = enforcer.enforce_retention(tenant_id, dataset_id).await?;
+    assert!(
+        result.errors.is_empty(),
+        "Enforcement must not error: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.total_snapshots_expired, 7,
+        "10 snapshots with keep=3 must expire 7"
+    );
+    assert_eq!(
+        result.total_partitions_dropped, 0,
+        "Recent data must not be partition-dropped"
+    );
+
+    // Reload: metadata now holds only the 3 kept snapshots, current survives.
+    let table_after = load_table().await?;
+    let snapshots_after = snapshot_manager.list_snapshots(&table_after)?;
+    assert_eq!(
+        snapshots_after.len(),
+        3,
+        "Only snapshots_to_keep snapshots may remain after expiration"
+    );
+    assert_eq!(
+        table_after.metadata().current_snapshot_id,
+        current_before,
+        "The current snapshot must survive expiration"
+    );
+
+    // The table is still readable via its current snapshot's manifests.
+    let manifests = table_after.manifests(None, None).await?;
+    assert!(
+        !manifests.is_empty(),
+        "Current snapshot must remain readable after expiration"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #558 and #539 (epic #563): `RetentionEnforcer` was non-functional outside dry-run — the partition-drop path always failed (`create_datafusion_context` unconditionally bailed, and the `ALTER TABLE … DROP PARTITION` SQL it would have run isn't supported by this DataFusion/Iceberg stack at all), and snapshot expiration logged "not yet implemented" and returned `Ok(0)`. Retention/TTL was effectively unenforced; storage grew unbounded while the config suggested otherwise.

### Design

- **Partition drops** commit one CAS-guarded, post-verified `replace` snapshot that keeps only the data files outside the expired `timestamp_hour` partitions — the same optimistic-concurrency model the compaction executor already uses (reusing `IcebergCommitter::commit_compaction`, including the post-commit reload that catches the SQL catalog's silent CAS losses), retried with backoff on snapshot conflicts with concurrent compaction/ingest. No Parquet rewrite is needed for whole-partition removal; **physical file deletion stays with the orphan cleaner**, consistent with the compaction model.
- **Snapshot expiration** commits a metadata-only `RemoveSnapshots` update via iceberg-rust's `expire_snapshots` (`retain_last = snapshots_to_keep`; ref-referenced and current snapshots preserved; `clean_orphan_files=false` — it's a no-op in this revision and the orphan cleaner is the deletion authority). Loads the table fresh since the partition-drop step may have advanced the snapshot.
- **Reader safety**: files referenced only by expired snapshots become orphans reclaimed after the orphan cleaner's grace period — that window is what protects in-flight queries, since queriers don't pin snapshots (noted in-code; a real reader lease is future work).
- **`get_tables` now lists the catalog namespace** instead of assuming a hardcoded five-table set, so retention no longer produces spurious per-table errors for tables that don't exist.
- Removed the dead DataFusion-SQL drop path and its SQL generators (which also had a latent partition-key mismatch: `hour='ISO'` vs the actual `timestamp_hour=<epoch-hours>` transform).

### Not in this PR

Per-table leasing for retention across multiple compactor instances (retention currently runs unleased, amplifying CAS retries under multi-instance deployments) — worth a follow-up alongside #560's lease renewal work.

### Tests

Integration tests now assert **real** enforcement instead of tolerating failure:
- `partition_drop`: expired partitions are gone from the live snapshot after enforcement, bytes accounted, snapshot advanced, grace period still protects boundary data, mixed signal types processed with zero errors, dry-run still commits nothing (5/5).
- `snapshot_expiration`: new end-to-end test — 10 snapshots with `keep=3` expires exactly 7 from metadata, the current snapshot survives, table stays readable (5/5).
- Compactor unit suite 92/92 (get_tables test now covers empty-catalog and real-table listing); `retention_cutoff`, `retention_failure_scenarios`, `orphan_cleanup`, `basic_compaction` all green; workspace clippy clean.

Closes #558
Closes #539
Part of #563