### PR TITLE
feat(common): enable OTLP profiles proto types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ opentelemetry = "0.32.0"
 opentelemetry_sdk = "0.32.1"
 opentelemetry-stdout = { version = "0.31.0" }
 opentelemetry-otlp = { version = "0.32.0" }
-opentelemetry-proto = "0.32.0"
+opentelemetry-proto = { version = "0.32.0", features = ["full", "profiles"] }
 opentelemetry-semantic-conventions = "0.32.1"
 
 tokio = { version = "1.48.0", features = [

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -19,3 +19,32 @@ pub mod wal;
 pub mod testing;
 
 pub use catalog_manager::CatalogManager;
+
+#[cfg(test)]
+mod otlp_profiles_proto_tests {
+    use opentelemetry_proto::tonic::collector::profiles::v1development::{
+        ExportProfilesServiceRequest, ExportProfilesServiceResponse,
+    };
+    use opentelemetry_proto::tonic::profiles::v1development::{
+        Profile, ProfilesData, ProfilesDictionary,
+    };
+
+    #[test]
+    fn profiles_proto_types_are_available() {
+        let request = ExportProfilesServiceRequest::default();
+        assert!(request.resource_profiles.is_empty());
+
+        let response = ExportProfilesServiceResponse::default();
+        assert!(response.partial_success.is_none());
+
+        let data = ProfilesData::default();
+        assert!(data.dictionary.is_none());
+
+        let dictionary = ProfilesDictionary::default();
+        assert!(dictionary.string_table.is_empty());
+
+        let profile = Profile::default();
+        assert!(profile.profile_id.is_empty());
+        assert_eq!(profile.time_unix_nano, 0);
+    }
+}


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | Layer | Status |
|---|---|---|
| 1 | enable OTLP profiles proto types | 👀 **← this PR** |
| 2+ | Flight schema, model, conversion, WAL, storage, query, APIs | 🔲 upcoming |

> First PR of the stacked implementation of the OpenTelemetry Profiles epic #343.

## This PR only
Enables the `profiles` feature on the workspace `opentelemetry-proto` dependency, making the `v1development` profiles messages (`Profile`, `ProfilesDictionary`, `ProfilesData`) and the `ProfilesService` gRPC client/server stubs available. Adds a smoke test pinning the types the rest of the stack builds on.

Note: the original issue proposed wiring protoc against the submodule; the crates.io crate already ships generated `v1development` types behind a feature flag, so this is the entire change.

Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for OpenTelemetry profile data in the application’s telemetry integration.

* **Tests**
  * Added coverage confirming that profile-related telemetry types are available and initialize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->