### PR TITLE
fix(config): remove the dead [auth] enabled flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,6 @@ SignalDB provides tenant isolation with API key-based authentication:
 
 ```toml
 [auth]
-enabled = true
-
 [[auth.tenants]]
 id = "acme"
 name = "Acme Corporation"

--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ Configure multi-tenancy in `signaldb.toml`:
 
 ```toml
 [auth]
-enabled = true
 
 [[auth.tenants]]
 id = "acme"

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -96,7 +96,6 @@ catalog_type = "sql"
 catalog_uri = "sqlite://$(pwd)/${BASE_DIR}/iceberg_catalog.db"
 
 [auth]
-enabled = true
 admin_api_key = "dev-admin-key"
 
 # Development tenant

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -8,8 +8,11 @@ dsn = "sqlite://.data/signaldb.db"
 
 [auth]
 # Multi-Tenancy Authentication Configuration
-# Controls API key validation and tenant isolation
-enabled = true  # Set to false to disable authentication (dev/testing only)
+# API key validation and tenant isolation are always enforced on the
+# tenant-facing ingest and query APIs; there is no off switch. (The
+# former `enabled` flag never did anything and was removed.) The
+# internal Flight ports are controlled separately by
+# internal_service_key below.
 
 # Admin API key for the /api/v1/admin/* management endpoints
 # Generate a strong random key for production use

--- a/src/acceptor/src/middleware/auth.rs
+++ b/src/acceptor/src/middleware/auth.rs
@@ -391,7 +391,6 @@ mod tests {
         // Setup authenticator
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),

--- a/src/acceptor/src/middleware/grpc_auth.rs
+++ b/src/acceptor/src/middleware/grpc_auth.rs
@@ -282,7 +282,6 @@ mod tests {
         // Setup authenticator
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),
@@ -331,7 +330,6 @@ mod tests {
     async fn test_grpc_auth_interceptor_missing_header() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![],
             admin_api_key: None,
             internal_service_key: None,
@@ -352,7 +350,6 @@ mod tests {
     async fn test_grpc_auth_interceptor_invalid_key() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![],
             admin_api_key: None,
             internal_service_key: None,

--- a/src/common/src/auth/authenticator.rs
+++ b/src/common/src/auth/authenticator.rs
@@ -246,7 +246,6 @@ mod tests {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
 
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),
@@ -307,7 +306,6 @@ mod tests {
     async fn test_invalid_api_key() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![],
             admin_api_key: None,
             internal_service_key: None,
@@ -327,7 +325,6 @@ mod tests {
     async fn test_tenant_mismatch() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),
@@ -366,7 +363,6 @@ mod tests {
     async fn test_invalid_dataset() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),
@@ -404,7 +400,6 @@ mod tests {
     async fn test_missing_default_dataset() {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -304,7 +304,6 @@ mod tests {
         // Setup authenticator
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),

--- a/src/common/src/catalog_manager.rs
+++ b/src/common/src/catalog_manager.rs
@@ -175,7 +175,6 @@ mod tests {
     fn create_test_config() -> Configuration {
         Configuration {
             auth: AuthConfig {
-                enabled: true,
                 tenants: vec![
                     TenantConfig {
                         id: "acme".to_string(),

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -554,11 +554,13 @@ impl Default for TenantLimits {
 }
 
 /// Authentication configuration
+///
+/// Authentication is always enforced on the tenant-facing ingest and
+/// query surfaces; there is no off switch (the former `enabled` flag was
+/// dead config that never gated anything, issue #553). The internal
+/// Flight mesh is separately controlled by `internal_service_key`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AuthConfig {
-    /// Whether multi-tenancy authentication is enabled
-    #[serde(default)]
-    pub enabled: bool,
     /// Default ingest rate limits applied to every tenant without an
     /// explicit `limits` override. Unset fields mean unlimited.
     #[serde(default)]
@@ -916,7 +918,7 @@ impl Configuration {
     /// Without an admin API key the tenant cannot be provisioned; a warning is
     /// logged and the config is left untouched.
     pub fn ensure_self_monitoring_tenant(&mut self) {
-        if !self.self_monitoring.enabled || !self.auth.enabled {
+        if !self.self_monitoring.enabled {
             return;
         }
         let tenant_id = self.self_monitoring.tenant_id.clone();
@@ -1149,6 +1151,28 @@ mod tests {
         });
         config.schema.catalog_uri = "sqlite://.data/catalog.db".to_string();
         config.validate_for_distributed("writer").unwrap();
+    }
+
+    #[test]
+    fn legacy_auth_enabled_key_is_tolerated() {
+        // Configs written before the dead `[auth] enabled` flag was
+        // removed must still load; the unknown key is ignored.
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "signaldb.toml",
+                r#"
+                [auth]
+                enabled = true
+                admin_api_key = "sk-admin"
+                "#,
+            )?;
+            let config: Configuration = Figment::new()
+                .merge(Serialized::defaults(Configuration::default()))
+                .merge(figment::providers::Toml::file("signaldb.toml"))
+                .extract()?;
+            assert_eq!(config.auth.admin_api_key.as_deref(), Some("sk-admin"));
+            Ok(())
+        });
     }
 
     #[test]
@@ -1405,7 +1429,6 @@ mod tests {
     fn self_monitoring_tenant_auto_provisioned_with_admin_key() {
         let mut config = Configuration::default();
         config.self_monitoring.enabled = true;
-        config.auth.enabled = true;
         config.auth.admin_api_key = Some("admin-key".to_string());
 
         config.ensure_self_monitoring_tenant();
@@ -1426,7 +1449,6 @@ mod tests {
     fn self_monitoring_tenant_not_provisioned_without_admin_key() {
         let mut config = Configuration::default();
         config.self_monitoring.enabled = true;
-        config.auth.enabled = true;
         config.auth.admin_api_key = None;
 
         config.ensure_self_monitoring_tenant();
@@ -1437,7 +1459,6 @@ mod tests {
     fn self_monitoring_tenant_not_duplicated_when_configured() {
         let mut config = Configuration::default();
         config.self_monitoring.enabled = true;
-        config.auth.enabled = true;
         config.auth.admin_api_key = Some("admin-key".to_string());
         config.auth.tenants.push(TenantConfig {
             id: "_system".to_string(),
@@ -1466,7 +1487,6 @@ mod tests {
     #[test]
     fn self_monitoring_tenant_not_provisioned_when_disabled() {
         let mut config = Configuration::default();
-        config.auth.enabled = true;
         config.auth.admin_api_key = Some("admin-key".to_string());
 
         config.ensure_self_monitoring_tenant();

--- a/src/common/src/flight/auth.rs
+++ b/src/common/src/flight/auth.rs
@@ -173,7 +173,6 @@ mod tests {
     async fn interceptor() -> FlightAuthInterceptor {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "acme".to_string(),
                 slug: "acme".to_string(),

--- a/src/common/src/testing/config_builder.rs
+++ b/src/common/src/testing/config_builder.rs
@@ -122,7 +122,6 @@ impl TestConfigBuilder {
         };
 
         self.config.auth.tenants.push(tenant_config);
-        self.config.auth.enabled = true;
         self
     }
 
@@ -166,12 +165,6 @@ impl TestConfigBuilder {
     /// Disable discovery.
     pub fn without_discovery(mut self) -> Self {
         self.config.discovery = None;
-        self
-    }
-
-    /// Enable authentication.
-    pub fn with_auth_enabled(mut self) -> Self {
-        self.config.auth.enabled = true;
         self
     }
 
@@ -255,7 +248,6 @@ mod tests {
             .with_tenant("acme", "prod")
             .build();
 
-        assert!(config.auth.enabled);
         assert_eq!(config.auth.tenants.len(), 1);
 
         let tenant = &config.auth.tenants[0];

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -111,7 +111,6 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
 
     // Configure test tenant
     config.auth = common::config::AuthConfig {
-        enabled: true,
         admin_api_key: None,
         internal_service_key: None,
         default_limits: Default::default(),

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -87,7 +87,6 @@ async fn setup_test_services() -> TestServices {
 
     // Configure single-tenant authentication for test
     config.auth = common::config::AuthConfig {
-        enabled: true,
         tenants: vec![common::config::TenantConfig {
             id: "test-tenant".to_string(),
             slug: "test-tenant".to_string(),
@@ -738,7 +737,6 @@ async fn test_tempo_v2_trace_endpoint() {
         .unwrap();
     let mut config = Configuration::default();
     config.auth = common::config::AuthConfig {
-        enabled: true,
         tenants: vec![common::config::TenantConfig {
             id: "test-tenant".to_string(),
             slug: "test-tenant".to_string(),
@@ -832,7 +830,6 @@ async fn setup_multi_tenant_test_services() -> TestServices {
 
     // Configure multi-tenant authentication
     config.auth = common::config::AuthConfig {
-        enabled: true,
         tenants: vec![
             common::config::TenantConfig {
                 id: "acme".to_string(),

--- a/tests-integration/tests/self_monitoring.rs
+++ b/tests-integration/tests/self_monitoring.rs
@@ -79,7 +79,6 @@ async fn self_monitoring_export_lands_in_system_wal() {
         poll_interval: Duration::from_secs(60),
         ttl: Duration::from_secs(300),
     });
-    config.auth.enabled = true;
     config.auth.admin_api_key = Some("test-admin-key".to_string());
     config.self_monitoring.enabled = true;
     config.self_monitoring.trace_sample_ratio = 1.0;

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -133,7 +133,6 @@ async fn test_iceberg_namespace_slug_based() -> Result<()> {
             dsn: "memory://".to_string(),
         },
         auth: AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "tenant-1".to_string(),
                 slug: "mycorp".to_string(),
@@ -296,7 +295,6 @@ async fn test_write_and_query_with_slugs() -> Result<()> {
             dsn: format!("file://{}", storage_path.display()),
         },
         auth: AuthConfig {
-            enabled: true,
             tenants: vec![TenantConfig {
                 id: "test-tenant".to_string(),
                 slug: "testco".to_string(),


### PR DESCRIPTION
## Summary

Closes #553 (epic #563): `AuthConfig.enabled` was dead config. It was never read by the `Authenticator` or any middleware/interceptor — tenant auth is wired unconditionally on every tenant-facing surface — yet `signaldb.dist.toml` documented `enabled = false` as "disable authentication (dev/testing only)". A dev who trusted that got unexplained 400/401s on every request.

### Why remove instead of making it real

- **Tenant identity is load-bearing**: `TenantContext` keys WAL paths (`.wal/{tenant}/{dataset}/…`) and Iceberg namespaces. There is no coherent unauthenticated storage path to fall back to — a real dev bypass means threading a synthetic default tenant end-to-end, which is a deliberate feature design, not a flag flip.
- **Nothing ever used it**: zero readers gate enforcement on it, zero tests set `enabled = false`, and every dev/test/quickstart flow (run-dev.sh, integration tests, compose) already provisions tenants + API keys.
- **The serde default made "making it real" dangerous**: the field defaulted to `false`, so giving it authority would have silently disabled auth for every config that omits it — a multi-tenant isolation regression by default.

The internal Flight ports remain separately controlled by `internal_service_key` (from #579/#589), which is the deliberate opt-in surface.

### Changes

- Field removed; the one real reader (self-monitoring tenant auto-provisioning) now gates only on `self_monitoring.enabled`.
- Legacy configs containing the key still load (unknown keys ignored) — covered by a new test.
- Docs fixed: `signaldb.dist.toml` now states auth is always enforced with no off switch; README, CLAUDE.md, and `run-dev.sh` no longer set or imply the flag.
- ~15 struct-literal sites (tests/builders) updated; `ConfigBuilder::with_auth_enabled` removed.

Related hardening from the issue (salted key hashing, secret indirection, constant-time admin-key compare) is intentionally left as follow-up — separate concern from the dead flag.

### Tests

`common` suite 203/203 (including the new legacy-key tolerance test and self-monitoring provisioning tests), workspace clippy clean.

Closes #553
Part of #563