### PR TITLE
feat(discovery): TTL-filter stale services, reap crashed nodes, round-robin routing

### DIFF
--- a/src/common/src/catalog.rs
+++ b/src/common/src/catalog.rs
@@ -649,6 +649,62 @@ impl Catalog {
         Ok(filtered)
     }
 
+    /// List ingesters whose heartbeat is fresher than `ttl`.
+    ///
+    /// Crashed services never deregister (only graceful shutdown does),
+    /// so consumers must ignore rows whose `last_seen` is stale or they
+    /// will route to dead addresses (issue #555).
+    pub async fn list_active_ingesters(
+        &self,
+        ttl: std::time::Duration,
+    ) -> Result<Vec<Ingester>, sqlx::Error> {
+        let ttl = chrono::Duration::from_std(ttl).unwrap_or(chrono::Duration::MAX);
+        let now = Utc::now();
+        let ingesters = self.list_ingesters().await?;
+        Ok(ingesters
+            .into_iter()
+            .filter(|ingester| now.signed_duration_since(ingester.last_seen) <= ttl)
+            .collect())
+    }
+
+    /// Delete ingester rows whose `last_seen` is older than `cutoff`.
+    ///
+    /// Returns the number of rows removed. Safe to run from every
+    /// service concurrently — the DELETE is idempotent.
+    pub async fn reap_stale_ingesters(&self, cutoff: DateTime<Utc>) -> Result<u64, sqlx::Error> {
+        let removed = match self {
+            Catalog::Sqlite(pool) => {
+                // last_seen is stored as chrono RFC3339 text (UTC, +00:00
+                // offset), so lexicographic comparison against another
+                // RFC3339 UTC timestamp is chronologically correct.
+                let stmt = r#"
+                DELETE FROM ingesters
+                WHERE last_seen < ?
+                "#;
+                query(stmt)
+                    .bind(cutoff.to_rfc3339())
+                    .execute(pool)
+                    .await?
+                    .rows_affected()
+            }
+            Catalog::Postgres(pool) => {
+                let stmt = r#"
+                DELETE FROM ingesters
+                WHERE last_seen < $1
+                "#;
+                query(stmt)
+                    .bind(cutoff)
+                    .execute(pool)
+                    .await?
+                    .rows_affected()
+            }
+        };
+        if removed > 0 {
+            tracing::info!(removed, cutoff = %cutoff, "Reaped stale service registrations");
+        }
+        Ok(removed)
+    }
+
     /// Deregister an ingester instance, removing it from the catalog.
     #[tracing::instrument(level = "debug", skip_all, fields(service_id = %id))]
     pub async fn deregister_ingester(&self, id: Uuid) -> Result<(), sqlx::Error> {
@@ -689,6 +745,29 @@ impl Catalog {
                 ticker.tick().await;
                 if let Err(e) = catalog.heartbeat(id).await {
                     tracing::error!(service_id = %id, error = %e, "Failed to send heartbeat for ingester");
+                }
+            }
+        })
+    }
+
+    /// Spawn a background task that periodically deletes service rows
+    /// whose heartbeat stopped more than `reap_after` ago. Every service
+    /// runs one; the DELETE is idempotent across instances.
+    pub fn spawn_ingester_reaper(
+        &self,
+        interval: std::time::Duration,
+        reap_after: std::time::Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        let catalog = self.clone();
+        tokio::spawn(async move {
+            let reap_after =
+                chrono::Duration::from_std(reap_after).unwrap_or(chrono::Duration::MAX);
+            let mut ticker = tokio::time::interval(interval);
+            loop {
+                ticker.tick().await;
+                let cutoff = Utc::now() - reap_after;
+                if let Err(e) = catalog.reap_stale_ingesters(cutoff).await {
+                    tracing::error!(error = %e, "Failed to reap stale service registrations");
                 }
             }
         })

--- a/src/common/src/flight/transport.rs
+++ b/src/common/src/flight/transport.rs
@@ -90,6 +90,8 @@ pub struct InMemoryFlightTransport {
     max_pool_size: usize,
     /// Connection timeout in seconds
     connection_timeout: u64,
+    /// Rotates capability-based selection across healthy instances.
+    round_robin: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl InMemoryFlightTransport {
@@ -100,6 +102,7 @@ impl InMemoryFlightTransport {
             connections: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             max_pool_size: 50,
             connection_timeout: 30,
+            round_robin: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -114,6 +117,7 @@ impl InMemoryFlightTransport {
             connections: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             max_pool_size,
             connection_timeout,
+            round_robin: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -279,8 +283,15 @@ impl InMemoryFlightTransport {
             return Err("No services found with required capability".into());
         }
 
-        // Simple round-robin selection (could be enhanced with proper load balancing)
-        let service = &services[0];
+        // Round-robin across healthy instances; sort by id for a stable
+        // rotation order regardless of catalog listing order.
+        let mut services = services;
+        services.sort_by_key(|s| s.service_id);
+        let index = self
+            .round_robin
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % services.len();
+        let service = &services[index];
         self.get_flight_client(service.service_id).await
     }
 
@@ -365,6 +376,7 @@ impl InMemoryFlightTransport {
             connections: self.connections.clone(),
             max_pool_size: self.max_pool_size,
             connection_timeout: self.connection_timeout,
+            round_robin: self.round_robin.clone(),
         };
 
         tokio::spawn(async move {

--- a/src/common/src/service_bootstrap.rs
+++ b/src/common/src/service_bootstrap.rs
@@ -39,6 +39,7 @@ pub struct ServiceBootstrap {
     address: String,
     config: Configuration,
     heartbeat_handle: Option<JoinHandle<()>>,
+    reaper_handle: Option<JoinHandle<()>>,
 }
 
 impl ServiceBootstrap {
@@ -92,6 +93,14 @@ impl ServiceBootstrap {
             Some(catalog.spawn_ingester_heartbeat(service_id, Duration::from_secs(30)))
         };
 
+        // Reap registrations whose heartbeat stopped: crashed services
+        // never deregister, so without this the catalog leaks a row per
+        // crash and routers keep handing out dead addresses (issue #555).
+        // Rows are deleted once they are 2x TTL stale — well past the
+        // staleness filter consumers apply at TTL.
+        let ttl = Self::discovery_ttl(&config);
+        let reaper_handle = Some(catalog.spawn_ingester_reaper(ttl, ttl * 2));
+
         Ok(ServiceBootstrap {
             catalog,
             service_id,
@@ -99,7 +108,17 @@ impl ServiceBootstrap {
             address,
             config,
             heartbeat_handle,
+            reaper_handle,
         })
+    }
+
+    /// The staleness TTL for service discovery from config (default 300s).
+    fn discovery_ttl(config: &Configuration) -> Duration {
+        config
+            .discovery
+            .as_ref()
+            .map(|d| d.ttl)
+            .unwrap_or_else(|| Duration::from_secs(300))
     }
 
     /// Ensure the data directory exists for SQLite databases
@@ -198,7 +217,9 @@ impl ServiceBootstrap {
     /// Discover other services of the specified type
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn discover_ingesters(&self) -> Result<Vec<Ingester>> {
-        let ingesters = self.catalog.list_ingesters().await?;
+        // Stale rows belong to crashed services; never hand them out.
+        let ttl = Self::discovery_ttl(&self.config);
+        let ingesters = self.catalog.list_active_ingesters(ttl).await?;
         Ok(ingesters)
     }
 
@@ -208,11 +229,18 @@ impl ServiceBootstrap {
         &self,
         capability: crate::flight::transport::ServiceCapability,
     ) -> Result<Vec<Ingester>> {
+        let ttl = Self::discovery_ttl(&self.config);
         let services = self
             .catalog
             .discover_services_by_capability(capability)
             .await?;
-        Ok(services)
+        // Stale rows belong to crashed services; never hand them out.
+        let now = chrono::Utc::now();
+        let ttl = chrono::Duration::from_std(ttl).unwrap_or(chrono::Duration::MAX);
+        Ok(services
+            .into_iter()
+            .filter(|s| now.signed_duration_since(s.last_seen) <= ttl)
+            .collect())
     }
 
     /// Discover all registered services (returns ingesters for now, extensible for other types)
@@ -362,6 +390,7 @@ impl ServiceBootstrap {
             address: address.to_string(),
             config,
             heartbeat_handle: None,
+            reaper_handle: None,
         })
     }
 
@@ -373,8 +402,11 @@ impl ServiceBootstrap {
             "Shutting down service and deregistering from catalog"
         );
 
-        // Stop heartbeat task
+        // Stop heartbeat and reaper tasks
         if let Some(handle) = self.heartbeat_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.reaper_handle.take() {
             handle.abort();
         }
 
@@ -388,8 +420,11 @@ impl ServiceBootstrap {
 
 impl Drop for ServiceBootstrap {
     fn drop(&mut self) {
-        // Stop heartbeat task on drop
+        // Stop heartbeat and reaper tasks on drop
         if let Some(handle) = self.heartbeat_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.reaper_handle.take() {
             handle.abort();
         }
     }

--- a/src/common/tests/catalog_sqlite_tests.rs
+++ b/src/common/tests/catalog_sqlite_tests.rs
@@ -278,3 +278,77 @@ async fn test_ingester_update_sqlite() {
     assert_eq!(ingesters[0].address, "127.0.0.1:8081");
     assert_eq!(ingesters[0].capabilities.len(), 2);
 }
+
+#[tokio::test]
+async fn test_list_active_ingesters_filters_stale_rows() {
+    let catalog = Catalog::new("sqlite::memory:")
+        .await
+        .expect("Failed to create catalog");
+
+    let id = Uuid::new_v4();
+    catalog
+        .register_ingester(
+            id,
+            "127.0.0.1:9000",
+            ServiceType::Querier,
+            &[ServiceCapability::QueryExecution],
+        )
+        .await
+        .expect("Failed to register ingester");
+
+    // A generous TTL keeps the freshly-registered service.
+    let active = catalog
+        .list_active_ingesters(std::time::Duration::from_secs(300))
+        .await
+        .expect("Failed to list active ingesters");
+    assert_eq!(active.len(), 1);
+
+    // A zero TTL treats it as stale — the row exists but must not be
+    // handed out.
+    let active = catalog
+        .list_active_ingesters(std::time::Duration::ZERO)
+        .await
+        .expect("Failed to list active ingesters");
+    assert!(active.is_empty(), "zero TTL must filter every row");
+
+    // The raw listing still contains the row (filtering, not deleting).
+    let all = catalog
+        .list_ingesters()
+        .await
+        .expect("Failed to list ingesters");
+    assert_eq!(all.len(), 1);
+}
+
+#[tokio::test]
+async fn test_reap_stale_ingesters_deletes_only_old_rows() {
+    let catalog = Catalog::new("sqlite::memory:")
+        .await
+        .expect("Failed to create catalog");
+
+    let id = Uuid::new_v4();
+    catalog
+        .register_ingester(
+            id,
+            "127.0.0.1:9000",
+            ServiceType::Writer,
+            &[ServiceCapability::Storage],
+        )
+        .await
+        .expect("Failed to register ingester");
+
+    // A cutoff in the past reaps nothing (the row is fresh).
+    let removed = catalog
+        .reap_stale_ingesters(chrono::Utc::now() - chrono::Duration::hours(1))
+        .await
+        .expect("Failed to reap");
+    assert_eq!(removed, 0);
+    assert_eq!(catalog.list_ingesters().await.unwrap().len(), 1);
+
+    // A cutoff in the future treats the row as stale and deletes it.
+    let removed = catalog
+        .reap_stale_ingesters(chrono::Utc::now() + chrono::Duration::hours(1))
+        .await
+        .expect("Failed to reap");
+    assert_eq!(removed, 1);
+    assert!(catalog.list_ingesters().await.unwrap().is_empty());
+}

--- a/src/router/src/discovery.rs
+++ b/src/router/src/discovery.rs
@@ -6,6 +6,7 @@ use common::flight::transport::{
 use common::service_bootstrap::ServiceType;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 use tonic::transport::Channel;
@@ -16,6 +17,10 @@ pub struct ServiceRegistry {
     services: Arc<RwLock<HashMap<uuid::Uuid, Ingester>>>,
     catalog: Catalog,
     flight_transport: Option<Arc<InMemoryFlightTransport>>,
+    /// Registrations with heartbeats older than this are treated as dead.
+    discovery_ttl: std::time::Duration,
+    /// Rotates get_service_for_routing across healthy instances.
+    round_robin: Arc<AtomicUsize>,
 }
 
 impl std::fmt::Debug for ServiceRegistry {
@@ -35,6 +40,8 @@ impl ServiceRegistry {
             services: Arc::new(RwLock::new(HashMap::new())),
             catalog,
             flight_transport: None,
+            discovery_ttl: std::time::Duration::from_secs(300),
+            round_robin: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -47,7 +54,15 @@ impl ServiceRegistry {
             services: Arc::new(RwLock::new(HashMap::new())),
             catalog,
             flight_transport: Some(Arc::new(flight_transport)),
+            discovery_ttl: std::time::Duration::from_secs(300),
+            round_robin: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    /// Override the staleness TTL applied when refreshing the registry.
+    pub fn with_discovery_ttl(mut self, ttl: std::time::Duration) -> Self {
+        self.discovery_ttl = ttl;
+        self
     }
 
     /// Start background polling to keep service registry updated
@@ -66,8 +81,10 @@ impl ServiceRegistry {
 
     /// Refresh the service registry from the catalog
     async fn refresh_services(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Update services (currently all registered as ingesters)
-        match self.catalog.list_ingesters().await {
+        // Update services (currently all registered as ingesters).
+        // Stale rows belong to crashed services; keep them out of the
+        // routing map (issue #555).
+        match self.catalog.list_active_ingesters(self.discovery_ttl).await {
             Ok(services) => {
                 let mut service_map = self.services.write().await;
                 service_map.clear();
@@ -89,12 +106,18 @@ impl ServiceRegistry {
         self.services.read().await.values().cloned().collect()
     }
 
-    /// Get a service for routing (round-robin for now)
+    /// Get a service for routing, rotating round-robin across the
+    /// healthy instances in the registry.
     pub async fn get_service_for_routing(&self) -> Option<Ingester> {
         let services = self.services.read().await;
-        // For now, return the first available service
-        // In the future, implement proper load balancing and service type filtering
-        services.values().next().cloned()
+        if services.is_empty() {
+            return None;
+        }
+        // Sort by id for a stable rotation order across refreshes.
+        let mut candidates: Vec<&Ingester> = services.values().collect();
+        candidates.sort_by_key(|service| service.id);
+        let index = self.round_robin.fetch_add(1, Ordering::Relaxed) % candidates.len();
+        Some(candidates[index].clone())
     }
 
     /// Get services by address pattern (useful for filtering by service type if encoded in address)
@@ -241,6 +264,68 @@ impl ServiceRegistry {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    fn mock_ingester(address: &str) -> common::catalog::Ingester {
+        common::catalog::Ingester {
+            id: uuid::Uuid::new_v4(),
+            address: address.to_string(),
+            last_seen: chrono::Utc::now(),
+            service_type: common::service_bootstrap::ServiceType::Querier,
+            capabilities: vec![common::flight::transport::ServiceCapability::QueryExecution],
+        }
+    }
+
+    #[tokio::test]
+    async fn routing_rotates_round_robin_across_services() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let registry = ServiceRegistry::new(catalog);
+
+        let first = mock_ingester("first:9000");
+        let second = mock_ingester("second:9000");
+        {
+            let mut services = registry.services.write().await;
+            services.insert(first.id, first.clone());
+            services.insert(second.id, second.clone());
+        }
+
+        let mut picked = Vec::new();
+        for _ in 0..4 {
+            picked.push(registry.get_service_for_routing().await.unwrap().id);
+        }
+        // Both services take part and consecutive picks alternate.
+        assert!(picked.contains(&first.id));
+        assert!(picked.contains(&second.id));
+        assert_ne!(picked[0], picked[1]);
+        assert_eq!(picked[0], picked[2]);
+        assert_eq!(picked[1], picked[3]);
+    }
+
+    #[tokio::test]
+    async fn refresh_drops_stale_services() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        catalog
+            .register_ingester(
+                id,
+                "fresh:9000",
+                common::service_bootstrap::ServiceType::Querier,
+                &[common::flight::transport::ServiceCapability::QueryExecution],
+            )
+            .await
+            .unwrap();
+
+        // Generous TTL: the service is visible after refresh.
+        let registry = ServiceRegistry::new(catalog.clone())
+            .with_discovery_ttl(std::time::Duration::from_secs(300));
+        registry.refresh_services().await.unwrap();
+        assert_eq!(registry.get_services().await.len(), 1);
+
+        // Zero TTL: the same row counts as a crashed service and is
+        // dropped from the routing map.
+        let registry = ServiceRegistry::new(catalog).with_discovery_ttl(std::time::Duration::ZERO);
+        registry.refresh_services().await.unwrap();
+        assert!(registry.get_services().await.is_empty());
+    }
 
     #[tokio::test]
     async fn test_service_registry_health_check_logic() {

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -42,7 +42,10 @@ impl std::fmt::Debug for InMemoryStateImpl {
 
 impl InMemoryStateImpl {
     pub fn new(catalog: Catalog, config: Configuration) -> Self {
-        let service_registry = discovery::ServiceRegistry::new(catalog.clone());
+        let mut service_registry = discovery::ServiceRegistry::new(catalog.clone());
+        if let Some(discovery_config) = &config.discovery {
+            service_registry = service_registry.with_discovery_ttl(discovery_config.ttl);
+        }
         let authenticator = Arc::new(Authenticator::new(
             config.auth.clone(),
             Arc::new(catalog.clone()),
@@ -61,8 +64,11 @@ impl InMemoryStateImpl {
         config: Configuration,
         flight_transport: common::flight::transport::InMemoryFlightTransport,
     ) -> Self {
-        let service_registry =
+        let mut service_registry =
             discovery::ServiceRegistry::with_flight_transport(catalog.clone(), flight_transport);
+        if let Some(discovery_config) = &config.discovery {
+            service_registry = service_registry.with_discovery_ttl(discovery_config.ttl);
+        }
         let authenticator = Arc::new(Authenticator::new(
             config.auth.clone(),
             Arc::new(catalog.clone()),


### PR DESCRIPTION
## Summary

Closes #555 (epic #563): service discovery listed every catalog row forever. No `last_seen`/TTL filter existed anywhere (`DiscoveryConfig.ttl` was defined but read nowhere), crashed services never deregister (only graceful shutdown does, and each restart registers a fresh UUID), so the catalog leaked one dead row per crash and routers kept handing out dead addresses. Selection also wasn't the round-robin its comments claimed — the router picked `values().next()` and the Flight transport picked `services[0]`.

### Design

- **Staleness filtering**: `Catalog::list_active_ingesters(ttl)` filters rows whose heartbeat is older than the TTL. `ServiceBootstrap`'s discovery paths and the router `ServiceRegistry` now use it with `DiscoveryConfig.ttl` (default 300s) — dead instances drop out of routing after one TTL even before their row is removed.
- **Reaper**: `Catalog::reap_stale_ingesters(cutoff)` deletes rows past the cutoff; `spawn_ingester_reaper` runs it periodically. Every `ServiceBootstrap` runs one (the DELETE is idempotent across instances), removing rows once they're **2× TTL** stale — comfortably past the staleness filter. Aborted on shutdown/Drop like the heartbeat task.
- **Round-robin for real**: both `ServiceRegistry::get_service_for_routing` and `InMemoryFlightTransport::get_client_for_capability` (the actually-exercised routing path) rotate across healthy instances via an atomic counter over a stable id-sorted order.
- SQLite stores `last_seen` as chrono RFC3339 UTC text, so the reaper's `WHERE last_seen < ?` comparison against an RFC3339 cutoff is chronologically correct; Postgres uses native `TIMESTAMPTZ`.

### Not in this PR (issue's remaining notes)

Stable service identity across restarts (reaping makes the fresh-UUID-per-boot rows self-cleaning) and graceful degradation when the catalog DB itself is down (the SPOF paragraph) — both follow-ups.

### Tests

- Catalog: fresh row kept under generous TTL / filtered under zero TTL (filtering ≠ deleting); reaper deletes only rows past the cutoff (7 sqlite catalog tests green).
- Registry: refresh drops stale services by TTL; round-robin alternates deterministically across instances.
- `common` suite 200/200; workspace clippy clean.

Closes #555
Part of #563