### PR TITLE
feat(querier): implement the Tempo gRPC querier protocol

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -59,9 +59,10 @@ HTTP Client (Tempo API)
 
 Key details:
 1. Router validates auth, discovers Queriers via `QueryExecution` capability
-2. Flight tickets encode query type + tenant context: `find_trace:{tenant}:{dataset}:{trace_id}`
+2. Flight tickets encode query type + tenant context: `find_trace:{tenant}:{dataset}:{trace_id}[:{start}:{end}]` (optional unix-second time hints)
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
-4. Results stream back as Arrow RecordBatches via Flight
+4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
+5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
 
 ## Service Components
 

--- a/.claude/skills/tempo-api/SKILL.md
+++ b/.claude/skills/tempo-api/SKILL.md
@@ -15,9 +15,9 @@ sources:
 | Endpoint | Status | Description |
 |----------|--------|-------------|
 | `GET /tempo/api/echo` | Implemented | Health check |
-| `GET /tempo/api/traces/{trace_id}` | Implemented | Single trace lookup -> routes to Querier |
+| `GET /tempo/api/traces/{trace_id}` | Implemented | Single trace lookup -> routes to Querier; `start`/`end` time hints prune the scanned range |
 | `GET /tempo/api/v2/traces/{trace_id}` | Implemented | Same handler as v1 for now |
-| `GET /tempo/api/search` | Implemented | Trace search with filters -> routes to Querier |
+| `GET /tempo/api/search` | Implemented | Trace search with filters -> routes to Querier; `spss` caps spans per span set in the response |
 | `GET /tempo/api/search/tags` | Implemented | Static tag set of actually-queryable tags (`service.name`, `name`, `status`) |
 | `GET /tempo/api/search/tag/{tag_name}/values` | Implemented | Real data: distinct column values via Flight SQL for supported tags; static values for `status`; 501 for unindexed attribute tags |
 | `GET /tempo/api/v2/search/tags` | Implemented | Same tag set, scoped (resource/intrinsic) |
@@ -31,10 +31,23 @@ sources:
 2. Router validates auth (API key -> TenantContext)
 3. Router discovers Querier via `QueryExecution` capability
 4. Router sends Flight `do_get` ticket to Querier
-5. Ticket format: `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}` or `search_traces:{tenant_slug}:{dataset_slug}:{params}`
+5. Ticket format: `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}[:{start}:{end}]` (unix-second time hints, appended only when present) or `search_traces:{tenant_slug}:{dataset_slug}:{params}`
 6. Querier executes DataFusion SQL against Iceberg tables
-7. Results stream back as Arrow RecordBatches
+7. Results stream back as Arrow RecordBatches (trace not found -> Flight `not_found` status -> HTTP 404)
 8. Router formats as Tempo JSON response
+
+## Tempo gRPC Querier Protocol (standalone querier)
+
+The standalone querier serves Tempo's internal `tempopb.Querier` gRPC
+protocol on its Flight port (default :50054) so a Tempo query-frontend can
+use SignalDB as a querier (`src/querier/src/services/tempo.rs`):
+
+- `FindTraceByID` / `SearchRecent`: implemented, backed by `TraceService`
+- Tenant: authenticated `TenantContext` extension wins, else `X-Scope-OrgID`
+  header (dataset `default`), else `default`/`default`
+- `SearchBlock`: `Unimplemented` (no Tempo block model in SignalDB)
+- Tag endpoints: static queryable tag set; tag values empty (HTTP API serves
+  real values via Flight SQL)
 
 ## Admin API Endpoints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6367,6 +6367,7 @@ dependencies = [
  "datafusion",
  "datafusion_iceberg",
  "futures",
+ "hex",
  "iceberg-rust",
  "log",
  "object_store",

--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -154,9 +154,14 @@ Any other `do_get` ticket (including `find_trace:...`, `search_traces:...`, and 
 
 | Ticket | Description |
 |--------|-------------|
-| `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}` | Single trace lookup |
-| `search_traces:{tenant_slug}:{dataset_slug}:{params_json}` | Trace search (`SearchQueryParams` as JSON) |
+| `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}[:{start}:{end}]` | Single trace lookup; the optional trailing segments are unix-second time hints (either may be empty) that prune the scanned range. Routers only append them when a hint is present, so the 3-part form remains valid. A missing trace yields a Flight `not_found` status, not an empty stream |
+| `search_traces:{tenant_slug}:{dataset_slug}:{params_json}` | Trace search (`SearchQueryParams` as JSON; unknown fields are ignored on deserialization) |
 | anything else | Treated as a raw SQL query executed via DataFusion |
+
+The standalone querier binary additionally serves Tempo's `tempopb.Querier`
+gRPC protocol on the same port as Flight (see the
+[Tempo API reference](../users/tempo-api-reference.md#tempo-grpc-querier-protocol));
+that protocol does not use tickets.
 
 There is no `trace_by_id?id=...` ticket form at the Querier; that command exists only in the Router's metadata path. The Tempo HTTP endpoints bypass the Router's Flight commands entirely and send `find_trace:`/`search_traces:`/SQL tickets straight to the Querier.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -216,7 +216,7 @@ flowchart LR
 
 | Property | Value |
 |----------|-------|
-| **Port** | Flight: 50054 |
+| **Port** | Flight: 50054 (standalone mode also serves Tempo's `tempopb.Querier` gRPC protocol on this port) |
 | **Capability** | `QueryExecution` |
 | **Engine** | DataFusion with Iceberg integration |
 
@@ -224,7 +224,7 @@ flowchart LR
 - `TenantCatalog` bridges DataFusion's 3-level model (`catalog.schema.table`) to Iceberg's 2-level namespace (`[tenant_slug, dataset_slug]`)
 - Registers per-dataset object stores with DataFusion's runtime environment
 - Handles Flight `do_get` tickets:
-  - `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}` -- single trace lookup
+  - `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}[:{start}:{end}]` -- single trace lookup with optional unix-second time hints
   - `search_traces:{tenant_slug}:{dataset_slug}:{params}` -- trace search with filters
 - Uses `TableReference::full(tenant_slug, dataset_slug, "traces")` with slug validation to prevent SQL injection
 

--- a/docs/users/tempo-api-reference.md
+++ b/docs/users/tempo-api-reference.md
@@ -18,9 +18,9 @@ authentication headers described in [Authentication](authentication.md)
 | Method | Path (under `/tempo`) | Status | Notes |
 |---|---|---|---|
 | GET | `/api/echo` | implemented | Returns `echo`; still requires auth headers |
-| GET | `/api/traces/{trace_id}` | implemented | Trace by ID; `start`/`end` params accepted but not applied |
+| GET | `/api/traces/{trace_id}` | implemented | Trace by ID; optional `start`/`end` (unix seconds) prune the scanned time range — pass a window bracketing the whole trace |
 | GET | `/api/v2/traces/{trace_id}` | implemented | Same handler as v1 |
-| GET | `/api/search` | implemented | Trace search, executed by the querier |
+| GET | `/api/search` | implemented | Trace search, executed by the querier; `spss` caps spans per span set (`matched` still reports the full count; omitted = all spans) |
 | GET | `/api/search/tags` | implemented | Static list of searchable tags: `service.name`, `name`, `status` |
 | GET | `/api/v2/search/tags` | implemented | Same tags, grouped into `resource` and `intrinsic` scopes |
 | GET | `/api/search/tag/{tag}/values` | partial | Real distinct values for `service.name` and `name` (also `resource.`/`span.`-scoped forms); static `ok`/`error`/`unset` for `status`; **501** for any other tag |
@@ -39,6 +39,24 @@ authentication headers described in [Authentication](authentication.md)
 | 501 | Feature not implemented (TraceQL metrics, unindexed tag values) |
 | 503 | No querier service available |
 | 504 | Query deadline exceeded |
+
+## Tempo gRPC querier protocol
+
+A standalone querier also serves Tempo's internal `tempopb.Querier` gRPC
+protocol on its Flight port (default `50054`), so a Tempo query-frontend
+can use SignalDB as a querier backend:
+
+- `FindTraceByID` and `SearchRecent` are fully implemented (including
+  `spans_per_span_set`).
+- The tenant is taken from Tempo's `X-Scope-OrgID` header (dataset
+  `default`), or from the authenticated tenant context when
+  `[auth].internal_service_key` is configured. Note that with an internal
+  service key set, the port requires SignalDB's internal auth headers,
+  which a stock Tempo query-frontend cannot send — run without the key on
+  a trusted network for Tempo interop.
+- `SearchBlock` returns `Unimplemented` (SignalDB stores data in Iceberg
+  tables, not Tempo blocks). Tag endpoints advertise the same static tag
+  set as the HTTP API; tag *value* enumeration is HTTP-only.
 
 ## Related
 

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -11,6 +11,7 @@ tempo-api = { path = "../tempo-api", features = ["server"] }
 
 async-trait.workspace = true
 dashmap.workspace = true
+hex.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -216,6 +216,12 @@ fn session_context_with_limits(limits: &QuerierConfig) -> SessionContext {
 }
 
 impl QuerierFlightService {
+    /// Build a Tempo gRPC querier backed by this service's trace query
+    /// engine, for serving `tempopb.Querier` alongside Flight.
+    pub fn tempo_querier(&self) -> crate::services::tempo::SignalDBQuerier {
+        crate::services::tempo::SignalDBQuerier::new(self.trace_service.clone())
+    }
+
     /// Create a new QuerierFlightService with default resource limits
     pub fn new(
         object_store: Arc<dyn ObjectStore>,

--- a/src/querier/src/lib.rs
+++ b/src/querier/src/lib.rs
@@ -3,3 +3,4 @@ mod query;
 mod services;
 
 pub use flight::QuerierFlightService;
+pub use services::tempo::SignalDBQuerier;

--- a/src/querier/src/main.rs
+++ b/src/querier/src/main.rs
@@ -7,6 +7,7 @@ use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
 use common::service_bootstrap::{ServiceBootstrap, ServiceType};
 use querier::QuerierFlightService;
 use std::sync::Arc;
+use tempo_api::tempopb::querier_server::QuerierServer;
 use tokio::signal;
 use tonic::transport::Server;
 
@@ -160,16 +161,23 @@ async fn main() -> anyhow::Result<()> {
              it must be restricted to a trusted network"
         );
     }
+    // Serve Tempo's internal querier gRPC protocol on the same port as
+    // Flight, so a Tempo query-frontend can use SignalDB as a querier.
+    let tempo_querier = flight_service.tempo_querier();
     let flight_handle = tokio::spawn(async move {
         let builder = Server::builder();
         let serve = match flight_auth {
             Some(interceptor) => {
+                let tempo_interceptor = interceptor.clone();
                 let mut builder = builder;
                 builder
                     .add_service(FlightServiceServer::with_interceptor(
                         flight_service,
                         move |req| interceptor.intercept(req),
                     ))
+                    .add_service(QuerierServer::with_interceptor(tempo_querier, move |req| {
+                        tempo_interceptor.intercept(req)
+                    }))
                     .serve(flight_addr)
                     .await
             }
@@ -177,6 +185,7 @@ async fn main() -> anyhow::Result<()> {
                 let mut builder = builder;
                 builder
                     .add_service(FlightServiceServer::new(flight_service))
+                    .add_service(QuerierServer::new(tempo_querier))
                     .serve(flight_addr)
                     .await
             }

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -22,9 +22,13 @@ pub struct FindTraceByIdParams {
 pub struct SearchQueryParams {
     pub q: Option<String>,
     pub tags: Option<String>,
-    pub min_duration: Option<i32>,
-    pub max_duration: Option<i32>,
+    /// Minimum span duration in nanoseconds
+    pub min_duration: Option<i64>,
+    /// Maximum span duration in nanoseconds
+    pub max_duration: Option<i64>,
     pub limit: Option<i32>,
-    pub start: Option<i32>,
-    pub end: Option<i32>,
+    /// Search window start (unix seconds)
+    pub start: Option<i64>,
+    /// Search window end (unix seconds)
+    pub end: Option<i64>,
 }

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -393,7 +393,7 @@ impl TraceService {
 
         // Apply time range filters if provided
         if let Some(start) = query.start {
-            let start_nanos = (start as i64) * 1_000_000_000;
+            let start_nanos = start.saturating_mul(1_000_000_000);
             df = df
                 .filter(col("start_time_unix_nano").gt_eq(lit(start_nanos)))
                 .map_err(|e| {
@@ -402,7 +402,7 @@ impl TraceService {
                 })?;
         }
         if let Some(end) = query.end {
-            let end_nanos = (end as i64) * 1_000_000_000;
+            let end_nanos = end.saturating_mul(1_000_000_000);
             df = df
                 .filter(col("start_time_unix_nano").lt_eq(lit(end_nanos)))
                 .map_err(|e| {
@@ -414,7 +414,7 @@ impl TraceService {
         // Apply duration filters
         if let Some(min_dur) = query.min_duration {
             df = df
-                .filter(col("duration_nanos").gt_eq(lit(min_dur as i64)))
+                .filter(col("duration_nanos").gt_eq(lit(min_dur)))
                 .map_err(|e| {
                     log::error!("Failed to apply min duration filter: {e}");
                     QuerierError::QueryFailed(e)
@@ -422,7 +422,7 @@ impl TraceService {
         }
         if let Some(max_dur) = query.max_duration {
             df = df
-                .filter(col("duration_nanos").lt_eq(lit(max_dur as i64)))
+                .filter(col("duration_nanos").lt_eq(lit(max_dur)))
                 .map_err(|e| {
                     log::error!("Failed to apply max duration filter: {e}");
                     QuerierError::QueryFailed(e)

--- a/src/querier/src/services/tempo.rs
+++ b/src/querier/src/services/tempo.rs
@@ -1,44 +1,365 @@
-use std::vec;
+//! # Tempo gRPC Querier Protocol
+//!
+//! Implements Tempo's internal `tempopb.Querier` gRPC service backed by
+//! [`TraceService`], allowing SignalDB to answer trace-by-id and search
+//! requests from a Tempo query-frontend.
+//!
+//! Tenant resolution mirrors the Flight service: an authenticated
+//! `TenantContext` request extension wins; otherwise the Tempo-conventional
+//! `X-Scope-OrgID` header selects the tenant (with the `default` dataset);
+//! otherwise `default`/`default`.
+//!
+//! `SearchBlock` is answered with `Unimplemented`: SignalDB stores data in
+//! Iceberg tables, not Tempo blocks, so block-scoped search has no meaning
+//! here. Tag endpoints return the statically queryable tag set (the same
+//! set the HTTP API advertises) rather than fabricated values.
+
+use std::collections::HashMap;
 
 use tempo_api::tempopb::{
     SearchBlockRequest, SearchRequest, SearchResponse, SearchTagValuesRequest,
     SearchTagValuesResponse, SearchTagValuesV2Response, SearchTagsRequest, SearchTagsResponse,
-    SearchTagsV2Response, SearchTagsV2Scope, TagValue, TraceByIdRequest, TraceByIdResponse,
-    querier_server::Querier, trace_by_id_response::Status,
+    SearchTagsV2Response, SearchTagsV2Scope, SpanSet, TraceByIdRequest, TraceByIdResponse,
+    TraceSearchMetadata, common as otlp_common, querier_server::Querier, resource as otlp_resource,
+    trace as otlp_trace, trace_by_id_response::Status as TraceByIdStatus,
 };
-use tonic::Response;
+use tonic::{Request, Response, Status};
 
-#[derive(Debug, Default)]
-#[allow(dead_code)]
-pub struct SignalDBQuerier {}
+use crate::query::error::QuerierError;
+use crate::query::trace::TraceService;
+use crate::query::{FindTraceByIdParams, SearchQueryParams};
+use common::model::span::{Span as ModelSpan, SpanKind, SpanStatus};
+
+// Keep in sync with the router's HTTP tag endpoints: these are the tags
+// search can actually filter on today.
+const RESOURCE_TAGS: &[&str] = &["service.name"];
+const INTRINSIC_TAGS: &[&str] = &["name", "status"];
+
+/// Tempo gRPC querier backed by SignalDB's trace query service.
+#[derive(Debug, Clone)]
+pub struct SignalDBQuerier {
+    trace_service: TraceService,
+}
+
+impl SignalDBQuerier {
+    pub fn new(trace_service: TraceService) -> Self {
+        Self { trace_service }
+    }
+
+    /// Resolve (tenant_slug, dataset_slug) for a request. An authenticated
+    /// `TenantContext` extension (inserted by the Flight auth interceptor)
+    /// takes precedence over Tempo's `X-Scope-OrgID` header.
+    fn resolve_tenant<T>(request: &Request<T>) -> (String, String) {
+        if let Some(ctx) = request.extensions().get::<common::auth::TenantContext>() {
+            return (ctx.tenant_slug.clone(), ctx.dataset_slug.clone());
+        }
+        let tenant = request
+            .metadata()
+            .get("x-scope-orgid")
+            .and_then(|v| v.to_str().ok())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("default")
+            .to_string();
+        (tenant, "default".to_string())
+    }
+}
+
+fn querier_error_to_status(e: QuerierError) -> Status {
+    match e {
+        QuerierError::TraceNotFound => Status::not_found(e.to_string()),
+        QuerierError::InvalidInput(msg) => Status::invalid_argument(msg),
+        QuerierError::Unsupported(msg) => Status::unimplemented(msg),
+        other => Status::internal(format!("Query failed: {other:?}")),
+    }
+}
+
+/// Collect a trace's spans depth-first, flattening the child hierarchy.
+fn collect_spans<'a>(spans: &'a [ModelSpan], out: &mut Vec<&'a ModelSpan>) {
+    for span in spans {
+        out.push(span);
+        collect_spans(&span.children, out);
+    }
+}
+
+fn json_to_any_value(value: &serde_json::Value) -> otlp_common::v1::AnyValue {
+    use otlp_common::v1::any_value::Value;
+    let inner = match value {
+        serde_json::Value::String(s) => Value::StringValue(s.clone()),
+        serde_json::Value::Bool(b) => Value::BoolValue(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::IntValue(i)
+            } else if let Some(f) = n.as_f64() {
+                Value::DoubleValue(f)
+            } else {
+                Value::StringValue(n.to_string())
+            }
+        }
+        other => Value::StringValue(other.to_string()),
+    };
+    otlp_common::v1::AnyValue { value: Some(inner) }
+}
+
+fn attrs_to_key_values(
+    attrs: &HashMap<String, serde_json::Value>,
+) -> Vec<otlp_common::v1::KeyValue> {
+    let mut kvs: Vec<otlp_common::v1::KeyValue> = attrs
+        .iter()
+        .map(|(key, value)| otlp_common::v1::KeyValue {
+            key: key.clone(),
+            value: Some(json_to_any_value(value)),
+        })
+        .collect();
+    // Deterministic output for consumers and tests
+    kvs.sort_by(|a, b| a.key.cmp(&b.key));
+    kvs
+}
+
+fn span_kind_to_proto(kind: &SpanKind) -> i32 {
+    use otlp_trace::v1::span::SpanKind as ProtoKind;
+    let kind = match kind {
+        SpanKind::Internal => ProtoKind::Internal,
+        SpanKind::Server => ProtoKind::Server,
+        SpanKind::Client => ProtoKind::Client,
+        SpanKind::Producer => ProtoKind::Producer,
+        SpanKind::Consumer => ProtoKind::Consumer,
+    };
+    kind as i32
+}
+
+fn span_status_to_proto(status: &SpanStatus) -> otlp_trace::v1::Status {
+    use otlp_trace::v1::status::StatusCode;
+    let code = match status {
+        SpanStatus::Unspecified => StatusCode::Unset,
+        SpanStatus::Ok => StatusCode::Ok,
+        SpanStatus::Error => StatusCode::Error,
+    };
+    otlp_trace::v1::Status {
+        message: String::new(),
+        code: code as i32,
+    }
+}
+
+/// Convert the internal trace model to the OTLP-shaped `tempopb.Trace`,
+/// grouping spans into one `ResourceSpans` per service.
+fn model_trace_to_proto(trace: &common::model::trace::Trace) -> tempo_api::tempopb::Trace {
+    let mut all_spans = Vec::new();
+    collect_spans(&trace.spans, &mut all_spans);
+
+    let mut by_service: HashMap<&str, Vec<&ModelSpan>> = HashMap::new();
+    for span in all_spans {
+        by_service.entry(&span.service_name).or_default().push(span);
+    }
+
+    let mut services: Vec<&str> = by_service.keys().copied().collect();
+    services.sort_unstable();
+
+    let resource_spans = services
+        .into_iter()
+        .map(|service_name| {
+            let spans = &by_service[service_name];
+            let proto_spans = spans
+                .iter()
+                .map(|span| otlp_trace::v1::Span {
+                    trace_id: hex::decode(&span.trace_id).unwrap_or_default(),
+                    span_id: hex::decode(&span.span_id).unwrap_or_default(),
+                    parent_span_id: hex::decode(&span.parent_span_id).unwrap_or_default(),
+                    name: span.name.clone(),
+                    kind: span_kind_to_proto(&span.span_kind),
+                    start_time_unix_nano: span.start_time_unix_nano,
+                    end_time_unix_nano: span
+                        .start_time_unix_nano
+                        .saturating_add(span.duration_nano),
+                    attributes: attrs_to_key_values(&span.attributes),
+                    status: Some(span_status_to_proto(&span.status)),
+                    ..Default::default()
+                })
+                .collect();
+
+            let mut resource_attrs = spans
+                .first()
+                .map(|s| attrs_to_key_values(&s.resource))
+                .unwrap_or_default();
+            if !resource_attrs.iter().any(|kv| kv.key == "service.name") {
+                resource_attrs.push(otlp_common::v1::KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(otlp_common::v1::AnyValue {
+                        value: Some(otlp_common::v1::any_value::Value::StringValue(
+                            service_name.to_string(),
+                        )),
+                    }),
+                });
+            }
+
+            otlp_trace::v1::ResourceSpans {
+                resource: Some(otlp_resource::v1::Resource {
+                    attributes: resource_attrs,
+                    dropped_attributes_count: 0,
+                }),
+                scope_spans: vec![otlp_trace::v1::ScopeSpans {
+                    scope: None,
+                    spans: proto_spans,
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }
+        })
+        .collect();
+
+    tempo_api::tempopb::Trace { resource_spans }
+}
+
+/// Convert a trace to Tempo search metadata, capping the span set at
+/// `span_cap` spans (`matched` always reports the full count).
+fn model_trace_to_search_metadata(
+    trace: &common::model::trace::Trace,
+    span_cap: Option<usize>,
+) -> TraceSearchMetadata {
+    let mut all_spans = Vec::new();
+    collect_spans(&trace.spans, &mut all_spans);
+
+    let mut earliest_start = u64::MAX;
+    let mut latest_end = 0u64;
+    let mut root_service_name = "unknown".to_string();
+    let mut root_trace_name = "unknown".to_string();
+    for span in &all_spans {
+        if span.is_root {
+            root_service_name = span.service_name.clone();
+            root_trace_name = span.name.clone();
+        }
+        earliest_start = earliest_start.min(span.start_time_unix_nano);
+        latest_end = latest_end.max(span.start_time_unix_nano.saturating_add(span.duration_nano));
+    }
+    let duration_ms = if earliest_start != u64::MAX && latest_end > earliest_start {
+        ((latest_end - earliest_start) / 1_000_000) as u32
+    } else {
+        0
+    };
+
+    let spans = all_spans
+        .iter()
+        .take(span_cap.unwrap_or(usize::MAX))
+        .map(|span| tempo_api::tempopb::Span {
+            span_id: span.span_id.clone(),
+            name: span.name.clone(),
+            start_time_unix_nano: span.start_time_unix_nano,
+            duration_nanos: span.duration_nano,
+            attributes: attrs_to_key_values(&span.attributes),
+        })
+        .collect();
+
+    TraceSearchMetadata {
+        trace_id: trace.trace_id.clone(),
+        root_service_name,
+        root_trace_name,
+        start_time_unix_nano: if earliest_start == u64::MAX {
+            0
+        } else {
+            earliest_start
+        },
+        duration_ms,
+        span_set: None,
+        span_sets: vec![SpanSet {
+            spans,
+            matched: all_spans.len() as u32,
+            attributes: Vec::new(),
+        }],
+        service_stats: HashMap::new(),
+    }
+}
+
+/// Map a Tempo `SearchRequest` onto SignalDB search parameters.
+fn search_request_to_params(req: &SearchRequest) -> SearchQueryParams {
+    let tags = if req.tags.is_empty() {
+        None
+    } else {
+        let mut pairs: Vec<String> = req.tags.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        pairs.sort_unstable();
+        Some(pairs.join(" "))
+    };
+    SearchQueryParams {
+        q: (!req.query.is_empty()).then(|| req.query.clone()),
+        tags,
+        min_duration: (req.min_duration_ms > 0)
+            .then(|| i64::from(req.min_duration_ms).saturating_mul(1_000_000)),
+        max_duration: (req.max_duration_ms > 0)
+            .then(|| i64::from(req.max_duration_ms).saturating_mul(1_000_000)),
+        limit: (req.limit > 0).then(|| i32::try_from(req.limit).unwrap_or(i32::MAX)),
+        start: (req.start > 0).then_some(i64::from(req.start)),
+        end: (req.end > 0).then_some(i64::from(req.end)),
+    }
+}
 
 #[tonic::async_trait]
 impl Querier for SignalDBQuerier {
     #[tracing::instrument(skip_all)]
     async fn find_trace_by_id(
         &self,
-        _request: tonic::Request<TraceByIdRequest>,
+        request: tonic::Request<TraceByIdRequest>,
     ) -> Result<tonic::Response<TraceByIdResponse>, tonic::Status> {
-        let response = TraceByIdResponse {
-            trace: None,
-            metrics: None,
-            status: Status::Complete as i32,
-            message: "Hello, World!".to_string(),
-        };
+        let (tenant_slug, dataset_slug) = Self::resolve_tenant(&request);
+        let req = request.into_inner();
+        let trace_id = hex::encode(&req.trace_id);
+        tracing::info!(
+            trace_id = %trace_id,
+            tenant_slug = %tenant_slug,
+            dataset_slug = %dataset_slug,
+            "Tempo gRPC trace lookup"
+        );
 
+        let params = FindTraceByIdParams {
+            trace_id,
+            start: None,
+            end: None,
+        };
+        let trace = self
+            .trace_service
+            .find_by_id_with_tenant(params, &tenant_slug, &dataset_slug)
+            .await
+            .map_err(querier_error_to_status)?;
+
+        // Tempo's protocol reports absence as a complete response without a
+        // trace; the query-frontend merges partial responses across queriers.
+        let response = TraceByIdResponse {
+            trace: trace.as_ref().map(model_trace_to_proto),
+            metrics: None,
+            status: TraceByIdStatus::Complete as i32,
+            message: String::new(),
+        };
         Ok(Response::new(response))
     }
 
     #[tracing::instrument(skip_all)]
     async fn search_recent(
         &self,
-        _request: tonic::Request<SearchRequest>,
+        request: tonic::Request<SearchRequest>,
     ) -> Result<tonic::Response<SearchResponse>, tonic::Status> {
+        let (tenant_slug, dataset_slug) = Self::resolve_tenant(&request);
+        let req = request.into_inner();
+        let span_cap = usize::try_from(req.spans_per_span_set)
+            .ok()
+            .filter(|v| *v > 0);
+        let params = search_request_to_params(&req);
+        tracing::info!(
+            tenant_slug = %tenant_slug,
+            dataset_slug = %dataset_slug,
+            params = ?params,
+            "Tempo gRPC trace search"
+        );
+
+        let traces = self
+            .trace_service
+            .find_traces_with_tenant(params, &tenant_slug, &dataset_slug)
+            .await
+            .map_err(querier_error_to_status)?;
+
         let response = SearchResponse {
-            traces: vec![],
+            traces: traces
+                .iter()
+                .map(|t| model_trace_to_search_metadata(t, span_cap))
+                .collect(),
             metrics: None,
         };
-
         Ok(Response::new(response))
     }
 
@@ -47,8 +368,9 @@ impl Querier for SignalDBQuerier {
         &self,
         _request: tonic::Request<SearchBlockRequest>,
     ) -> Result<tonic::Response<SearchResponse>, tonic::Status> {
-        // Implement the method logic here
-        unimplemented!()
+        Err(Status::unimplemented(
+            "SignalDB stores data in Iceberg tables, not Tempo blocks; block-scoped search is not supported",
+        ))
     }
 
     #[tracing::instrument(skip_all)]
@@ -58,9 +380,12 @@ impl Querier for SignalDBQuerier {
     ) -> Result<tonic::Response<SearchTagsResponse>, tonic::Status> {
         let response = SearchTagsResponse {
             metrics: None,
-            tag_names: vec!["my_tag".to_string()],
+            tag_names: RESOURCE_TAGS
+                .iter()
+                .chain(INTRINSIC_TAGS)
+                .map(|t| t.to_string())
+                .collect(),
         };
-
         Ok(Response::new(response))
     }
 
@@ -71,12 +396,17 @@ impl Querier for SignalDBQuerier {
     ) -> Result<tonic::Response<SearchTagsV2Response>, tonic::Status> {
         let response = SearchTagsV2Response {
             metrics: None,
-            scopes: vec![SearchTagsV2Scope {
-                name: "resource".to_string(),
-                tags: vec!["my_tag".to_string()],
-            }],
+            scopes: vec![
+                SearchTagsV2Scope {
+                    name: "resource".to_string(),
+                    tags: RESOURCE_TAGS.iter().map(|t| t.to_string()).collect(),
+                },
+                SearchTagsV2Scope {
+                    name: "intrinsic".to_string(),
+                    tags: INTRINSIC_TAGS.iter().map(|t| t.to_string()).collect(),
+                },
+            ],
         };
-
         Ok(Response::new(response))
     }
 
@@ -85,12 +415,12 @@ impl Querier for SignalDBQuerier {
         &self,
         _request: tonic::Request<SearchTagValuesRequest>,
     ) -> Result<tonic::Response<SearchTagValuesResponse>, tonic::Status> {
-        let response = SearchTagValuesResponse {
-            tag_values: vec!["my_tag".to_string()],
+        // Value enumeration is served by the HTTP API via Flight SQL; here we
+        // return an empty set rather than fabricated values.
+        Ok(Response::new(SearchTagValuesResponse {
+            tag_values: Vec::new(),
             metrics: None,
-        };
-
-        Ok(Response::new(response))
+        }))
     }
 
     #[tracing::instrument(skip_all)]
@@ -98,13 +428,136 @@ impl Querier for SignalDBQuerier {
         &self,
         _request: tonic::Request<SearchTagValuesRequest>,
     ) -> Result<tonic::Response<SearchTagValuesV2Response>, tonic::Status> {
-        let response = SearchTagValuesV2Response {
-            tag_values: vec![TagValue {
-                r#type: "my_tag".to_string(),
-                value: "Hello, World!".to_string(),
-            }],
+        Ok(Response::new(SearchTagValuesV2Response {
+            tag_values: Vec::new(),
             metrics: None,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_span(span_id: &str, service: &str, is_root: bool) -> ModelSpan {
+        ModelSpan {
+            trace_id: "0af7651916cd43dd8448eb211c80319c".to_string(),
+            span_id: span_id.to_string(),
+            parent_span_id: String::new(),
+            status: SpanStatus::Ok,
+            is_root,
+            name: format!("op-{span_id}"),
+            service_name: service.to_string(),
+            span_kind: SpanKind::Server,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            duration_nano: 5_000_000,
+            attributes: HashMap::new(),
+            resource: HashMap::new(),
+            children: Vec::new(),
+        }
+    }
+
+    fn make_trace(spans: Vec<ModelSpan>) -> common::model::trace::Trace {
+        common::model::trace::Trace {
+            trace_id: "0af7651916cd43dd8448eb211c80319c".to_string(),
+            spans,
+        }
+    }
+
+    #[test]
+    fn trace_converts_to_resource_spans_grouped_by_service() {
+        let trace = make_trace(vec![
+            make_span("b7ad6b7169203331", "svc-a", true),
+            make_span("00f067aa0ba902b7", "svc-b", false),
+        ]);
+
+        let proto = model_trace_to_proto(&trace);
+        assert_eq!(proto.resource_spans.len(), 2);
+
+        let first = &proto.resource_spans[0];
+        let service_attr = &first.resource.as_ref().unwrap().attributes[0];
+        assert_eq!(service_attr.key, "service.name");
+        let span = &first.scope_spans[0].spans[0];
+        assert_eq!(span.span_id, hex::decode("b7ad6b7169203331").unwrap());
+        assert_eq!(
+            span.end_time_unix_nano,
+            1_700_000_000_000_000_000 + 5_000_000
+        );
+        assert_eq!(span.kind, otlp_trace::v1::span::SpanKind::Server as i32);
+        assert_eq!(
+            span.status.as_ref().unwrap().code,
+            otlp_trace::v1::status::StatusCode::Ok as i32
+        );
+    }
+
+    #[test]
+    fn search_metadata_caps_spans_but_reports_full_match_count() {
+        let spans = (0..5)
+            .map(|i| make_span(&format!("{i:016x}"), "svc", i == 0))
+            .collect();
+        let metadata = model_trace_to_search_metadata(&make_trace(spans), Some(2));
+
+        assert_eq!(metadata.span_sets.len(), 1);
+        assert_eq!(metadata.span_sets[0].spans.len(), 2);
+        assert_eq!(metadata.span_sets[0].matched, 5);
+        assert_eq!(metadata.root_service_name, "svc");
+        assert_eq!(metadata.duration_ms, 5);
+    }
+
+    #[test]
+    fn search_request_maps_onto_search_params() {
+        let mut tags = HashMap::new();
+        tags.insert("service.name".to_string(), "api".to_string());
+        let req = SearchRequest {
+            tags,
+            min_duration_ms: 100,
+            max_duration_ms: 5_000,
+            limit: 25,
+            start: 1_700_000_000,
+            end: 1_700_003_600,
+            query: String::new(),
+            spans_per_span_set: 3,
         };
-        Ok(Response::new(response))
+
+        let params = search_request_to_params(&req);
+        assert_eq!(params.q, None);
+        assert_eq!(params.tags.as_deref(), Some("service.name=api"));
+        assert_eq!(params.min_duration, Some(100_000_000));
+        assert_eq!(params.max_duration, Some(5_000_000_000));
+        assert_eq!(params.limit, Some(25));
+        assert_eq!(params.start, Some(1_700_000_000));
+        assert_eq!(params.end, Some(1_700_003_600));
+    }
+
+    #[test]
+    fn tenant_resolution_prefers_context_then_header() {
+        let mut request = Request::new(());
+        request
+            .metadata_mut()
+            .insert("x-scope-orgid", "acme".parse().unwrap());
+        assert_eq!(
+            SignalDBQuerier::resolve_tenant(&request),
+            ("acme".to_string(), "default".to_string())
+        );
+
+        request
+            .extensions_mut()
+            .insert(common::auth::TenantContext::new(
+                "tenant-x".to_string(),
+                "prod".to_string(),
+                "tenant-x".to_string(),
+                "prod".to_string(),
+                None,
+                common::auth::TenantSource::Config,
+            ));
+        assert_eq!(
+            SignalDBQuerier::resolve_tenant(&request),
+            ("tenant-x".to_string(), "prod".to_string())
+        );
+
+        assert_eq!(
+            SignalDBQuerier::resolve_tenant(&Request::new(())),
+            ("default".to_string(), "default".to_string())
+        );
     }
 }


### PR DESCRIPTION
Replaces the `SignalDBQuerier` stub (fabricated data / `unimplemented!` panics) with a real `tempopb.Querier` implementation backed by `TraceService`, served on the querier's Flight port so a Tempo query-frontend can use SignalDB as a querier:

- `FindTraceByID`: internal model → OTLP-shaped `ResourceSpans` grouped per service
- `SearchRecent`: Tempo search → SignalDB params, honors `spans_per_span_set`
- Tenant: authenticated `TenantContext` wins, else `X-Scope-OrgID`, else default/default
- `SearchBlock`: honest `Unimplemented` (no Tempo block model); tag endpoints advertise the real queryable set

Querier-internal search params widen to i64 for lossless u32 epoch/duration mapping (wire-compatible). Includes docs updates for the whole stack.

## Stack

| # | PR | |
|---|---|---|
| 1 | #613 refactor(querier): remove superseded dead query code |  |
| 2 | #614 feat(tempo): start/end time hints in trace lookup |  |
| 3 | #615 feat(tempo): spss span cap in search |  |
| 4 | #616 feat(querier): explicit trace not-found status |  |
| 5 | #617 feat(querier): Tempo gRPC querier protocol | **← this PR** |

> Review the diff against this PR's base branch, not main. Merge bottom-up.