### PR TITLE
fix(writer): harden the write path against panics and silent task death

### DIFF
--- a/src/common/src/wal/mod.rs
+++ b/src/common/src/wal/mod.rs
@@ -211,10 +211,12 @@ impl WalSegment {
         dataset_id: &str,
         metadata: Option<String>,
     ) -> Result<Uuid> {
+        // A clock before the epoch yields timestamp 0 rather than a panic
+        // on the hot write path.
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
 
         // Write data to data file first
         let data_offset = self.data_size;
@@ -563,7 +565,9 @@ impl Wal {
         } else {
             all_segments
                 .last()
-                .expect("segments list should not be empty")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("WAL segment list empty despite discovered segment ids")
+                })?
                 .clone()
         };
 
@@ -584,6 +588,37 @@ impl Wal {
     /// Stable identity of this WAL directory (see the `writer_id` field).
     pub fn writer_id(&self) -> &str {
         &self.writer_id
+    }
+
+    /// Move a poison entry aside: persist its raw payload to
+    /// `<wal_dir>/dead-letter/<entry_id>.bin` (fsynced) and mark the
+    /// entry processed so it stops blocking the processing loop. The
+    /// data is preserved for manual inspection/replay rather than lost.
+    ///
+    /// Returns the dead-letter file path.
+    pub async fn dead_letter(&self, entry_id: Uuid) -> Result<PathBuf> {
+        let entry = self
+            .get_entries()
+            .await?
+            .into_iter()
+            .find(|e| e.id == entry_id)
+            .ok_or_else(|| anyhow::anyhow!("WAL entry {entry_id} not found"))?;
+        let data = self.read_entry_data(&entry).await?;
+
+        let dir = self.config.wal_dir.join("dead-letter");
+        create_dir_all(&dir).await?;
+        let path = dir.join(format!("{}.bin", entry_id.simple()));
+        let mut file = File::create(&path)
+            .await
+            .with_context(|| format!("Failed to create dead-letter file {}", path.display()))?;
+        file.write_all(&data).await?;
+        file.flush().await?;
+        file.sync_all()
+            .await
+            .context("Failed to fsync dead-letter file")?;
+
+        self.mark_processed(entry_id).await?;
+        Ok(path)
     }
 
     /// Load the persisted writer id from `writer.id`, creating (and
@@ -1132,6 +1167,41 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn dead_letter_preserves_payload_and_marks_processed() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            max_segment_size: 1024,
+            max_buffer_entries: 10,
+            flush_interval_secs: 1,
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            retention_secs: 3600,
+            cleanup_interval_secs: 300,
+            compaction_threshold: 0.5,
+        };
+        let wal = Wal::new(config).await.unwrap();
+
+        let payload = b"poison payload".to_vec();
+        let entry_id = wal
+            .append(WalOperation::WriteTraces, payload.clone(), None)
+            .await
+            .unwrap();
+        wal.flush().await.unwrap();
+
+        let path = wal.dead_letter(entry_id).await.unwrap();
+        let preserved = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(preserved, payload, "payload must be preserved verbatim");
+
+        // The entry no longer blocks processing.
+        let unprocessed = wal.get_unprocessed_entries().await.unwrap();
+        assert!(
+            unprocessed.is_empty(),
+            "dead-lettered entry must be marked processed"
+        );
+    }
 
     #[tokio::test]
     async fn writer_id_is_stable_across_reopen() {

--- a/src/writer/src/flight_iceberg.rs
+++ b/src/writer/src/flight_iceberg.rs
@@ -55,15 +55,31 @@ impl IcebergWriterFlightService {
         let processor = self.processor.clone();
 
         let handle = tokio::spawn(async move {
+            const BASE_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(5);
+            const MAX_BACKOFF: tokio::time::Duration = tokio::time::Duration::from_secs(300);
+            let mut consecutive_failures: u32 = 0;
             loop {
                 let mut processor_guard = processor.lock().await;
-                if let Err(e) = processor_guard.process_pending_entries().await {
-                    tracing::error!(error = %e, "Background WAL processing error");
+                match processor_guard.process_pending_entries().await {
+                    Ok(()) => consecutive_failures = 0,
+                    Err(e) => {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        tracing::error!(
+                            error = %e,
+                            consecutive_failures,
+                            "Background WAL processing error"
+                        );
+                    }
                 }
                 drop(processor_guard);
 
-                // Process every 5 seconds
-                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                // Exponential backoff on repeated failures so a persistently
+                // failing catalog/store is not hammered every 5 seconds.
+                let delay = BASE_INTERVAL
+                    .saturating_mul(1u32 << consecutive_failures.min(6))
+                    .min(MAX_BACKOFF)
+                    .max(BASE_INTERVAL);
+                tokio::time::sleep(delay).await;
             }
         });
 

--- a/src/writer/src/main.rs
+++ b/src/writer/src/main.rs
@@ -201,12 +201,20 @@ async fn main() -> anyhow::Result<()> {
             tracing::error!(error = %e, "Flight server exited with error");
         }
     });
+    let mut flight_handle = flight_handle;
 
-    // Await shutdown signal
-    signal::ctrl_c()
-        .await
-        .context("Failed to listen for shutdown signal")?;
-    tracing::info!("Shutting down writer service");
+    // Await shutdown signal — or the Flight server dying. A writer whose
+    // ingest port is gone must exit (so the orchestrator restarts it)
+    // instead of idling as a zombie that accepts nothing.
+    tokio::select! {
+        result = signal::ctrl_c() => {
+            result.context("Failed to listen for shutdown signal")?;
+            tracing::info!("Shutting down writer service");
+        }
+        _ = &mut flight_handle => {
+            anyhow::bail!("Writer Flight server terminated unexpectedly; exiting so the process can be restarted");
+        }
+    }
 
     // Graceful shutdown: unregister Flight service
     flight_transport

--- a/src/writer/src/processor.rs
+++ b/src/writer/src/processor.rs
@@ -13,6 +13,11 @@ use uuid::Uuid;
 /// of the idempotency marker written with each commit (one uuid per entry).
 const MAX_ENTRIES_PER_COMMIT: usize = 1024;
 
+/// Consecutive failures after which an entry is dead-lettered: its raw
+/// payload is preserved under `<wal_dir>/dead-letter/` and the entry is
+/// marked processed so it stops blocking ingestion.
+const MAX_ENTRY_FAILURES: u32 = 10;
+
 /// WAL processor that reads entries and writes them to Iceberg tables
 /// Replaces the direct Parquet writing approach with transaction-based Iceberg writes
 pub struct WalProcessor {
@@ -21,6 +26,12 @@ pub struct WalProcessor {
     object_store: Arc<dyn ObjectStore>,
     // Cache of table writers per tenant/table combination
     table_writers: HashMap<String, IcebergTableWriter>,
+    /// Consecutive processing failures per entry. Entries that keep
+    /// failing are dead-lettered so one poison entry cannot wedge the
+    /// processing loop forever (in-memory: a restart grants a fresh set
+    /// of attempts, which is fine — dead-lettering only needs to happen
+    /// eventually).
+    entry_failures: HashMap<Uuid, u32>,
 }
 
 impl WalProcessor {
@@ -35,6 +46,7 @@ impl WalProcessor {
             catalog_manager,
             object_store,
             table_writers: HashMap::new(),
+            entry_failures: HashMap::new(),
         }
     }
 
@@ -77,8 +89,26 @@ impl WalProcessor {
                 continue;
             }
 
-            let (tenant_id, dataset_id, table_name) = self.determine_target_table(&entry)?;
-            let batch = self.deserialize_entry_data(&entry).await?;
+            // A poison entry (unroutable or undeserializable) must not
+            // abort the whole cycle: record the failure, skip it this
+            // round, and dead-letter it once it exhausts its attempts.
+            let routed = match self.determine_target_table(&entry) {
+                Ok(routed) => routed,
+                Err(e) => {
+                    tracing::warn!(entry_id = %entry.id, error = %e, "Failed to route WAL entry");
+                    self.record_entry_failure(entry.id).await;
+                    continue;
+                }
+            };
+            let batch = match self.deserialize_entry_data(&entry).await {
+                Ok(batch) => batch,
+                Err(e) => {
+                    tracing::warn!(entry_id = %entry.id, error = %e, "Failed to deserialize WAL entry");
+                    self.record_entry_failure(entry.id).await;
+                    continue;
+                }
+            };
+            let (tenant_id, dataset_id, table_name) = routed;
 
             grouped_entries
                 .entry((tenant_id, dataset_id, table_name))
@@ -90,11 +120,15 @@ impl WalProcessor {
         // process_batch_for_table, interleaved with commits to preserve
         // the idempotency-marker invariant.
         for ((tenant_id, dataset_id, table_name), entries) in grouped_entries {
+            let group_ids: Vec<Uuid> = entries.iter().map(|(id, _)| *id).collect();
             match self
                 .process_batch_for_table(&tenant_id, &dataset_id, &table_name, entries)
                 .await
             {
                 Ok(processed_ids) => {
+                    for entry_id in &processed_ids {
+                        self.entry_failures.remove(entry_id);
+                    }
                     tracing::debug!(
                         entry_count = processed_ids.len(),
                         tenant_id = %tenant_id,
@@ -104,6 +138,9 @@ impl WalProcessor {
                 }
                 Err(e) => {
                     tracing::error!(tenant_id = %tenant_id, table_name = %table_name, error = %e, "Failed to process batch for table");
+                    for entry_id in group_ids {
+                        self.record_entry_failure(entry_id).await;
+                    }
                 }
             }
         }
@@ -200,6 +237,34 @@ impl WalProcessor {
         }
 
         Ok(processed_ids)
+    }
+
+    /// Record a processing failure for an entry, dead-lettering it once
+    /// it exhausts its attempts.
+    async fn record_entry_failure(&mut self, entry_id: Uuid) {
+        let failures = self.entry_failures.entry(entry_id).or_insert(0);
+        *failures += 1;
+        if *failures < MAX_ENTRY_FAILURES {
+            return;
+        }
+        match self.wal.dead_letter(entry_id).await {
+            Ok(path) => {
+                tracing::error!(
+                    entry_id = %entry_id,
+                    failures = *failures,
+                    path = %path.display(),
+                    "WAL entry exhausted its retries; payload preserved in the                      dead-letter directory and entry marked processed"
+                );
+                self.entry_failures.remove(&entry_id);
+            }
+            Err(e) => {
+                tracing::error!(
+                    entry_id = %entry_id,
+                    error = %e,
+                    "Failed to dead-letter WAL entry; it will be retried"
+                );
+            }
+        }
     }
 
     /// Determine which tenant, dataset, and table an entry should go to
@@ -437,6 +502,54 @@ mod tests {
         assert_eq!(tenant, "globex");
         assert_eq!(dataset, "staging");
         assert_eq!(table, "logs");
+    }
+
+    #[tokio::test]
+    async fn poison_entry_is_dead_lettered_after_exhausting_retries() {
+        let temp_dir = tempdir().unwrap();
+        let wal_config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            max_segment_size: 1024 * 1024,
+            max_buffer_entries: 1000,
+            flush_interval_secs: 5,
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            retention_secs: 3600,
+            cleanup_interval_secs: 300,
+            compaction_threshold: 0.5,
+        };
+        let wal = Arc::new(Wal::new(wal_config).await.unwrap());
+        let catalog_manager = Arc::new(CatalogManager::new_in_memory().await.unwrap());
+        let object_store = Arc::new(InMemory::new());
+
+        // Garbage bytes: deserialization fails on every attempt. Before
+        // the dead-letter path this aborted every processing cycle
+        // forever.
+        let entry_id = wal
+            .append(WalOperation::WriteTraces, b"not arrow ipc".to_vec(), None)
+            .await
+            .unwrap();
+        wal.flush().await.unwrap();
+
+        let mut processor = WalProcessor::new(wal.clone(), catalog_manager, object_store);
+        for _ in 0..super::MAX_ENTRY_FAILURES {
+            processor
+                .process_pending_entries()
+                .await
+                .expect("a poison entry must not abort the cycle");
+        }
+
+        // The entry is out of the way and its payload is preserved.
+        assert!(
+            wal.get_unprocessed_entries().await.unwrap().is_empty(),
+            "poison entry must be dead-lettered and marked processed"
+        );
+        let dead_letter_path = temp_dir
+            .path()
+            .join("dead-letter")
+            .join(format!("{}.bin", entry_id.simple()));
+        let preserved = tokio::fs::read(&dead_letter_path).await.unwrap();
+        assert_eq!(preserved, b"not arrow ipc");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #562, the last open task of epic #563's original findings: several write-path failure modes either panicked or wedged silently.

### Changes

- **Zombie writer**: when the Flight server task died (bind/serve error), the error was logged inside the spawned task while `main` kept waiting on ctrl_c with a dead ingest port. `main` now `select!`s on the server task and exits with an error so the orchestrator restarts the process.
- **Poison entries**: an unroutable or undeserializable WAL entry aborted every processing cycle at the grouping stage (`?` on deserialize) — one bad entry wedged ingestion forever. Failures are now tracked per entry; after 10 attempts the raw payload is preserved (fsynced) under `<wal_dir>/dead-letter/<id>.bin` via the new `Wal::dead_letter` and the entry is marked processed — unblocking the loop without losing the bytes.
- **Backoff**: the background processing loop retried every 5s regardless of outcome; it now backs off exponentially (5s doubling to a 5-minute cap) on consecutive failures, resetting on success.
- **Panic removal**: WAL append survives a pre-epoch clock (timestamp 0 instead of unwrap panic); the segment-load `expect` became a proper error.

The `Arc<Mutex<WalProcessor>>` throughput ceiling noted in the issue is a performance concern, not a panic/silent-death one — left for a dedicated change.

### Tests

- `Wal::dead_letter` preserves the payload verbatim and marks the entry processed.
- Processor-level: a garbage-bytes entry no longer aborts cycles and lands in dead-letter after exhausting retries, leaving the WAL empty of unprocessed entries.
- WAL replay idempotency suite stays green (3/3); `common` WAL suite 6/6; writer suite 18/18; workspace clippy clean.

Closes #562
Part of #563