### PR TITLE
fix(iceberg): load fresh table metadata in ensure_table instead of caching handles

### DIFF
--- a/src/common/src/iceberg/table_manager.rs
+++ b/src/common/src/iceberg/table_manager.rs
@@ -1,6 +1,5 @@
-//! Manages Iceberg table lifecycle -- loading, creating, and caching tables.
+//! Manages Iceberg table lifecycle -- loading and creating tables.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -8,53 +7,40 @@ use iceberg_rust::catalog::Catalog as IcebergCatalog;
 use iceberg_rust::catalog::create::CreateTableBuilder;
 use iceberg_rust::catalog::tabular::Tabular;
 use iceberg_rust::table::Table;
-use tokio::sync::RwLock;
 
 use super::names;
 use super::schemas;
 
-/// Manages the lifecycle of Iceberg tables with caching.
+/// Manages the lifecycle of Iceberg tables.
 ///
 /// Provides `ensure_table()` which loads an existing table or creates it
-/// if it doesn't exist. Tables are cached by (tenant_id, dataset_id, table_name).
+/// if it doesn't exist. Every call loads fresh metadata from the catalog:
+/// a `Table` handle carries table metadata as of load time, so handing out
+/// long-lived cached handles would hide snapshots committed by other
+/// writers (issue #537). Callers that need a current view must call
+/// `ensure_table` again rather than hold on to an old handle.
 pub struct IcebergTableManager {
     catalog: Arc<dyn IcebergCatalog>,
-    cache: RwLock<HashMap<(String, String, String), Table>>,
 }
 
 impl IcebergTableManager {
     /// Create from catalog reference.
     pub fn new(catalog: Arc<dyn IcebergCatalog>) -> Self {
-        Self {
-            catalog,
-            cache: RwLock::new(HashMap::new()),
-        }
+        Self { catalog }
     }
 
     /// Load an existing table or create it if it doesn't exist.
     ///
     /// This method:
-    /// 1. Checks the in-memory cache
-    /// 2. Tries `load_tabular()` -- single catalog round-trip
-    /// 3. On NotFound -> creates the table with schema from `schemas::TableSchema`
-    /// 4. Handles `AlreadyExists` gracefully (concurrent callers)
-    /// 5. Caches the result
+    /// 1. Tries `load_tabular()` -- single catalog round-trip, fresh metadata
+    /// 2. On NotFound -> creates the table with schema from `schemas::TableSchema`
+    /// 3. Handles `AlreadyExists` gracefully (concurrent callers)
     pub async fn ensure_table(
         &self,
         tenant_slug: &str,
         dataset_slug: &str,
         table_name: &str,
     ) -> Result<Table> {
-        let cache_key = (
-            tenant_slug.to_string(),
-            dataset_slug.to_string(),
-            table_name.to_string(),
-        );
-
-        if let Some(table) = self.cache.read().await.get(&cache_key).cloned() {
-            return Ok(table);
-        }
-
         let ident = names::build_table_identifier(tenant_slug, dataset_slug, table_name);
         if let Ok(tabular) = self.catalog.clone().load_tabular(&ident).await {
             let table = match tabular {
@@ -67,7 +53,6 @@ impl IcebergTableManager {
                 }
             };
 
-            self.cache.write().await.insert(cache_key, table.clone());
             return Ok(table);
         }
 
@@ -162,16 +147,6 @@ impl IcebergTableManager {
             }
         };
 
-        self.cache.write().await.insert(cache_key, table.clone());
         Ok(table)
-    }
-
-    /// Invalidate a cached table, forcing reload on next access.
-    pub async fn invalidate(&self, tenant_id: &str, dataset_id: &str, table_name: &str) {
-        self.cache.write().await.remove(&(
-            tenant_id.to_string(),
-            dataset_id.to_string(),
-            table_name.to_string(),
-        ));
     }
 }

--- a/src/common/tests/iceberg_integration.rs
+++ b/src/common/tests/iceberg_integration.rs
@@ -27,3 +27,58 @@ async fn test_iceberg_sql_catalog_basic_operations() {
     // For full namespace operations testing, we would need to use the git version
     // of iceberg-rust which requires upgrading DataFusion from v47 to v50+.
 }
+
+/// Regression test for #537: `ensure_table` must reflect commits made through
+/// other handles (writer appends, compactor replaces) instead of returning a
+/// point-in-time cached `Table` whose metadata predates them.
+#[tokio::test]
+async fn ensure_table_reflects_commits_made_through_other_handles() {
+    use common::iceberg::table_manager::IcebergTableManager;
+    use iceberg_rust::catalog::tabular::Tabular;
+
+    let config = SchemaConfig {
+        catalog_type: "sql".to_string(),
+        catalog_uri: "sqlite::memory:".to_string(),
+        default_schemas: common::config::DefaultSchemas::default(),
+    };
+    let catalog = create_catalog(config).await.unwrap();
+    let manager = IcebergTableManager::new(catalog.clone());
+
+    // First call creates the table.
+    manager
+        .ensure_table("tenant", "dataset", "logs")
+        .await
+        .unwrap();
+
+    // Commit a metadata change through an independent fresh handle, the way
+    // the writer or compactor would from another task or process.
+    let ident = common::iceberg::names::build_table_identifier("tenant", "dataset", "logs");
+    let mut fresh = match catalog.clone().load_tabular(&ident).await.unwrap() {
+        Tabular::Table(table) => table,
+        _ => panic!("expected a table for {ident}"),
+    };
+    fresh
+        .new_transaction(None)
+        .update_properties(vec![(
+            "signaldb.test-marker".to_string(),
+            "committed".to_string(),
+        )])
+        .commit()
+        .await
+        .unwrap();
+
+    // A second ensure_table call must observe that commit.
+    let observed = manager
+        .ensure_table("tenant", "dataset", "logs")
+        .await
+        .unwrap();
+    assert_eq!(
+        observed
+            .metadata()
+            .properties
+            .get("signaldb.test-marker")
+            .map(String::as_str),
+        Some("committed"),
+        "ensure_table returned a stale handle that misses a committed update"
+    );
+}

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -35,11 +35,11 @@ impl ParquetRewriter {
         Self { catalog_manager }
     }
 
-    /// Load a table with fresh metadata, bypassing the `ensure_table` cache.
+    /// Load a table with fresh metadata, without creating it if missing.
     ///
-    /// The `IcebergTableManager` cache returns stale `Table` handles that do
-    /// not reflect snapshots committed after the handle was cached; compaction
-    /// must always operate on current metadata.
+    /// Unlike `ensure_table`, this never creates the table: compaction must
+    /// only operate on tables that already exist, and always on current
+    /// metadata.
     pub async fn load_fresh_table(
         &self,
         tenant_id: &str,


### PR DESCRIPTION
## Summary

Closes #537: `IcebergTableManager` cached `Table` handles by `(tenant, dataset, table)` forever, so `ensure_table()` returned metadata **as of caching time**. Snapshots committed afterwards — by the writer's INSERT path, the compactor, or any other committer — were invisible through the returned handle. During epic #432 this silently turned all compaction into a no-op (`current_snapshot_id = None` on a table with thousands of committed rows) and let integration tests pass vacuously.

### Fix

- Drop the cache: every `ensure_table()` call now does a fresh `load_tabular()` (single catalog round-trip; the SQL catalog maintains its own metadata bookkeeping). The create-on-NotFound path and concurrent-creation idempotency are unchanged.
- Remove `invalidate()` — it existed only to poke the now-removed cache and had no callers.
- Update the compactor's `load_fresh_table` docs, which described the stale-cache workaround; the method remains as the load-without-create path compaction needs.

### Tests

- New regression test `ensure_table_reflects_commits_made_through_other_handles`: create table via `ensure_table`, commit a metadata update through an independent fresh handle (as the writer/compactor do), and assert a second `ensure_table` observes it. Failed before the fix (stale handle), passes after.
- `common`, `compactor`, `writer` suites green; workspace clippy clean; cargo machete/deny clean.