### PR TITLE
fix(compactor): plan from real manifest data instead of synthetic files

### DIFF
--- a/src/compactor/src/planner.rs
+++ b/src/compactor/src/planner.rs
@@ -239,9 +239,19 @@ impl CompactionPlanner {
         Ok(candidates)
     }
 
-    /// Group files by partition
+    /// Group the table's live data files for planning.
     ///
-    /// Reads Iceberg manifest files and groups data files by their partition values.
+    /// Reads the REAL data file set from the current snapshot's manifests
+    /// so the planning thresholds operate on actual file counts and sizes
+    /// (issue #559 — this used to fabricate synthetic files, which made
+    /// every table with a snapshot a candidate on every cycle).
+    ///
+    /// All files are grouped under the single `"all"` key: the executor
+    /// rewrites and commits the WHOLE table (a `replace` snapshot), so the
+    /// candidate's `partition_id = "all"` deliberately keys the lease at
+    /// table granularity — the unit the executor actually mutates.
+    /// Partition-scoped planning must not be introduced without also
+    /// scoping the rewrite/commit (see issue #559's latent-race note).
     async fn group_files_by_partition(
         &self,
         table: &iceberg_rust::catalog::tabular::Tabular,
@@ -254,10 +264,9 @@ impl CompactionPlanner {
             }
         };
 
-        let metadata = table.metadata();
-
         // Get current snapshot
-        let snapshot_id = metadata
+        let snapshot_id = table
+            .metadata()
             .current_snapshot_id
             .ok_or_else(|| anyhow::anyhow!("Table has no current snapshot"))?;
 
@@ -267,59 +276,28 @@ impl CompactionPlanner {
             snapshot_id
         );
 
-        // For Phase 2, we use a simplified approach:
-        // Since iceberg-rust's manifest reading API is still evolving,
-        // we'll use the table scan API which provides file-level information
-        // through the DataFusion integration.
-        //
-        // The table's metadata contains snapshot information, but for practical
-        // purposes in Phase 2, we'll group files by a synthetic partition key
-        // based on the table's partitioning scheme.
-        //
-        // A full implementation would:
-        // 1. Read manifest list from snapshot
-        // 2. Parse Avro manifest files
-        // 3. Extract data file entries with partition values
-        // 4. Group by formatted partition key
-        //
-        // For Phase 2, we create synthetic FileInfo entries to enable
-        // end-to-end testing of the compaction flow. The actual data reading
-        // is handled by the executor through DataFusion, so these entries
-        // are only used for planning thresholds.
-
-        let mut partitions: HashMap<String, Vec<FileInfo>> = HashMap::new();
-
-        // Create a synthetic partition for all files
-        // This allows the executor to process the table
-        let partition_key = "all".to_string();
-
-        // Phase 2 workaround: Create synthetic file entries to pass planning thresholds
-        // We create files that:
-        // - Meet the file count threshold (default: 10)
-        // - Have sizes that justify compaction (< target size)
-        // - Total to a reasonable compaction workload
-        //
-        // TODO(Phase 3): Replace with actual manifest reading to get real file metadata
-        let synthetic_files: Vec<FileInfo> = (0..15)
-            .map(|i| FileInfo {
-                path: format!("data/partition-all/file-{}.parquet", i),
-                size_bytes: 5 * 1024 * 1024, // 5MB each (small files needing compaction)
-                record_count: 50000,         // Estimated rows
+        let files: Vec<FileInfo> = crate::iceberg::ManifestReader::new()
+            .get_snapshot_files(table)
+            .await
+            .context("Failed to read data files from manifests")?
+            .into_iter()
+            .map(|file| FileInfo {
+                path: file.file_path,
+                size_bytes: file.file_size_bytes,
+                record_count: file.record_count,
             })
             .collect();
 
         tracing::debug!(
-            "Phase 2: Created {} synthetic file entries for planning (actual data read via DataFusion)",
-            synthetic_files.len()
-        );
-
-        partitions.insert(partition_key, synthetic_files);
-
-        tracing::debug!(
-            "Grouped files into {} partitions for table {}",
-            partitions.len(),
+            "Read {} live data files from manifests for table {}",
+            files.len(),
             table.identifier()
         );
+
+        let mut partitions: HashMap<String, Vec<FileInfo>> = HashMap::new();
+        if !files.is_empty() {
+            partitions.insert("all".to_string(), files);
+        }
 
         Ok(partitions)
     }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 # Workspace crates
 acceptor = { path = "../src/acceptor" }
-common = { path = "../src/common" }
+common = { path = "../src/common", features = ["testing"] }
 compactor = { path = "../src/compactor" }
 querier = { path = "../src/querier" }
 router = { path = "../src/router" }

--- a/tests-integration/tests/compactor/basic_compaction.rs
+++ b/tests-integration/tests/compactor/basic_compaction.rs
@@ -10,42 +10,11 @@ use common::catalog_manager::CatalogManager;
 use compactor::executor::{CompactionExecutor, ExecutorConfig};
 use compactor::metrics::CompactionMetrics;
 use compactor::planner::{CompactionCandidate, CompactionPlanner, PartitionStats, PlannerConfig};
-use datafusion::arrow::array::{Int64Array, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use object_store::memory::InMemory;
 use std::sync::Arc;
-use tempfile::tempdir;
+use tests_integration::fixtures::{DataGeneratorConfig, PartitionGranularity};
+use tests_integration::generators;
 use writer::IcebergTableWriter;
-
-/// Helper to create test trace data
-fn create_test_trace_batch(trace_id: &str, num_rows: usize) -> Result<RecordBatch> {
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("trace_id", DataType::Utf8, false),
-        Field::new("span_id", DataType::Utf8, false),
-        Field::new("span_name", DataType::Utf8, false),
-        Field::new("timestamp", DataType::Int64, false),
-        Field::new("duration_ns", DataType::Int64, false),
-    ]));
-
-    let trace_ids: Vec<String> = (0..num_rows).map(|_| trace_id.to_string()).collect();
-    let span_ids: Vec<String> = (0..num_rows).map(|i| format!("span-{}", i)).collect();
-    let span_names: Vec<String> = (0..num_rows).map(|i| format!("test-span-{}", i)).collect();
-    let timestamps: Vec<i64> = (0..num_rows).map(|i| 1700000000000 + i as i64).collect();
-    let durations: Vec<i64> = (0..num_rows).map(|_| 1000000).collect();
-
-    let batch = RecordBatch::try_new(
-        schema,
-        vec![
-            Arc::new(StringArray::from(trace_ids)),
-            Arc::new(StringArray::from(span_ids)),
-            Arc::new(StringArray::from(span_names)),
-            Arc::new(Int64Array::from(timestamps)),
-            Arc::new(Int64Array::from(durations)),
-        ],
-    )?;
-
-    Ok(batch)
-}
 
 /// Test basic compaction with a simple scenario
 #[tokio::test]
@@ -53,62 +22,70 @@ async fn test_basic_compaction() -> Result<()> {
     // Initialize logging for the test
     let _ = env_logger::builder().is_test(true).try_init();
 
-    // Setup test environment
-    let _temp_dir = tempdir()?;
-    let catalog_manager = Arc::new(CatalogManager::new_in_memory().await?);
+    // Setup: the planner discovers work by iterating configured tenants,
+    // so the test tenant must exist in auth config.
+    let config = common::testing::TestConfigBuilder::new()
+        .in_memory()
+        .with_tenant("test-tenant", "test-dataset")
+        .build();
+    let catalog_manager = Arc::new(CatalogManager::new(config).await?);
     let object_store = Arc::new(InMemory::new());
 
-    // Create the traces table with some test data
     let tenant_id = "test-tenant";
     let dataset_id = "test-dataset";
     let table_name = "traces";
-
-    log::info!(
-        "Creating test table {}/{}/{}",
-        tenant_id,
-        dataset_id,
-        table_name
-    );
-
-    // Create writer for the table
-    let result = IcebergTableWriter::new(
+    let mut writer = IcebergTableWriter::new(
         &catalog_manager,
         object_store.clone(),
         tenant_id.to_string(),
         dataset_id.to_string(),
         table_name.to_string(),
     )
-    .await;
+    .await
+    .expect("Failed to create Iceberg writer");
 
-    // For Phase 2, we expect table creation to work but may have environment limitations
-    match result {
-        Ok(mut writer) => {
-            log::info!("Successfully created Iceberg writer");
-
-            // Write some small batches (simulating multiple small files)
-            for i in 0..5 {
-                let batch = create_test_trace_batch(&format!("trace-{}", i), 100)?;
-                log::info!("Writing test batch {} with {} rows", i, batch.num_rows());
-
-                if let Err(e) = writer.write_batch(batch).await {
-                    log::warn!("Failed to write batch {}: {}", i, e);
-                    // Continue - may fail due to test environment
-                }
-            }
-
-            log::info!("Completed writing test data");
-        }
-        Err(e) => {
-            log::warn!("Could not create writer in test environment: {}", e);
-            // For Phase 2, this is acceptable as we're testing the compactor logic
-            // The core functionality is unit tested
-            return Ok(());
-        }
+    // 5 separate writes -> 5 small live files: the table genuinely needs
+    // compaction.
+    let config = DataGeneratorConfig {
+        partition_count: 1,
+        files_per_partition: 1,
+        rows_per_file: 100,
+        base_timestamp: chrono::Utc::now().timestamp_millis() - (60 * 60 * 1000),
+        partition_granularity: PartitionGranularity::Hour,
+    };
+    for _ in 0..5 {
+        generators::generate_traces(&mut writer, &config).await?;
     }
+
+    // Count the REAL live files before compaction.
+    let manifest_reader = compactor::iceberg::ManifestReader::new();
+    let table_identifier =
+        catalog_manager.build_table_identifier(tenant_id, dataset_id, table_name);
+    let load_table = || async {
+        match catalog_manager
+            .catalog()
+            .load_tabular(&table_identifier)
+            .await
+            .expect("Failed to load table")
+        {
+            iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
+            _ => panic!("Expected table"),
+        }
+    };
+    let files_before = manifest_reader
+        .get_snapshot_files(&load_table().await)
+        .await?;
+    let rows_before: u64 = files_before.iter().map(|f| f.record_count).sum();
+    assert!(
+        files_before.len() >= 2,
+        "Test setup must produce multiple small files, got {}",
+        files_before.len()
+    );
+    assert_eq!(rows_before, 500, "5 writes x 100 rows");
 
     // Create compaction planner
     let planner_config = PlannerConfig {
-        file_count_threshold: 2, // Low threshold for testing
+        file_count_threshold: 3, // Low threshold for testing (above post-compaction steady state)
         min_input_file_size_bytes: 100,
         max_files_per_job: 50,
         target_file_size_bytes: 128 * 1024 * 1024,
@@ -116,55 +93,58 @@ async fn test_basic_compaction() -> Result<()> {
 
     let planner = CompactionPlanner::new(catalog_manager.clone(), planner_config.clone());
 
-    log::info!("Running compaction planning");
-
-    // Run planning
+    // Planning must be based on the REAL file set (issue #559): the table
+    // has multiple small files, so it is a candidate with real stats.
     let candidates = planner.plan().await?;
+    assert_eq!(
+        candidates.len(),
+        1,
+        "expected exactly one whole-table candidate, got {candidates:?}"
+    );
+    let candidate = &candidates[0];
+    assert_eq!(candidate.partition_id, "all");
+    assert_eq!(
+        candidate.stats.file_count,
+        files_before.len(),
+        "candidate must report the real live file count"
+    );
 
-    log::info!("Found {} compaction candidates", candidates.len());
+    // Execute the compaction and verify it actually reduced the file set.
+    let executor_config = ExecutorConfig::from(&planner_config);
+    let metrics = CompactionMetrics::new();
+    let executor =
+        CompactionExecutor::new(catalog_manager.clone(), executor_config, metrics.clone());
+    let result = executor
+        .execute_candidate(candidates.into_iter().next().unwrap())
+        .await?;
+    assert!(
+        matches!(
+            result.status,
+            compactor::executor::CompactionStatus::Success
+        ),
+        "compaction must succeed: {:?}",
+        result.error
+    );
 
-    // For Phase 2 with simplified manifest reading, we may or may not find candidates
-    // The important thing is that the planning doesn't error
-    if !candidates.is_empty() {
-        // Create executor and metrics
-        let executor_config = ExecutorConfig::from(&planner_config);
-        let metrics = CompactionMetrics::new();
-        let executor =
-            CompactionExecutor::new(catalog_manager.clone(), executor_config, metrics.clone());
+    let files_after = manifest_reader
+        .get_snapshot_files(&load_table().await)
+        .await?;
+    let rows_after: u64 = files_after.iter().map(|f| f.record_count).sum();
+    assert!(
+        files_after.len() < files_before.len(),
+        "compaction must reduce the live file count ({} -> {})",
+        files_before.len(),
+        files_after.len()
+    );
+    assert_eq!(rows_after, rows_before, "compaction must not lose rows");
 
-        // Execute compaction
-        for candidate in candidates {
-            log::info!(
-                "Executing compaction for {}/{}/{}",
-                candidate.tenant_id,
-                candidate.dataset_id,
-                candidate.table_name
-            );
-
-            match executor.execute_candidate(candidate).await {
-                Ok(result) => {
-                    log::info!("Compaction result: {:?}", result.status);
-                    log::info!("Duration: {:?}", result.duration);
-
-                    if let Some(error) = result.error {
-                        log::warn!("Compaction had error: {}", error);
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Compaction execution failed: {}", e);
-                    // This is acceptable in test environment
-                }
-            }
-        }
-
-        // Check metrics
-        let summary = metrics.summary();
-        log::info!("Compaction metrics:");
-        log::info!("  Jobs started: {}", summary.jobs_started);
-        log::info!("  Jobs succeeded: {}", summary.jobs_succeeded);
-        log::info!("  Jobs failed: {}", summary.jobs_failed);
-        log::info!("  Conflicts detected: {}", summary.conflicts_detected);
-    }
+    // With the table compacted below the threshold, re-planning finds
+    // nothing — the planner no longer flags every table forever.
+    let candidates = planner.plan().await?;
+    assert!(
+        candidates.is_empty(),
+        "compacted table must not be re-flagged: {candidates:?}"
+    );
 
     log::info!("Basic compaction test completed successfully");
 


### PR DESCRIPTION
## Summary

Closes #559 (epic #563): `group_files_by_partition` fabricated 15 synthetic 5 MB files under a hardcoded `"all"` partition, so `evaluate_partition` ran on fake stats and **every table with a snapshot was a compaction candidate every cycle**. The only brake on endless re-compaction was the executor's ≤1-real-file short-circuit — the planner's thresholds were dead relative to real data.

### Design

- The planner now reads the **live data file set from the current snapshot's manifests** (`ManifestReader::get_snapshot_files`), so the file-count / min-size / average-vs-target thresholds operate on reality. Empty and already-compacted tables stop being flagged; small-file tables are flagged for what they actually contain.
- Files stay grouped under the single `"all"` key **on purpose**: the executor rewrites and commits the whole table (a `replace` snapshot), so `partition_id = "all"` keys the lease at exactly the granularity the executor mutates — closing the issue's latent race (two per-partition leases on one table would both full-table-rewrite and fight at commit). This constraint is now documented at the source; partition-scoped planning must land together with a partition-scoped rewrite/`overwrite` commit (follow-up).

### Test honesty

`test_basic_compaction` previously tolerated every failure and silently exercised nothing: its hand-built batch never matched the traces schema (writes failed and were warned away) and the in-memory config had no tenants for the planner to iterate (planning always returned zero candidates). It now:
- writes 5 real small files through the shared data generator,
- asserts the planner reports the **real** file count in exactly one whole-table candidate,
- asserts compaction succeeds, reduces the live file set, and loses no rows,
- asserts the compacted table is **not re-flagged** by a subsequent plan.

(`tests-integration` now enables `common`'s `testing` feature for the config builder.)

### Tests

Compactor unit suite 92/92 (planner threshold tests unchanged — `evaluate_partition`'s signature kept); basic/logs/metrics/concurrent/multi-instance/partition-drop/snapshot-expiration compaction suites all green; workspace clippy clean.

Closes #559
Part of #563