### PR TITLE
feat(tempo): honor start/end time hints in single-trace lookup

### DIFF
--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -147,6 +147,9 @@ enum TicketRequest {
         tenant_slug: String,
         dataset_slug: String,
         trace_id: String,
+        /// Optional unix-second time hints bracketing the expected trace
+        start: Option<i64>,
+        end: Option<i64>,
     },
     SearchTraces {
         tenant_slug: String,
@@ -378,24 +381,46 @@ impl QuerierFlightService {
     /// Parse ticket content to determine query type and parameters
     #[allow(clippy::result_large_err)]
     fn parse_ticket(&self, ticket_content: &str) -> Result<TicketRequest, Status> {
-        // New format: find_trace:{tenant_slug}:{dataset_slug}:{trace_id}
+        // Format: find_trace:{tenant_slug}:{dataset_slug}:{trace_id}[:{start}:{end}]
+        // The optional trailing segments are unix-second time hints; either
+        // may be empty. Routers only append them when a hint is present, so
+        // the short form remains valid.
         if let Some(remainder) = ticket_content.strip_prefix("find_trace:") {
-            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
-            if parts.len() == 3 {
+            let parts: Vec<&str> = remainder.splitn(5, ':').collect();
+            if parts.len() == 3 || parts.len() == 5 {
+                let parse_hint = |name: &str, value: &str| -> Result<Option<i64>, Status> {
+                    if value.is_empty() {
+                        return Ok(None);
+                    }
+                    value.parse::<i64>().map(Some).map_err(|_| {
+                        Status::invalid_argument(format!(
+                            "Invalid find_trace ticket: {name} '{value}' is not a unix timestamp"
+                        ))
+                    })
+                };
+                let (start, end) = if parts.len() == 5 {
+                    (parse_hint("start", parts[3])?, parse_hint("end", parts[4])?)
+                } else {
+                    (None, None)
+                };
                 tracing::info!(
                     tenant_slug = %parts[0],
                     dataset_slug = %parts[1],
                     trace_id = %parts[2],
+                    start = ?start,
+                    end = ?end,
                     "Parsing find_trace ticket"
                 );
                 return Ok(TicketRequest::FindTrace {
                     tenant_slug: parts[0].to_string(),
                     dataset_slug: parts[1].to_string(),
                     trace_id: parts[2].to_string(),
+                    start,
+                    end,
                 });
             } else {
                 return Err(Status::invalid_argument(
-                    "Invalid find_trace ticket format. Expected: find_trace:tenant_slug:dataset_slug:trace_id",
+                    "Invalid find_trace ticket format. Expected: find_trace:tenant_slug:dataset_slug:trace_id[:start:end]",
                 ));
             }
         }
@@ -757,18 +782,22 @@ impl FlightService for QuerierFlightService {
                         tenant_slug,
                         dataset_slug,
                         trace_id,
+                        start,
+                        end,
                     } => {
                         tracing::info!(
                             tenant_slug = %tenant_slug,
                             dataset_slug = %dataset_slug,
                             trace_id = %trace_id,
+                            start = ?start,
+                            end = ?end,
                             "Executing find_trace"
                         );
 
                         let params = FindTraceByIdParams {
                             trace_id,
-                            start: None,
-                            end: None,
+                            start,
+                            end,
                         };
 
                         match self
@@ -1182,6 +1211,66 @@ mod tests {
 
         let flight_transport = Arc::new(InMemoryFlightTransport::new(bootstrap));
         QuerierFlightService::new(object_store, flight_transport)
+    }
+
+    #[tokio::test]
+    async fn parse_find_trace_ticket_legacy_form_has_no_hints() {
+        let service = make_service().await;
+        match service.parse_ticket("find_trace:acme:prod:abc123").unwrap() {
+            TicketRequest::FindTrace {
+                tenant_slug,
+                dataset_slug,
+                trace_id,
+                start,
+                end,
+            } => {
+                assert_eq!(tenant_slug, "acme");
+                assert_eq!(dataset_slug, "prod");
+                assert_eq!(trace_id, "abc123");
+                assert_eq!(start, None);
+                assert_eq!(end, None);
+            }
+            other => panic!("expected FindTrace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_find_trace_ticket_with_time_hints() {
+        let service = make_service().await;
+        match service
+            .parse_ticket("find_trace:acme:prod:abc123:1700000000:1700003600")
+            .unwrap()
+        {
+            TicketRequest::FindTrace { start, end, .. } => {
+                assert_eq!(start, Some(1_700_000_000));
+                assert_eq!(end, Some(1_700_003_600));
+            }
+            other => panic!("expected FindTrace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_find_trace_ticket_allows_empty_hint_segments() {
+        let service = make_service().await;
+        match service
+            .parse_ticket("find_trace:acme:prod:abc123::1700003600")
+            .unwrap()
+        {
+            TicketRequest::FindTrace { start, end, .. } => {
+                assert_eq!(start, None);
+                assert_eq!(end, Some(1_700_003_600));
+            }
+            other => panic!("expected FindTrace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_find_trace_ticket_rejects_non_numeric_hint() {
+        let service = make_service().await;
+        let status = service
+            .parse_ticket("find_trace:acme:prod:abc123:soon:later")
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
     }
 
     /// Register a catalog `name` with schema `schema` containing a

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -3,12 +3,14 @@ pub mod search_filter;
 pub mod table_ref;
 pub mod trace;
 
+/// Parameters for single-trace lookup.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct FindTraceByIdParams {
     pub trace_id: String,
-    pub start: Option<String>,
-    pub end: Option<String>,
+    /// Optional unix-second hint: only consider spans starting at or after this time.
+    pub start: Option<i64>,
+    /// Optional unix-second hint: only consider spans starting at or before this time.
+    pub end: Option<i64>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -77,7 +77,7 @@ impl TraceService {
             .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
 
         // Use DataFrame API with parameterized filter (prevents SQL injection)
-        let df = self
+        let mut df = self
             .session_context
             .table(table_ref)
             .await
@@ -99,6 +99,33 @@ impl TraceService {
                 );
                 QuerierError::QueryFailed(e)
             })?;
+
+        // Apply the Tempo time hints as span-start bounds. Callers are
+        // expected to pass a window bracketing the whole trace (Grafana's
+        // Tempo datasource pads it by 30 minutes on each side), so this
+        // prunes the scanned time range without truncating traces.
+        if let Some(start) = params.start {
+            df = df
+                .filter(col("start_time_unix_nano").gt_eq(lit(start.saturating_mul(1_000_000_000))))
+                .map_err(|e| {
+                    log::error!(
+                        "Failed to apply start hint for trace_id={}: {e}",
+                        params.trace_id
+                    );
+                    QuerierError::QueryFailed(e)
+                })?;
+        }
+        if let Some(end) = params.end {
+            df = df
+                .filter(col("start_time_unix_nano").lt_eq(lit(end.saturating_mul(1_000_000_000))))
+                .map_err(|e| {
+                    log::error!(
+                        "Failed to apply end hint for trace_id={}: {e}",
+                        params.trace_id
+                    );
+                    QuerierError::QueryFailed(e)
+                })?;
+        }
 
         let results = df.collect().await.map_err(|e| {
             log::error!(

--- a/src/router/src/endpoints/tempo.rs
+++ b/src/router/src/endpoints/tempo.rs
@@ -516,7 +516,7 @@ pub async fn echo() -> &'static str {
 ///
 /// See https://grafana.com/docs/tempo/latest/api_docs/#query
 #[tracing::instrument(
-    skip(state, tenant_ctx, _params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id
@@ -526,12 +526,14 @@ pub async fn query_single_trace<S: RouterState>(
     state: State<S>,
     tenant_ctx: TenantContextExtractor,
     Path(trace_id): Path<String>,
-    Query(_params): Query<TraceQueryParams>,
+    Query(params): Query<TraceQueryParams>,
 ) -> Result<axum::Json<tempo_api::Trace>, axum::http::StatusCode> {
     tracing::info!(
         trace_id = %trace_id,
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id,
+        start = ?params.start,
+        end = ?params.end,
         "Querying for trace"
     );
 
@@ -555,11 +557,23 @@ pub async fn query_single_trace<S: RouterState>(
         }
     };
 
-    // Create Flight query for trace lookup with tenant context (using slugs for Iceberg namespace)
-    let ticket = Ticket::new(format!(
-        "find_trace:{}:{}:{trace_id}",
-        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
-    ));
+    // Create Flight query for trace lookup with tenant context (using slugs
+    // for the Iceberg namespace). Time-hint segments are only appended when
+    // present so tickets without hints keep the legacy 3-part form.
+    let ticket_content = match (params.start, params.end) {
+        (None, None) => format!(
+            "find_trace:{}:{}:{trace_id}",
+            tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+        ),
+        (start, end) => format!(
+            "find_trace:{}:{}:{trace_id}:{}:{}",
+            tenant_ctx.0.tenant_slug,
+            tenant_ctx.0.dataset_slug,
+            start.map(|v| v.to_string()).unwrap_or_default(),
+            end.map(|v| v.to_string()).unwrap_or_default()
+        ),
+    };
+    let ticket = Ticket::new(ticket_content);
     let mut flight_request = tonic::Request::new(ticket);
     common::flight::trace_context::inject_context_into_request(&mut flight_request);
     if let Some(key) = &state.config().auth.internal_service_key {

--- a/src/tempo-api/src/lib.rs
+++ b/src/tempo-api/src/lib.rs
@@ -27,12 +27,14 @@ pub mod tempopb {
 
 pub mod v2;
 
+/// Query parameters for single-trace lookup.
+///
+/// `start`/`end` are optional unix-second hints bracketing the expected
+/// trace, used to prune the scanned time range.
 #[derive(Deserialize, Debug)]
 pub struct TraceQueryParams {
-    #[allow(dead_code)]
-    start: Option<String>,
-    #[allow(dead_code)]
-    end: Option<String>,
+    pub start: Option<i64>,
+    pub end: Option<i64>,
 }
 
 /// Parameters for TraceQL metrics queries


### PR DESCRIPTION
Tempo's `GET /api/traces/{id}?start=&end=` hints were parsed and discarded. They now flow router → Flight ticket (`find_trace:tenant:dataset:trace_id[:start:end]`, legacy 3-part form still valid) → DataFusion span-start bounds, letting the querier prune the scanned time range. Includes ticket-parse unit tests.

## Stack

| # | PR | |
|---|---|---|
| 1 | #613 refactor(querier): remove superseded dead query code |  |
| 2 | #614 feat(tempo): start/end time hints in trace lookup | **← this PR** |
| 3 | #615 feat(tempo): spss span cap in search |  |
| 4 | #616 feat(querier): explicit trace not-found status |  |
| 5 | #617 feat(querier): Tempo gRPC querier protocol |  |

> Review the diff against this PR's base branch, not main. Merge bottom-up.