### PR TITLE
feat(querier): surface trace not-found as an explicit Flight status

### DIFF
--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -815,11 +815,24 @@ impl FlightService for QuerierFlightService {
                             }
                             Ok(None) => {
                                 tracing::info!("No trace found");
-                                vec![]
+                                let e = crate::query::error::QuerierError::TraceNotFound;
+                                return Err(Status::not_found(e.to_string()));
                             }
                             Err(e) => {
                                 tracing::error!(error = ?e, "Error querying trace");
-                                return Err(Status::internal(format!("Trace query failed: {e:?}")));
+                                // Mirror the search arm: caller errors are
+                                // surfaced as such instead of a blanket 500.
+                                return Err(match e {
+                                    crate::query::error::QuerierError::InvalidInput(msg) => {
+                                        Status::invalid_argument(msg)
+                                    }
+                                    crate::query::error::QuerierError::Unsupported(msg) => {
+                                        Status::unimplemented(msg)
+                                    }
+                                    other => {
+                                        Status::internal(format!("Trace query failed: {other:?}"))
+                                    }
+                                });
                             }
                         }
                     }

--- a/src/querier/src/query/error.rs
+++ b/src/querier/src/query/error.rs
@@ -2,7 +2,6 @@ use datafusion::error::DataFusionError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum QuerierError {
-    #[allow(dead_code)] // Constructed once trace lookup maps not-found to a Flight status
     #[error("Trace not found")]
     TraceNotFound,
     #[error("Query failed: {0}")]

--- a/src/router/src/endpoints/tempo.rs
+++ b/src/router/src/endpoints/tempo.rs
@@ -602,13 +602,13 @@ pub async fn query_single_trace<S: RouterState>(
             let mut stream = response.into_inner();
             let mut trace_data = Vec::new();
 
-            // Collect all flight data
+            // Collect all flight data. The querier's terminal status can
+            // surface here rather than at do_get, so map it in both places.
             while let Some(flight_data) = stream.next().await {
                 match flight_data {
                     Ok(data) => trace_data.push(data),
                     Err(e) => {
-                        tracing::error!(error = %e, "Error reading flight data");
-                        return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+                        return Err(trace_lookup_status_to_http(&trace_id, &e));
                     }
                 }
             }
@@ -629,14 +629,41 @@ pub async fn query_single_trace<S: RouterState>(
             }
         }
         Err(e) => {
-            tracing::error!(trace_id = %trace_id, error = %e, "Flight query failed for trace");
-            return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+            return Err(trace_lookup_status_to_http(&trace_id, &e));
         }
     }
 
     // Return 404 when no trace data is found
     tracing::info!(trace_id = %trace_id, "Trace not found");
     Err(axum::http::StatusCode::NOT_FOUND)
+}
+
+/// Map the querier's Flight status for a trace lookup onto an HTTP status.
+/// Not-found is an expected outcome and logged at info; everything else is
+/// an error.
+fn trace_lookup_status_to_http(trace_id: &str, status: &tonic::Status) -> axum::http::StatusCode {
+    match status.code() {
+        tonic::Code::NotFound => {
+            tracing::info!(trace_id = %trace_id, "Trace not found");
+            axum::http::StatusCode::NOT_FOUND
+        }
+        tonic::Code::InvalidArgument => {
+            tracing::warn!(trace_id = %trace_id, error = %status, "Invalid trace query");
+            axum::http::StatusCode::BAD_REQUEST
+        }
+        tonic::Code::ResourceExhausted => {
+            tracing::warn!(trace_id = %trace_id, error = %status, "Trace query throttled");
+            axum::http::StatusCode::TOO_MANY_REQUESTS
+        }
+        tonic::Code::DeadlineExceeded => {
+            tracing::error!(trace_id = %trace_id, error = %status, "Trace query timed out");
+            axum::http::StatusCode::GATEWAY_TIMEOUT
+        }
+        _ => {
+            tracing::error!(trace_id = %trace_id, error = %status, "Flight query failed for trace");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
 }
 
 /// GET https://grafana.com/docs/tempo/latest/api_docs/#search


### PR DESCRIPTION
Trace lookup communicated absence via an empty stream. The querier now returns Flight `not_found` (finally constructing `QuerierError::TraceNotFound`) and maps caller errors to proper codes, mirroring the search arm. The router translates the status onto HTTP (404/400/429/504) in both places it can surface. Empty-stream fallback still yields 404 for older queriers.

## Stack

| # | PR | |
|---|---|---|
| 1 | #613 refactor(querier): remove superseded dead query code |  |
| 2 | #614 feat(tempo): start/end time hints in trace lookup |  |
| 3 | #615 feat(tempo): spss span cap in search |  |
| 4 | #616 feat(querier): explicit trace not-found status | **← this PR** |
| 5 | #617 feat(querier): Tempo gRPC querier protocol |  |

> Review the diff against this PR's base branch, not main. Merge bottom-up.