### PR TITLE
feat(auth): per-tenant query rate limits and API key/dataset quotas

### DIFF
--- a/.claude/skills/configuration/SKILL.md
+++ b/.claude/skills/configuration/SKILL.md
@@ -72,8 +72,18 @@ Env: `SIGNALDB_SCHEMA_CATALOG_TYPE`, `SIGNALDB_SCHEMA_CATALOG_URI`
 ### Authentication
 ```toml
 [auth]
-enabled = true
 admin_api_key = "sk-admin-key"
+
+# Default per-tenant rate limits and quotas; unset fields = unlimited.
+# Rate limits return 429 / RESOURCE_EXHAUSTED; count quotas return
+# 429 with error code "quota_exceeded".
+[auth.default_limits]
+max_ingest_requests_per_sec = 100
+max_ingest_bytes_per_sec = 10485760   # 10 MiB/s
+max_query_requests_per_sec = 50       # router HTTP query API
+max_api_keys = 10                     # active (non-revoked) keys
+max_datasets = 25
+burst_seconds = 2.0
 
 [[auth.tenants]]
 id = "acme"
@@ -95,7 +105,15 @@ dsn = "s3://acme-archive/signals"   # Per-dataset storage override
 [[auth.tenants.api_keys]]
 key = "sk-acme-prod-key-123"
 name = "Production Key"
+
+# Per-tenant override; takes precedence over [auth.default_limits]
+[auth.tenants.limits]
+max_ingest_requests_per_sec = 500
+max_query_requests_per_sec = 200
 ```
+
+Note: there is no `[auth] enabled` flag — authentication is always
+enforced on tenant-facing surfaces (#553).
 
 ### Compactor
 ```toml

--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -3,9 +3,10 @@ name: multi-tenancy
 description: SignalDB multi-tenancy and authentication - tenant model, auth flow, isolation layers, slug-based naming, API keys, admin API, and CLI. Use when working with tenant isolation, authentication, API keys, or dataset management.
 user-invocable: false
 sources:
-  - src/common/src/auth.rs
+  - src/common/src/auth/**
   - src/common/src/config/mod.rs
-  - src/router/src/admin.rs
+  - src/common/src/ratelimit.rs
+  - src/router/src/endpoints/admin.rs
 ---
 
 # SignalDB Multi-Tenancy & Authentication
@@ -59,7 +60,6 @@ All storage paths and Iceberg identifiers use **slugs** (URL-friendly), not raw 
 
 ```toml
 [auth]
-enabled = true
 admin_api_key = "sk-admin-key"
 
 [[auth.tenants]]
@@ -83,6 +83,24 @@ dsn = "s3://acme-archive/signals"    # Per-dataset override
 key = "sk-acme-prod-key-123"
 name = "Production Key"
 ```
+
+## Rate Limits & Quotas
+
+`TenantLimits` (`[auth.default_limits]`, overridable per tenant via
+`[[auth.tenants]].limits`; resolved by `AuthConfig::limits_for`). Unset
+fields mean unlimited; DB-provisioned tenants get the defaults.
+
+| Limit | Enforced at | On exceed |
+|-------|-------------|-----------|
+| `max_ingest_requests_per_sec` / `max_ingest_bytes_per_sec` | Acceptor (OTLP gRPC, remote_write) | 429 / RESOURCE_EXHAUSTED |
+| `max_query_requests_per_sec` | Router HTTP query API (`/tempo`, `/api/v1`) | 429 |
+| `max_api_keys` (active keys only) | Admin API key creation | 429 `quota_exceeded` |
+| `max_datasets` | Admin API dataset creation | 429 `quota_exceeded` |
+| `[querier] max_concurrent_queries_per_tenant` | Querier | query rejected |
+
+Token buckets per dimension (`common::ratelimit::TenantRateLimiter`);
+ingest and query budgets are independent. Storage quotas: not yet
+implemented (#610).
 
 ## Admin API (Router)
 
@@ -108,7 +126,8 @@ signaldb-cli dataset create --tenant acme --name production --slug prod
 | File | Purpose |
 |------|---------|
 | `src/common/src/config/mod.rs` | Tenant/dataset config structs |
-| `src/common/src/auth.rs` | Authenticator, TenantContext |
+| `src/common/src/auth/` | Authenticator, TenantContext, middleware |
 | `src/common/src/catalog_manager.rs` | Slug resolution |
-| `src/router/src/admin.rs` | Admin API endpoints |
+| `src/router/src/endpoints/admin.rs` | Admin API endpoints (incl. quota checks) |
+| `src/common/src/ratelimit.rs` | Per-tenant token-bucket rate limiter |
 | `src/signaldb-cli/` | CLI for tenant management |

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -28,12 +28,17 @@ dsn = "sqlite://.data/signaldb.db"
 # All SignalDB services must share the same value.
 # internal_service_key = "sk-internal-your-secret-key-here"
 
-# Default per-tenant ingest rate limits, applied to every tenant without an
-# explicit [auth.tenants.limits] override. Unset fields mean unlimited.
-# Exceeding a limit returns HTTP 429 / gRPC RESOURCE_EXHAUSTED (retryable).
+# Default per-tenant rate limits and quotas, applied to every tenant without
+# an explicit [auth.tenants.limits] override. Unset fields mean unlimited.
+# Exceeding a rate limit returns HTTP 429 / gRPC RESOURCE_EXHAUSTED
+# (retryable); exceeding a count quota returns HTTP 429 with error code
+# "quota_exceeded".
 # [auth.default_limits]
 # max_ingest_requests_per_sec = 100
 # max_ingest_bytes_per_sec = 10485760   # 10 MiB/s
+# max_query_requests_per_sec = 50       # router HTTP query API
+# max_api_keys = 10                     # active (non-revoked) keys per tenant
+# max_datasets = 25                     # datasets per tenant
 # burst_seconds = 2.0                   # burst allowance in seconds of budget
 
 # Tenant definitions with API keys and datasets
@@ -46,10 +51,13 @@ slug = "acme"
 name = "Acme Corporation"
 default_dataset = "production"  # Used when X-Dataset-ID header is not provided
 
-# Per-tenant rate-limit override (takes precedence over [auth.default_limits])
+# Per-tenant limits override (takes precedence over [auth.default_limits])
 # [auth.tenants.limits]
 # max_ingest_requests_per_sec = 500
 # max_ingest_bytes_per_sec = 52428800   # 50 MiB/s
+# max_query_requests_per_sec = 200
+# max_api_keys = 20
+# max_datasets = 50
 
 # API keys for the Acme tenant
 # Each key can have a descriptive name for auditing

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -528,7 +528,7 @@ pub struct TenantConfig {
     pub limits: Option<TenantLimits>,
 }
 
-/// Per-tenant ingest rate limits.
+/// Per-tenant rate limits and quotas.
 ///
 /// Unset fields mean unlimited. `burst_seconds` controls how many
 /// seconds' worth of budget a tenant may consume in a burst.
@@ -539,6 +539,12 @@ pub struct TenantLimits {
     pub max_ingest_requests_per_sec: Option<u32>,
     /// Maximum ingest payload bytes per second.
     pub max_ingest_bytes_per_sec: Option<u64>,
+    /// Maximum query API requests per second (router HTTP endpoints).
+    pub max_query_requests_per_sec: Option<u32>,
+    /// Maximum number of active (non-revoked) API keys.
+    pub max_api_keys: Option<u32>,
+    /// Maximum number of datasets.
+    pub max_datasets: Option<u32>,
     /// Burst allowance in seconds of budget (minimum 1.0).
     pub burst_seconds: f64,
 }
@@ -548,6 +554,9 @@ impl Default for TenantLimits {
         Self {
             max_ingest_requests_per_sec: None,
             max_ingest_bytes_per_sec: None,
+            max_query_requests_per_sec: None,
+            max_api_keys: None,
+            max_datasets: None,
             burst_seconds: 2.0,
         }
     }
@@ -561,7 +570,7 @@ impl Default for TenantLimits {
 /// Flight mesh is separately controlled by `internal_service_key`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AuthConfig {
-    /// Default ingest rate limits applied to every tenant without an
+    /// Default rate limits and quotas applied to every tenant without an
     /// explicit `limits` override. Unset fields mean unlimited.
     #[serde(default)]
     pub default_limits: TenantLimits,
@@ -580,6 +589,19 @@ pub struct AuthConfig {
     /// network.
     #[serde(default)]
     pub internal_service_key: Option<String>,
+}
+
+impl AuthConfig {
+    /// Effective limits for `tenant_id`: the tenant's `limits` override
+    /// when configured, otherwise `default_limits`. Tenants provisioned
+    /// at runtime (DB-backed) have no config entry and get the defaults.
+    pub fn limits_for(&self, tenant_id: &str) -> &TenantLimits {
+        self.tenants
+            .iter()
+            .find(|t| t.id == tenant_id)
+            .and_then(|t| t.limits.as_ref())
+            .unwrap_or(&self.default_limits)
+    }
 }
 
 fn default_self_monitoring_endpoint() -> String {

--- a/src/common/src/ratelimit.rs
+++ b/src/common/src/ratelimit.rs
@@ -2,7 +2,8 @@
 //!
 //! Token-bucket rate limiting keyed by tenant id, used by the ingest
 //! paths (OTLP gRPC, Prometheus remote_write) to keep one tenant from
-//! exhausting shared acceptor throughput.
+//! exhausting shared acceptor throughput, and by the router's query API
+//! to keep one tenant from monopolizing shared query capacity.
 //!
 //! Limits come from `[auth].default_limits` with optional per-tenant
 //! overrides (`[[auth.tenants]].limits`). Unset limits mean unlimited,
@@ -55,6 +56,7 @@ impl TokenBucket {
 struct TenantBuckets {
     requests: Option<TokenBucket>,
     bytes: Option<TokenBucket>,
+    query_requests: Option<TokenBucket>,
 }
 
 /// The dimension that rejected a request.
@@ -64,6 +66,8 @@ pub enum RateLimitKind {
     Requests,
     /// The per-tenant ingest bytes/second limit.
     Bytes,
+    /// The per-tenant query API requests/second limit.
+    QueryRequests,
 }
 
 /// Error returned when a tenant exceeds an ingest limit.
@@ -78,6 +82,7 @@ impl std::fmt::Display for RateLimitExceeded {
         let what = match self.kind {
             RateLimitKind::Requests => "request rate",
             RateLimitKind::Bytes => "ingest byte rate",
+            RateLimitKind::QueryRequests => "query request rate",
         };
         write!(
             f,
@@ -141,22 +146,7 @@ impl TenantRateLimiter {
             return Ok(());
         }
 
-        let entry = self
-            .buckets
-            .entry(tenant_id.to_string())
-            .or_insert_with(|| {
-                let burst_secs = limits.burst_seconds.max(1.0);
-                Mutex::new(TenantBuckets {
-                    requests: limits.max_ingest_requests_per_sec.map(|rps| {
-                        let rate = f64::from(rps);
-                        TokenBucket::new(rate, rate * burst_secs, now)
-                    }),
-                    bytes: limits.max_ingest_bytes_per_sec.map(|bps| {
-                        let rate = bps as f64;
-                        TokenBucket::new(rate, rate * burst_secs, now)
-                    }),
-                })
-            });
+        let entry = self.bucket_entry(tenant_id, now);
         let mut buckets = entry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -178,6 +168,63 @@ impl TenantRateLimiter {
             });
         }
         Ok(())
+    }
+
+    /// Record one query API request for the tenant, rejecting it if the
+    /// query request-rate budget is exhausted.
+    pub fn check_query(&self, tenant_id: &str) -> Result<(), RateLimitExceeded> {
+        self.check_query_at(tenant_id, Instant::now())
+    }
+
+    /// [`Self::check_query`] with an injectable clock for tests.
+    fn check_query_at(&self, tenant_id: &str, now: Instant) -> Result<(), RateLimitExceeded> {
+        let limits = self.limits_for(tenant_id);
+        if limits.max_query_requests_per_sec.is_none() {
+            return Ok(());
+        }
+
+        let entry = self.bucket_entry(tenant_id, now);
+        let mut buckets = entry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if let Some(bucket) = buckets.query_requests.as_mut()
+            && !bucket.try_acquire(1.0, now)
+        {
+            return Err(RateLimitExceeded {
+                tenant_id: tenant_id.to_string(),
+                kind: RateLimitKind::QueryRequests,
+            });
+        }
+        Ok(())
+    }
+
+    /// The tenant's bucket set, created from its limits on first use.
+    fn bucket_entry(
+        &self,
+        tenant_id: &str,
+        now: Instant,
+    ) -> dashmap::mapref::one::RefMut<'_, String, Mutex<TenantBuckets>> {
+        let limits = self.limits_for(tenant_id);
+        self.buckets
+            .entry(tenant_id.to_string())
+            .or_insert_with(|| {
+                let burst_secs = limits.burst_seconds.max(1.0);
+                Mutex::new(TenantBuckets {
+                    requests: limits.max_ingest_requests_per_sec.map(|rps| {
+                        let rate = f64::from(rps);
+                        TokenBucket::new(rate, rate * burst_secs, now)
+                    }),
+                    bytes: limits.max_ingest_bytes_per_sec.map(|bps| {
+                        let rate = bps as f64;
+                        TokenBucket::new(rate, rate * burst_secs, now)
+                    }),
+                    query_requests: limits.max_query_requests_per_sec.map(|qps| {
+                        let rate = f64::from(qps);
+                        TokenBucket::new(rate, rate * burst_secs, now)
+                    }),
+                })
+            })
     }
 }
 
@@ -215,6 +262,75 @@ mod tests {
         for _ in 0..10_000 {
             assert!(limiter.check_ingest("acme", 1_000_000).is_ok());
         }
+    }
+
+    #[test]
+    fn query_rate_is_enforced_and_refills() {
+        let limiter = limiter(
+            TenantLimits {
+                max_query_requests_per_sec: Some(4),
+                burst_seconds: 1.0,
+                ..Default::default()
+            },
+            vec![],
+        );
+
+        let start = Instant::now();
+        for _ in 0..4 {
+            assert!(limiter.check_query_at("acme", start).is_ok());
+        }
+        let denied = limiter.check_query_at("acme", start).unwrap_err();
+        assert_eq!(denied.kind, RateLimitKind::QueryRequests);
+
+        // Half a second refills two tokens.
+        let later = start + Duration::from_millis(500);
+        for _ in 0..2 {
+            assert!(limiter.check_query_at("acme", later).is_ok());
+        }
+        assert!(limiter.check_query_at("acme", later).is_err());
+    }
+
+    #[test]
+    fn query_rate_unlimited_when_unset_even_with_ingest_limits() {
+        let limiter = limiter(
+            TenantLimits {
+                max_ingest_requests_per_sec: Some(1),
+                burst_seconds: 1.0,
+                ..Default::default()
+            },
+            vec![],
+        );
+
+        let start = Instant::now();
+        // Exhaust the ingest budget; queries must be unaffected.
+        assert!(limiter.check_ingest_at("acme", 0, start).is_ok());
+        assert!(limiter.check_ingest_at("acme", 0, start).is_err());
+        for _ in 0..1_000 {
+            assert!(limiter.check_query_at("acme", start).is_ok());
+        }
+    }
+
+    #[test]
+    fn query_and_ingest_budgets_are_independent() {
+        let limiter = limiter(
+            TenantLimits {
+                max_ingest_requests_per_sec: Some(2),
+                max_query_requests_per_sec: Some(2),
+                burst_seconds: 1.0,
+                ..Default::default()
+            },
+            vec![],
+        );
+
+        let start = Instant::now();
+        assert!(limiter.check_query_at("acme", start).is_ok());
+        assert!(limiter.check_query_at("acme", start).is_ok());
+        assert!(limiter.check_query_at("acme", start).is_err());
+
+        // The exhausted query budget must not consume ingest tokens.
+        assert!(limiter.check_ingest_at("acme", 0, start).is_ok());
+        assert!(limiter.check_ingest_at("acme", 0, start).is_ok());
+        assert!(limiter.check_ingest_at("acme", 0, start).is_err());
     }
 
     #[test]

--- a/src/router/src/endpoints/admin.rs
+++ b/src/router/src/endpoints/admin.rs
@@ -423,6 +423,42 @@ pub async fn create_api_key<S: RouterState>(
         Ok(Some(_)) => {}
     }
 
+    // Enforce the tenant's API key quota (active keys only; revoked keys
+    // do not count against it).
+    if let Some(max_keys) = state.config().auth.limits_for(&tenant_id).max_api_keys {
+        match state.catalog().list_api_keys(&tenant_id).await {
+            Ok(keys) => {
+                let active = keys.iter().filter(|k| k.revoked_at.is_none()).count();
+                if active as u64 >= u64::from(max_keys) {
+                    return (
+                        StatusCode::TOO_MANY_REQUESTS,
+                        Json(
+                            serde_json::to_value(ApiError::new(
+                                "quota_exceeded",
+                                format!(
+                                    "Tenant '{tenant_id}' already has {active} active API keys \
+                                     (limit {max_keys}); revoke a key or raise max_api_keys"
+                                ),
+                            ))
+                            .unwrap(),
+                        ),
+                    )
+                        .into_response();
+                }
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(
+                        serde_json::to_value(ApiError::new("internal_error", e.to_string()))
+                            .unwrap(),
+                    ),
+                )
+                    .into_response();
+            }
+        }
+    }
+
     // Generate a new raw API key
     let raw_key = format!("sk-{}-{}", tenant_id, Uuid::new_v4());
     let key_hash = Authenticator::hash_api_key(&raw_key);
@@ -615,6 +651,42 @@ pub async fn create_dataset<S: RouterState>(
                 .into_response();
         }
         Ok(Some(_)) => {}
+    }
+
+    // Enforce the tenant's dataset quota.
+    if let Some(max_datasets) = state.config().auth.limits_for(&tenant_id).max_datasets {
+        match state.catalog().get_datasets(&tenant_id).await {
+            Ok(datasets) => {
+                let count = datasets.len();
+                if count as u64 >= u64::from(max_datasets) {
+                    return (
+                        StatusCode::TOO_MANY_REQUESTS,
+                        Json(
+                            serde_json::to_value(ApiError::new(
+                                "quota_exceeded",
+                                format!(
+                                    "Tenant '{tenant_id}' already has {count} datasets \
+                                     (limit {max_datasets}); delete a dataset or raise \
+                                     max_datasets"
+                                ),
+                            ))
+                            .unwrap(),
+                        ),
+                    )
+                        .into_response();
+                }
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(
+                        serde_json::to_value(ApiError::new("internal_error", e.to_string()))
+                            .unwrap(),
+                    ),
+                )
+                    .into_response();
+            }
+        }
     }
 
     match state
@@ -862,6 +934,128 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    async fn create_quota_test_state(limits: common::config::TenantLimits) -> InMemoryStateImpl {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let mut config = Configuration::default();
+        config.auth.default_limits = limits;
+        InMemoryStateImpl::new(catalog, config)
+    }
+
+    #[tokio::test]
+    async fn api_key_quota_rejects_creation_beyond_limit() {
+        let state = create_quota_test_state(common::config::TenantLimits {
+            max_api_keys: Some(2),
+            ..Default::default()
+        })
+        .await;
+        state
+            .catalog()
+            .upsert_tenant("acme", "Acme Corp", None, "database")
+            .await
+            .unwrap();
+        let app = admin_router(state);
+
+        let create = |name: &str| {
+            Request::builder()
+                .method("POST")
+                .uri("/tenants/acme/api-keys")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"name": "{name}"}}"#)))
+                .unwrap()
+        };
+
+        let mut first_key_id = String::new();
+        for name in ["one", "two"] {
+            let response = app.clone().oneshot(create(name)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+            if name == "one" {
+                let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+                    .await
+                    .unwrap();
+                let created: CreateApiKeyResponse = serde_json::from_slice(&body).unwrap();
+                first_key_id = created.id;
+            }
+        }
+
+        // Third key exceeds the quota.
+        let response = app.clone().oneshot(create("three")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let error: ApiError = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error.error, "quota_exceeded");
+
+        // Revoking a key frees quota: creation succeeds again.
+        let request = Request::builder()
+            .method("DELETE")
+            .uri(format!("/tenants/acme/api-keys/{first_key_id}"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let response = app.clone().oneshot(create("three")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn dataset_quota_rejects_creation_beyond_limit() {
+        let state = create_quota_test_state(common::config::TenantLimits {
+            max_datasets: Some(1),
+            ..Default::default()
+        })
+        .await;
+        state
+            .catalog()
+            .upsert_tenant("acme", "Acme Corp", None, "database")
+            .await
+            .unwrap();
+        let app = admin_router(state);
+
+        let create = |name: &str| {
+            Request::builder()
+                .method("POST")
+                .uri("/tenants/acme/datasets")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"name": "{name}"}}"#)))
+                .unwrap()
+        };
+
+        let response = app.clone().oneshot(create("production")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let response = app.clone().oneshot(create("staging")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let error: ApiError = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error.error, "quota_exceeded");
+    }
+
+    #[tokio::test]
+    async fn quotas_unlimited_by_default() {
+        let state = create_admin_test_state().await;
+        state
+            .catalog()
+            .upsert_tenant("acme", "Acme Corp", None, "database")
+            .await
+            .unwrap();
+        let app = admin_router(state);
+
+        for i in 0..20 {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/tenants/acme/api-keys")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"name": "key-{i}"}}"#)))
+                .unwrap();
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+        }
     }
 
     #[tokio::test]

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -5,9 +5,10 @@ use axum::{
     response::IntoResponse,
     routing::{delete, get, post, put},
 };
-use common::auth::{Authenticator, admin_auth_middleware, auth_middleware};
+use common::auth::{Authenticator, TenantContext, admin_auth_middleware, auth_middleware};
 use common::catalog::Catalog;
 use common::config::Configuration;
+use common::ratelimit::TenantRateLimiter;
 use std::sync::Arc;
 
 pub mod discovery;
@@ -108,6 +109,24 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
     let auth_layer =
         middleware::from_fn(move |req, next| auth_middleware(authenticator.clone(), req, next));
 
+    // Per-tenant query request-rate limiting, applied after authentication
+    // (it reads the TenantContext the auth layer inserts). Tenants without
+    // a max_query_requests_per_sec limit are unaffected.
+    let query_limiter = Arc::new(TenantRateLimiter::from_auth_config(&state.config().auth));
+    let query_rate_layer =
+        middleware::from_fn(move |req: axum::extract::Request, next: middleware::Next| {
+            let limiter = query_limiter.clone();
+            async move {
+                if let Some(ctx) = req.extensions().get::<TenantContext>()
+                    && let Err(e) = limiter.check_query(&ctx.tenant_id)
+                {
+                    tracing::warn!(tenant_id = %ctx.tenant_id, "Query request rate limited");
+                    return (StatusCode::TOO_MANY_REQUESTS, e.to_string()).into_response();
+                }
+                next.run(req).await
+            }
+        });
+
     // Create admin auth middleware layer
     let admin_key_hash = state
         .config()
@@ -178,11 +197,18 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
         // Protected routes with authentication
         .nest(
             "/tempo",
-            endpoints::tempo::router().layer(auth_layer.clone()),
+            endpoints::tempo::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
         )
         // Admin routes with admin authentication
         .nest("/api/v1/admin", admin_router)
-        .nest("/api/v1", endpoints::tenant::router().layer(auth_layer))
+        .nest(
+            "/api/v1",
+            endpoints::tenant::router()
+                .layer(query_rate_layer)
+                .layer(auth_layer),
+        )
         // OTel HTTP server metrics for all routes (no-op unless
         // self-monitoring is enabled)
         .layer(middleware::from_fn(
@@ -207,4 +233,71 @@ async fn health_check() -> impl IntoResponse {
 fn load_openapi_spec() -> serde_json::Value {
     serde_json::from_str(include_str!("../../../api/admin-api.json"))
         .expect("api/admin-api.json must be valid JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use common::config::{ApiKeyConfig, TenantConfig, TenantLimits};
+    use tower::ServiceExt;
+
+    fn test_config(query_limit: Option<u32>) -> Configuration {
+        let mut config = Configuration::default();
+        config.auth = common::config::AuthConfig {
+            default_limits: TenantLimits {
+                max_query_requests_per_sec: query_limit,
+                burst_seconds: 1.0,
+                ..Default::default()
+            },
+            tenants: vec![TenantConfig {
+                id: "acme".to_string(),
+                slug: "acme".to_string(),
+                name: "Acme".to_string(),
+                default_dataset: Some("default".to_string()),
+                datasets: vec![],
+                api_keys: vec![ApiKeyConfig {
+                    key: "sk-test-key".to_string(),
+                    name: Some("test".to_string()),
+                }],
+                schema_config: None,
+                limits: None,
+            }],
+            ..Default::default()
+        };
+        config
+    }
+
+    async fn echo_request(app: &Router) -> StatusCode {
+        let request = Request::builder()
+            .uri("/tempo/api/echo")
+            .header("authorization", "Bearer sk-test-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        app.clone().oneshot(request).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn query_requests_are_rate_limited_per_tenant() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let state = InMemoryStateImpl::new(catalog, test_config(Some(2)));
+        let app = create_router(state);
+
+        assert_eq!(echo_request(&app).await, StatusCode::OK);
+        assert_eq!(echo_request(&app).await, StatusCode::OK);
+        assert_eq!(echo_request(&app).await, StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn query_requests_unlimited_without_configured_limit() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let state = InMemoryStateImpl::new(catalog, test_config(None));
+        let app = create_router(state);
+
+        for _ in 0..50 {
+            assert_eq!(echo_request(&app).await, StatusCode::OK);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Completes the titled scope of #557 — *No per-tenant quotas or rate limits (ingest, keys, datasets, request rate)*. Ingest rate limits landed in #594 and the per-tenant concurrent-query cap in #595; this PR adds the remaining three dimensions to `TenantLimits`:

| Limit | Enforced where | On exceed |
|---|---|---|
| `max_query_requests_per_sec` | Router HTTP query surfaces (`/tempo`, `/api/v1`), after authentication | 429 |
| `max_api_keys` | `POST /api/v1/admin/tenants/{id}/api-keys` | 429 `quota_exceeded` |
| `max_datasets` | `POST /api/v1/admin/tenants/{id}/datasets` | 429 `quota_exceeded` |

### Design

- Query rate limiting reuses the existing token-bucket `TenantRateLimiter` with a new independent `query_requests` bucket — exhausting the ingest budget never affects queries and vice versa. The middleware reads the `TenantContext` the auth layer inserts, so it keys on the verified tenant id, and sits inside the auth layer (auth runs first).
- `max_api_keys` counts **active** keys only — revoking a key frees quota.
- New `AuthConfig::limits_for(tenant_id)` resolves a tenant's `[[auth.tenants]].limits` override or `[auth.default_limits]`; tenants provisioned at runtime via the admin API get the defaults. All new fields default to unset = unlimited, so existing deployments are unaffected.
- `signaldb.dist.toml` documents the new keys with examples.

### Out of scope (tracked separately)

Storage quotas need usage accounting from Iceberg metadata and get a follow-up issue rather than riding along here.

### Tests

- `ratelimit`: query-rate enforcement + refill, unlimited-when-unset, ingest/query budget independence (8/8)
- `admin`: key quota rejects third key then accepts after revocation; dataset quota; unlimited-by-default (10/10)
- `router`: end-to-end middleware test through `create_router` with real auth — 2 requests pass, third gets 429; no limit → 50 requests pass (24/24)
- Workspace clippy/fmt/machete/deny clean

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-tenant query request rate limits.
  * Added API key and dataset quotas, with rejected requests returning clear quota or rate-limit errors.
  * Revoked API keys no longer count toward the active key quota.
  * Tenants without configured limits remain unrestricted by default.
* **Documentation**
  * Expanded configuration examples to document query rate limits, API key quotas, and dataset quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->