### PR TITLE
fix(compactor): renew leases during long compactions and use the DB clock

### DIFF
--- a/src/common/src/catalog.rs
+++ b/src/common/src/catalog.rs
@@ -1486,16 +1486,19 @@ impl Catalog {
                 Ok(result.rows_affected() > 0)
             }
             Catalog::Postgres(pool) => {
+                // Use the database clock (NOW()) for both the expiry stamp
+                // and the takeover comparison so that clock skew between
+                // compactor instances cannot steal a live lease.
                 let stmt = r#"
                 INSERT INTO compactor_leases
                     (tenant_id, dataset_id, table_name, partition_id, holder_id, acquired_at, expires_at)
-                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                VALUES ($1, $2, $3, $4, $5, NOW(), NOW() + $6 * INTERVAL '1 millisecond')
                 ON CONFLICT (tenant_id, dataset_id, table_name, partition_id) DO UPDATE
                 SET holder_id   = EXCLUDED.holder_id,
                     acquired_at = EXCLUDED.acquired_at,
                     expires_at  = EXCLUDED.expires_at,
                     renewed_at  = NULL
-                WHERE compactor_leases.expires_at < $8
+                WHERE compactor_leases.expires_at < NOW()
                 "#;
                 let result = query(stmt)
                     .bind(tenant_id)
@@ -1503,9 +1506,7 @@ impl Catalog {
                     .bind(table_name)
                     .bind(partition_id)
                     .bind(holder_id)
-                    .bind(now)
-                    .bind(expires_at)
-                    .bind(now) // WHERE clause: existing lease must be expired
+                    .bind(ttl_ms)
                     .execute(pool)
                     .await?;
                 Ok(result.rows_affected() > 0)
@@ -1556,19 +1557,19 @@ impl Catalog {
                 Ok(result.rows_affected() > 0)
             }
             Catalog::Postgres(pool) => {
+                // DB clock, matching try_acquire (clock-skew immunity).
                 let stmt = r#"
                 UPDATE compactor_leases
-                SET expires_at = $1,
-                    renewed_at = $2
-                WHERE tenant_id    = $3
-                  AND dataset_id   = $4
-                  AND table_name   = $5
-                  AND partition_id = $6
-                  AND holder_id    = $7
+                SET expires_at = NOW() + $1 * INTERVAL '1 millisecond',
+                    renewed_at = NOW()
+                WHERE tenant_id    = $2
+                  AND dataset_id   = $3
+                  AND table_name   = $4
+                  AND partition_id = $5
+                  AND holder_id    = $6
                 "#;
                 let result = query(stmt)
-                    .bind(expires_at)
-                    .bind(now)
+                    .bind(ttl_ms)
                     .bind(tenant_id)
                     .bind(dataset_id)
                     .bind(table_name)
@@ -1652,8 +1653,7 @@ impl Catalog {
                 Ok(result.rows_affected())
             }
             Catalog::Postgres(pool) => {
-                let result = query("DELETE FROM compactor_leases WHERE expires_at < $1")
-                    .bind(now)
+                let result = query("DELETE FROM compactor_leases WHERE expires_at < NOW()")
                     .execute(pool)
                     .await?;
                 Ok(result.rows_affected())

--- a/src/compactor/src/flight.rs
+++ b/src/compactor/src/flight.rs
@@ -189,12 +189,15 @@ impl FlightService for CompactorFlightService {
                 for candidate in candidates {
                     match self.lease_manager.try_acquire_default(&candidate).await {
                         Ok(Some(lease)) => {
+                            // Keep the lease alive for jobs longer than the TTL.
+                            let renewal = self.lease_manager.spawn_renewal(lease.clone());
                             match self.executor.execute_candidate(candidate).await {
                                 Ok(_) => started += 1,
                                 Err(e) => {
                                     tracing::error!("compact_now execution failed: {e:#}");
                                 }
                             }
+                            drop(renewal);
                             if let Err(e) = self.lease_manager.release(&lease).await {
                                 tracing::warn!("compact_now lease release failed: {e:#}");
                             }

--- a/src/compactor/src/lease/mod.rs
+++ b/src/compactor/src/lease/mod.rs
@@ -77,6 +77,18 @@ impl From<CompactorLease> for Lease {
     }
 }
 
+/// Keeps a lease's background renewal task alive; dropping the guard
+/// stops renewal (see [`LeaseManager::spawn_renewal`]).
+pub struct LeaseRenewalGuard {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for LeaseRenewalGuard {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// Manages distributed compaction leases via the shared SQL catalog.
 ///
 /// Create one `LeaseManager` per compactor instance and reuse it across
@@ -205,6 +217,55 @@ impl LeaseManager {
         }
     }
 
+    /// Keep a lease alive while a long-running compaction executes.
+    ///
+    /// Spawns a background task renewing the lease every `ttl / 3`; the
+    /// task stops when the returned guard is dropped. Without this, any
+    /// compaction longer than the lease TTL (default 300s) silently lost
+    /// its lease mid-run and a second instance started a duplicate
+    /// full-table rewrite (issue #560).
+    ///
+    /// A failed renewal (lease stolen, catalog unreachable) is logged
+    /// loudly but does not abort the job: the Iceberg CAS commit plus
+    /// post-commit verification still guarantee only one commit wins —
+    /// the lease exists to avoid wasted duplicate work, not correctness.
+    pub fn spawn_renewal(&self, lease: Lease) -> LeaseRenewalGuard {
+        let manager = self.clone();
+        let ttl = self.default_ttl;
+        let renew_every = (ttl / 3).max(Duration::from_secs(1));
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(renew_every);
+            // The first tick fires immediately; the lease was just
+            // acquired, so skip it.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                match manager.renew(&lease, ttl).await {
+                    Ok(()) => {
+                        tracing::debug!(
+                            tenant_id = %lease.tenant_id,
+                            table_name = %lease.table_name,
+                            partition_id = %lease.partition_id,
+                            "Renewed compaction lease"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            tenant_id = %lease.tenant_id,
+                            table_name = %lease.table_name,
+                            partition_id = %lease.partition_id,
+                            error = %e,
+                            "Failed to renew compaction lease; a concurrent \
+                             instance may start duplicate work (the Iceberg \
+                             CAS commit still protects correctness)"
+                        );
+                    }
+                }
+            }
+        });
+        LeaseRenewalGuard { handle }
+    }
+
     /// Release a lease explicitly after compaction completes.
     ///
     /// If the lease was stolen (another instance took it over), this is a no-op
@@ -290,6 +351,45 @@ mod tests {
                 avg_file_size_bytes: 204_800,
             },
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn renewal_keeps_lease_held_past_its_ttl() {
+        let catalog = Arc::new(make_catalog().await);
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        // 900ms TTL -> renewal every 300ms... but spawn_renewal floors the
+        // interval at 1s, so use a 3s TTL for a meaningful renewal at 1s.
+        let ttl = Duration::from_secs(3);
+        let mgr1 = LeaseManager::new(catalog.clone(), id1, ttl);
+        let mgr2 = LeaseManager::new(catalog.clone(), id2, ttl);
+        let cand = make_candidate("renewal-test");
+
+        let lease = mgr1
+            .try_acquire_default(&cand)
+            .await
+            .unwrap()
+            .expect("instance 1 acquires");
+        let renewal = mgr1.spawn_renewal(lease.clone());
+
+        // Sleep past the original TTL: the renewal task must have
+        // extended the lease, so instance 2 still cannot take it.
+        tokio::time::sleep(ttl + Duration::from_millis(500)).await;
+        let steal = mgr2.try_acquire_default(&cand).await.unwrap();
+        assert!(
+            steal.is_none(),
+            "renewed lease must not be stolen after the original TTL"
+        );
+
+        // Stop renewing: after the TTL elapses the lease expires and
+        // instance 2 takes over.
+        drop(renewal);
+        tokio::time::sleep(ttl + Duration::from_millis(500)).await;
+        let steal = mgr2.try_acquire_default(&cand).await.unwrap();
+        assert!(
+            steal.is_some(),
+            "expired lease must be claimable once renewal stops"
+        );
     }
 
     #[tokio::test]

--- a/src/compactor/src/main.rs
+++ b/src/compactor/src/main.rs
@@ -368,6 +368,9 @@ async fn main() -> Result<()> {
                                                     candidate.partition_id
                                                 );
 
+                                                // Keep the lease alive for jobs longer than the TTL.
+                                                let renewal = lease_manager.spawn_renewal(lease.clone());
+
                                                 match executor.execute_candidate(candidate).await {
                                                     Ok(result) => {
                                                         tracing::info!(
@@ -396,6 +399,7 @@ async fn main() -> Result<()> {
                                                 }
 
                                                 // Release the lease regardless of job outcome
+                                                drop(renewal);
                                                 if let Err(e) = lease_manager.release(&lease).await {
                                                     tracing::warn!("Failed to release lease: {e:#}");
                                                 }


### PR DESCRIPTION
## Summary

Closes #560 (epic #563): compaction leases were never renewed outside tests. Any job longer than the 300s TTL silently lost its lease mid-run, and a second instance acquired it and started a duplicate full-table rewrite — bounded by the Iceberg CAS + post-commit verify (one commit wins, the loser conflicts into a no-op), but pure wasted CPU/IO and thrash.

### Design

- **`LeaseManager::spawn_renewal(lease)`** keeps a lease alive while a job runs: a background task renews every `ttl/3` (floored at 1s) and stops when the returned guard drops. Both execution sites — the background compaction loop and the `compact_now` Flight action — hold a renewal guard across `execute_candidate`. A failed renewal (stolen lease, catalog unreachable) is logged loudly but does not abort the job: the CAS commit protects correctness; the lease exists to prevent duplicate work.
- **DB clock on PostgreSQL**: lease acquisition, takeover comparison (`WHERE expires_at < NOW()`), renewal, and stale-lease expiry now use the database's `NOW()` instead of each instance's `Utc::now()`, so clock skew between compactor instances can no longer steal a live lease. SQLite keeps the process clock — it's embedded, there is no second clock to skew against.
- **Fencing tokens** remain a follow-up (noted from the issue); the post-commit snapshot verification already downgrades a lost lease from a correctness problem to an efficiency one.

### Tests

- New `renewal_keeps_lease_held_past_its_ttl`: with a 3s TTL, a renewed lease survives past its original TTL against a competing instance, and expires promptly once the guard drops (real end-to-end through the catalog).
- Compactor suite 93/93; multi-instance and concurrent-writes integration suites green; workspace clippy clean.

Closes #560
Part of #563