### PR TITLE
fix(config): refuse in-memory discovery/catalog in standalone services

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -41,6 +41,8 @@ services:
     environment:
       SIGNALDB_DATABASE_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
       SIGNALDB_DISCOVERY_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
+      SIGNALDB__SCHEMA__CATALOG_TYPE: "sql"
+      SIGNALDB__SCHEMA__CATALOG_URI: "postgres://signaldb:password@postgres:5432/signaldb"
       WRITER_FLIGHT_ADDR: "0.0.0.0:50051"
       WRITER_ADVERTISE_ADDR: "signaldb-writer:50051"
       # WAL persistence configuration - mounted to persistent volume
@@ -82,6 +84,8 @@ services:
     environment:
       SIGNALDB_DATABASE_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
       SIGNALDB_DISCOVERY_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
+      SIGNALDB__SCHEMA__CATALOG_TYPE: "sql"
+      SIGNALDB__SCHEMA__CATALOG_URI: "postgres://signaldb:password@postgres:5432/signaldb"
       ACCEPTOR_GRPC_ADDR: "0.0.0.0:4317"
       ACCEPTOR_HTTP_ADDR: "0.0.0.0:4318"
       # WAL persistence for acceptor durability
@@ -109,6 +113,8 @@ services:
     environment:
       SIGNALDB_DATABASE_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
       SIGNALDB_DISCOVERY_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
+      SIGNALDB__SCHEMA__CATALOG_TYPE: "sql"
+      SIGNALDB__SCHEMA__CATALOG_URI: "postgres://signaldb:password@postgres:5432/signaldb"
       QUERIER_FLIGHT_ADDR: "0.0.0.0:50054"
       QUERIER_ADVERTISE_ADDR: "signaldb-querier:50054"
       # S3/MinIO storage configuration
@@ -135,6 +141,8 @@ services:
     environment:
       SIGNALDB_DATABASE_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
       SIGNALDB_DISCOVERY_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
+      SIGNALDB__SCHEMA__CATALOG_TYPE: "sql"
+      SIGNALDB__SCHEMA__CATALOG_URI: "postgres://signaldb:password@postgres:5432/signaldb"
       ROUTER_FLIGHT_ADDR: "0.0.0.0:50053"
       ROUTER_HTTP_ADDR: "0.0.0.0:3001"
     ports:
@@ -153,6 +161,8 @@ services:
     environment:
       SIGNALDB_DATABASE_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
       SIGNALDB_DISCOVERY_DSN: "postgres://signaldb:password@postgres:5432/signaldb"
+      SIGNALDB__SCHEMA__CATALOG_TYPE: "sql"
+      SIGNALDB__SCHEMA__CATALOG_URI: "postgres://signaldb:password@postgres:5432/signaldb"
       # Compactor config uses double-underscore separator for fields with underscores
       SIGNALDB__COMPACTOR__ENABLED: "true"
       SIGNALDB__COMPACTOR__TICK_INTERVAL: "5m"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,6 +61,8 @@ services:
     environment:
       - SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
       - SIGNALDB_DISCOVERY_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
+      - SIGNALDB__SCHEMA__CATALOG_TYPE=sql
+      - SIGNALDB__SCHEMA__CATALOG_URI=postgres://postgres:postgres@postgres-15:5432/signaldb_test
     ports:
       - "4317:4317"
       - "4318:4318"
@@ -80,6 +82,8 @@ services:
     environment:
       - SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
       - SIGNALDB_DISCOVERY_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
+      - SIGNALDB__SCHEMA__CATALOG_TYPE=sql
+      - SIGNALDB__SCHEMA__CATALOG_URI=postgres://postgres:postgres@postgres-15:5432/signaldb_test
     ports:
       - "50053:50053"
       - "3000:3000"
@@ -99,6 +103,8 @@ services:
     environment:
       - SIGNALDB_DATABASE_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
       - SIGNALDB_DISCOVERY_DSN=postgres://postgres:postgres@postgres-15:5432/signaldb_test
+      - SIGNALDB__SCHEMA__CATALOG_TYPE=sql
+      - SIGNALDB__SCHEMA__CATALOG_URI=postgres://postgres:postgres@postgres-15:5432/signaldb_test
     ports:
       - "50051:50051"
     volumes:

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -112,8 +112,14 @@ dsn = "file:///.data/storage"
 
 [schema]
 # Iceberg catalog configuration for table metadata
+#
+# IMPORTANT: the in-memory default only works in monolithic mode (the
+# single `signaldb` binary). Standalone services REFUSE to start with an
+# in-memory catalog — every process would get its own private catalog.
+# Distributed deployments must point catalog_uri at a shared database:
+# PostgreSQL for production, a shared sqlite:// file for single-host dev.
 catalog_type = "sql"                   # sql (recommended) or memory
-catalog_uri = "sqlite::memory:"        # In-memory SQLite catalog
+catalog_uri = "sqlite::memory:"        # In-memory SQLite catalog (monolithic only)
 # catalog_uri = "sqlite://.data/catalog.db"  # Persistent SQLite catalog
 # catalog_uri = "postgres://user:password@localhost:5432/iceberg"  # Production PostgreSQL
 
@@ -156,7 +162,12 @@ metrics_enabled = true
 
 [discovery]
 # Service discovery configuration
-dsn = "sqlite::memory:"               # In-memory service registry
+#
+# IMPORTANT: the in-memory default only works in monolithic mode.
+# Standalone services REFUSE to start with an in-memory registry —
+# services could never discover each other. Use PostgreSQL for
+# production; a shared sqlite:// file works for single-host dev.
+dsn = "sqlite::memory:"               # In-memory service registry (monolithic only)
 heartbeat_interval = "30s"
 poll_interval = "60s"
 ttl = "300s"

--- a/src/acceptor/src/main.rs
+++ b/src/acceptor/src/main.rs
@@ -63,6 +63,9 @@ async fn main() -> Result<()> {
 
     // Load application configuration
     let config = utils::load_config(cli.common.config.as_ref())?;
+    // Standalone services need shared discovery/catalog backends; the
+    // in-memory defaults only make sense in monolithic mode (issue #554).
+    config.validate_for_distributed("acceptor")?;
 
     // Handle common commands that don't require starting the service
     let command = cli.command.unwrap_or_default();

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -839,6 +839,73 @@ impl Configuration {
         Ok(config)
     }
 
+    /// Validate this configuration for a standalone (distributed) service.
+    ///
+    /// The defaults use `sqlite::memory:` for service discovery and the
+    /// Iceberg catalog, which is coherent only in monolithic mode: each
+    /// standalone binary would get its own private in-memory registry and
+    /// catalog, so services could never discover each other or see each
+    /// other's tables. Fail fast instead of starting a silently broken
+    /// deployment (issue #554).
+    ///
+    /// File-based SQLite is allowed with a prominent warning: it works for
+    /// single-host development (all services sharing one file, as
+    /// `scripts/run-dev.sh` sets up) but has no multi-node story —
+    /// PostgreSQL is required for production distributed deployments.
+    ///
+    /// Monolithic mode (`signaldb-bin`) intentionally does not call this.
+    pub fn validate_for_distributed(&self, service_name: &str) -> anyhow::Result<()> {
+        fn is_in_memory(dsn: &str) -> bool {
+            dsn.starts_with("sqlite::memory:") || dsn == "memory://" || dsn == "memory"
+        }
+        fn is_file_sqlite(dsn: &str) -> bool {
+            dsn.starts_with("sqlite:") && !is_in_memory(dsn)
+        }
+
+        // Discovery registry: bootstrap falls back to [database] when no
+        // [discovery] section is configured.
+        let (discovery_dsn, discovery_source) = match &self.discovery {
+            Some(discovery) => (discovery.dsn.as_str(), "[discovery] dsn"),
+            None => (self.database.dsn.as_str(), "[database] dsn"),
+        };
+        if is_in_memory(discovery_dsn) {
+            anyhow::bail!(
+                "{service_name} cannot run as a standalone service with {discovery_source} = \
+                 \"sqlite::memory:\": every process would get its own private service registry \
+                 and services could never discover each other. Point {discovery_source} at a \
+                 database shared by all services (PostgreSQL for production, a shared \
+                 sqlite:// file for single-host development), or run the monolithic \
+                 `signaldb` binary instead."
+            );
+        }
+
+        // Iceberg catalog: same failure mode for table metadata.
+        if self.schema.catalog_type == "memory" || is_in_memory(&self.schema.catalog_uri) {
+            anyhow::bail!(
+                "{service_name} cannot run as a standalone service with an in-memory Iceberg \
+                 catalog ([schema] catalog_type = \"{}\", catalog_uri = \"{}\"): every process \
+                 would get its own private catalog and services could never see each other's \
+                 tables. Point [schema] catalog_uri at a database shared by all services \
+                 (PostgreSQL for production), or run the monolithic `signaldb` binary instead.",
+                self.schema.catalog_type,
+                self.schema.catalog_uri
+            );
+        }
+
+        if is_file_sqlite(discovery_dsn) || is_file_sqlite(&self.schema.catalog_uri) {
+            tracing::warn!(
+                service = %service_name,
+                discovery_dsn = %redact_dsn(discovery_dsn),
+                catalog_uri = %redact_dsn(&self.schema.catalog_uri),
+                "SQLite-backed discovery/catalog only works when every service shares the same \
+                 file on one host (single-writer lock, no multi-node support); use PostgreSQL \
+                 for production distributed deployments"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Auto-provision the self-monitoring tenant when self-monitoring is
     /// enabled together with authentication but no matching tenant is
     /// configured.
@@ -1024,6 +1091,64 @@ mod tests {
             assert_eq!(config.querier.max_search_limit, 50);
             Ok(())
         });
+    }
+
+    #[test]
+    fn distributed_validation_rejects_in_memory_backends() {
+        // The defaults are in-memory: standalone services must refuse them.
+        let config = Configuration::default();
+        let error = config
+            .validate_for_distributed("querier")
+            .expect_err("in-memory discovery must be rejected");
+        assert!(error.to_string().contains("service registry"), "{error}");
+
+        // Shared discovery but in-memory catalog: still rejected.
+        let config = Configuration {
+            discovery: Some(DiscoveryConfig {
+                dsn: "postgres://db/signaldb".to_string(),
+                ..DiscoveryConfig::default()
+            }),
+            ..Configuration::default()
+        };
+        let error = config
+            .validate_for_distributed("querier")
+            .expect_err("in-memory catalog must be rejected");
+        assert!(error.to_string().contains("catalog"), "{error}");
+
+        // No [discovery] section: the [database] fallback is checked.
+        let config = Configuration {
+            discovery: None,
+            database: DatabaseConfig {
+                dsn: "sqlite::memory:".to_string(),
+            },
+            ..Configuration::default()
+        };
+        assert!(config.validate_for_distributed("router").is_err());
+    }
+
+    #[test]
+    fn distributed_validation_accepts_shared_backends() {
+        // PostgreSQL everywhere: fine.
+        let mut config = Configuration {
+            discovery: Some(DiscoveryConfig {
+                dsn: "postgres://db/signaldb".to_string(),
+                ..DiscoveryConfig::default()
+            }),
+            schema: SchemaConfig {
+                catalog_uri: "postgres://db/iceberg".to_string(),
+                ..SchemaConfig::default()
+            },
+            ..Configuration::default()
+        };
+        config.validate_for_distributed("writer").unwrap();
+
+        // File-based SQLite: allowed (single-host dev) with a warning.
+        config.discovery = Some(DiscoveryConfig {
+            dsn: "sqlite://.data/signaldb.db".to_string(),
+            ..DiscoveryConfig::default()
+        });
+        config.schema.catalog_uri = "sqlite://.data/catalog.db".to_string();
+        config.validate_for_distributed("writer").unwrap();
     }
 
     #[test]

--- a/src/compactor/src/main.rs
+++ b/src/compactor/src/main.rs
@@ -83,6 +83,10 @@ async fn main() -> Result<()> {
         Configuration::default()
     };
 
+    // Standalone services need shared discovery/catalog backends; the
+    // in-memory defaults only make sense in monolithic mode (issue #554).
+    config.validate_for_distributed("compactor")?;
+
     // Check if compactor is enabled
     if !config.compactor.enabled {
         tracing::info!("Compactor is disabled in configuration (compactor.enabled = false)");

--- a/src/querier/src/main.rs
+++ b/src/querier/src/main.rs
@@ -52,6 +52,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Load configuration
     let config = utils::load_config(cli.common.config.as_ref())?;
+    // Standalone services need shared discovery/catalog backends; the
+    // in-memory defaults only make sense in monolithic mode (issue #554).
+    config.validate_for_distributed("querier")?;
 
     // Handle common commands that don't require starting the service
     let command = cli.command.unwrap_or_default();

--- a/src/router/src/main.rs
+++ b/src/router/src/main.rs
@@ -52,6 +52,9 @@ async fn main() -> Result<()> {
 
     // Load application configuration
     let config = utils::load_config(cli.common.config.as_ref())?;
+    // Standalone services need shared discovery/catalog backends; the
+    // in-memory defaults only make sense in monolithic mode (issue #554).
+    config.validate_for_distributed("router")?;
 
     // Handle common commands that don't require starting the service
     let command = cli.command.unwrap_or_default();

--- a/src/writer/src/main.rs
+++ b/src/writer/src/main.rs
@@ -62,6 +62,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Load configuration
     let config = utils::load_config(cli.common.config.as_ref())?;
+    // Standalone services need shared discovery/catalog backends; the
+    // in-memory defaults only make sense in monolithic mode (issue #554).
+    config.validate_for_distributed("writer")?;
 
     // Handle common commands that don't require starting the service
     let command = cli.command.unwrap_or_default();


### PR DESCRIPTION
## Summary

Closes #554 (epic #563): `[discovery] dsn` and `[schema] catalog_uri` default to `sqlite::memory:`, which is coherent only in monolithic mode. Run as separate services, every binary silently got its own private in-memory registry and Iceberg catalog — services could never discover each other or see each other's tables. Our own `compose.yml` shipped exactly this footgun: PostgreSQL for discovery, but the catalog left on the in-memory default.

### Design

- **`Configuration::validate_for_distributed(service)`**, called by the five standalone service mains right after config load (the monolith intentionally does not call it):
  - In-memory discovery or catalog backends → **fail fast at startup** with a message explaining why it can't work and what to do (shared PostgreSQL for production, shared `sqlite://` file for single-host dev, or run the monolithic binary).
  - File-based SQLite → **prominent warning** (works when every service shares one file on one host — exactly what `scripts/run-dev.sh services` sets up — but has no multi-node story).
  - The `[database]` fallback used when `[discovery]` is absent is validated identically.
- `compose.yml` (5 services) and `docker-compose.test.yml` (3 services) now set `SIGNALDB__SCHEMA__CATALOG_URI` to the shared PostgreSQL; both files validate with `docker compose config`.
- `signaldb.dist.toml` documents the monolithic-only nature of the in-memory defaults on both sections.

`run-dev.sh services` is unaffected: it already exports file-based/postgres DSNs for discovery, database, and catalog.

### Tests

- Unit tests: in-memory discovery rejected, in-memory catalog rejected (even with shared discovery), `[database]` fallback checked, PostgreSQL accepted, file-SQLite accepted.
- Config suite 36/36; workspace clippy clean.

Closes #554
Part of #563