### PR TITLE
feat(wal): add WriteProfiles operation and profiles WAL config

### DIFF
--- a/src/acceptor/src/handler/wal_manager.rs
+++ b/src/acceptor/src/handler/wal_manager.rs
@@ -29,6 +29,8 @@ pub struct WalManager {
     logs_config: WalConfig,
     /// Base configuration template for metrics WALs
     metrics_config: WalConfig,
+    /// Base configuration template for profile WALs
+    profiles_config: WalConfig,
 }
 
 impl WalManager {
@@ -39,6 +41,7 @@ impl WalManager {
     /// * `traces_config` - Base WAL configuration for traces
     /// * `logs_config` - Base WAL configuration for logs
     /// * `metrics_config` - Base WAL configuration for metrics
+    /// * `profiles_config` - Base WAL configuration for profiles
     ///
     /// The `wal_dir` in each config should point to the base directory (e.g., `.wal`).
     /// The manager will create subdirectories per tenant/dataset/signal.
@@ -46,6 +49,7 @@ impl WalManager {
         traces_config: WalConfig,
         logs_config: WalConfig,
         metrics_config: WalConfig,
+        profiles_config: WalConfig,
     ) -> Self {
         Self {
             wals: Arc::new(Mutex::new(HashMap::new())),
@@ -53,6 +57,7 @@ impl WalManager {
             traces_config,
             logs_config,
             metrics_config,
+            profiles_config,
         }
     }
 
@@ -62,7 +67,7 @@ impl WalManager {
     ///
     /// * `tenant_id` - The tenant identifier
     /// * `dataset_id` - The dataset identifier
-    /// * `signal_type` - The signal type ("traces", "logs", or "metrics")
+    /// * `signal_type` - The signal type ("traces", "logs", "metrics", or "profiles")
     ///
     /// # Returns
     ///
@@ -128,11 +133,12 @@ impl WalManager {
             "traces" => &self.traces_config,
             "logs" => &self.logs_config,
             "metrics" => &self.metrics_config,
+            "profiles" => &self.profiles_config,
             _ => {
                 // Remove guard on failure
                 self.init_guards.lock().await.remove(&key);
                 return Err(anyhow::anyhow!(
-                    "Unknown signal type: {signal_type}. Must be 'traces', 'logs', or 'metrics'"
+                    "Unknown signal type: {signal_type}. Must be 'traces', 'logs', 'metrics', or 'profiles'"
                 ));
             }
         };
@@ -202,7 +208,12 @@ impl WalManager {
     /// Returns the number of newly opened WAL instances.
     pub async fn discover_existing_wals(&self) -> Result<usize, anyhow::Error> {
         let mut base_dirs = Vec::new();
-        for config in [&self.traces_config, &self.logs_config, &self.metrics_config] {
+        for config in [
+            &self.traces_config,
+            &self.logs_config,
+            &self.metrics_config,
+            &self.profiles_config,
+        ] {
             if !base_dirs.contains(&config.wal_dir) {
                 base_dirs.push(config.wal_dir.clone());
             }
@@ -245,7 +256,7 @@ impl WalManager {
     async fn scan_wal_layout(
         base_dir: &std::path::Path,
     ) -> Result<Vec<(String, String, String)>, anyhow::Error> {
-        const SIGNALS: [&str; 3] = ["traces", "logs", "metrics"];
+        const SIGNALS: [&str; 4] = ["traces", "logs", "metrics", "profiles"];
         let mut found = Vec::new();
 
         let mut tenants = tokio::fs::read_dir(base_dir).await?;
@@ -328,6 +339,7 @@ mod tests {
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
+            create_test_config(&base_path),
         );
 
         let _wal = manager
@@ -348,6 +360,7 @@ mod tests {
         let base_path = temp_dir.path().to_path_buf();
 
         let manager = WalManager::new(
+            create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
@@ -378,6 +391,7 @@ mod tests {
         let base_path = temp_dir.path().to_path_buf();
 
         let manager = WalManager::new(
+            create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
@@ -415,6 +429,7 @@ mod tests {
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
+            create_test_config(&base_path),
         );
 
         let wal_prod = manager
@@ -446,6 +461,7 @@ mod tests {
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
+            create_test_config(&base_path),
         );
 
         let wal_traces = manager
@@ -469,11 +485,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_wal_manager_creates_profiles_wal() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_path = temp_dir.path().to_path_buf();
+
+        let manager = WalManager::new(
+            create_test_config(&base_path),
+            create_test_config(&base_path),
+            create_test_config(&base_path),
+            create_test_config(&base_path),
+        );
+
+        let _wal = manager
+            .get_wal("acme", "production", "profiles")
+            .await
+            .unwrap();
+
+        let expected_path = base_path.join("acme").join("production").join("profiles");
+        assert!(expected_path.exists());
+    }
+
+    #[tokio::test]
     async fn test_wal_manager_invalid_signal_type() {
         let temp_dir = TempDir::new().unwrap();
         let base_path = temp_dir.path().to_path_buf();
 
         let manager = WalManager::new(
+            create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
@@ -497,6 +535,7 @@ mod tests {
         let base_path = temp_dir.path().to_path_buf();
 
         let manager = WalManager::new(
+            create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
@@ -533,6 +572,7 @@ mod tests {
         let base_path = temp_dir.path().to_path_buf();
 
         let manager = Arc::new(WalManager::new(
+            create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),
             create_test_config(&base_path),

--- a/src/acceptor/src/handler/wal_retry.rs
+++ b/src/acceptor/src/handler/wal_retry.rs
@@ -211,6 +211,7 @@ mod tests {
             test_config(base_dir),
             test_config(base_dir),
             test_config(base_dir),
+            test_config(base_dir),
         )
     }
 

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -140,10 +140,17 @@ pub async fn init_acceptor_resources(
     metrics_wal_config.max_buffer_entries = 5000;
     metrics_wal_config.flush_interval_secs = 10;
 
+    // Base WAL config for profiles - large payloads, lower entry count
+    let mut profiles_wal_config = WalConfig::with_defaults(wal_dir.clone());
+    profiles_wal_config.max_segment_size = 256 * 1024 * 1024; // 256MB
+    profiles_wal_config.max_buffer_entries = 500;
+    profiles_wal_config.flush_interval_secs = 60;
+
     let wal_manager = Arc::new(WalManager::new(
         traces_wal_config,
         logs_wal_config,
         metrics_wal_config,
+        profiles_wal_config,
     ));
 
     tracing::info!(

--- a/src/common/src/wal/mod.rs
+++ b/src/common/src/wal/mod.rs
@@ -43,6 +43,8 @@ pub enum WalOperation {
     WriteLogs,
     /// Write operation for metric data
     WriteMetrics,
+    /// Write operation for profile data
+    WriteProfiles,
     /// Flush operation to persistent storage
     Flush,
 }

--- a/src/writer/src/processor.rs
+++ b/src/writer/src/processor.rs
@@ -321,6 +321,7 @@ impl WalProcessor {
                         "metrics_gauge".to_string()
                     })
             }
+            common::wal::WalOperation::WriteProfiles => "profiles".to_string(),
             common::wal::WalOperation::Flush => {
                 return Err(anyhow::anyhow!(
                     "Flush operations should not be processed as table writes"

--- a/tests-integration/tests/e2e/end_to_end_logs_metrics_tests.rs
+++ b/tests-integration/tests/e2e/end_to_end_logs_metrics_tests.rs
@@ -154,6 +154,7 @@ async fn setup_logs_metrics_services() -> TestServices {
     let wal_manager = Arc::new(WalManager::new(
         wal_config.clone(),
         wal_config.clone(),
+        wal_config.clone(),
         wal_config,
     ));
 

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -154,10 +154,12 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
     let traces_wal_config = WalConfig::with_defaults(wal_dir.clone());
     let logs_wal_config = WalConfig::with_defaults(wal_dir.clone());
     let metrics_wal_config = WalConfig::with_defaults(wal_dir.clone());
+    let profiles_wal_config = WalConfig::with_defaults(wal_dir.clone());
     let wal_manager = Arc::new(WalManager::new(
         traces_wal_config,
         logs_wal_config,
         metrics_wal_config,
+        profiles_wal_config,
     ));
 
     // Create authenticator

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -217,6 +217,7 @@ async fn setup_test_services() -> TestServices {
         wal_config.clone(), // traces config
         wal_config.clone(), // logs config
         wal_config.clone(), // metrics config
+        wal_config.clone(), // profiles config
     ));
     let trace_handler = TraceHandler::new(flight_transport.clone(), wal_manager.clone());
     let acceptor_service = TraceAcceptorService::new(trace_handler);
@@ -993,6 +994,7 @@ async fn setup_multi_tenant_test_services() -> TestServices {
         acme_wal_config.clone(), // traces config (acme)
         acme_wal_config.clone(), // logs config
         acme_wal_config.clone(), // metrics config
+        acme_wal_config.clone(), // profiles config
     ));
 
     // Create acceptor with gRPC authentication interceptor

--- a/tests-integration/tests/self_monitoring.rs
+++ b/tests-integration/tests/self_monitoring.rs
@@ -102,6 +102,7 @@ async fn self_monitoring_export_lands_in_system_wal() {
         wal_config(&temp_dir, "traces"),
         wal_config(&temp_dir, "logs"),
         wal_config(&temp_dir, "metrics"),
+        wal_config(&temp_dir, "profiles"),
     ));
 
     let trace_handler = TraceHandler::new(flight_transport, wal_manager.clone());
@@ -216,6 +217,7 @@ async fn anti_loop_guard_prevents_reinstrumentation_of_system_requests() {
             wal_config(&temp_dir, "traces"),
             wal_config(&temp_dir, "logs"),
             wal_config(&temp_dir, "metrics"),
+            wal_config(&temp_dir, "profiles"),
         ));
         let service = TraceAcceptorService::new(TraceHandler::new(flight_transport, wal_manager));
 


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1 | #618 enable OTLP profiles proto types | ✅ merged |
| 2 | #619 profile data model + Flight schema | ⏳ auto-merge armed |
| 3 | #623 OTLP → Arrow conversion | 🔁 in review |
| 4 | WAL WriteProfiles operation | 👀 **← this PR** |
| 5+ | Iceberg schema, acceptor, writer, query, APIs | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-03-conversion`), not main.

## This PR only
- `WalOperation::WriteProfiles` variant (bincode-compatible additive change)
- `WalManager` gains a dedicated profiles base config — 256MB segments, 500 buffered entries, 60s flush — isolated under `.wal/{tenant}/{dataset}/profiles/`; discovery/replay scans include the profiles layout
- Writer's `WalProcessor` routes `WriteProfiles` entries to the `profiles` table (full writer integration follows in the #353 layer)
- All `WalManager::new` call sites updated; new unit test for profiles WAL creation/isolation

Closes #348