### PR TITLE
feat(quotas): per-tenant storage quotas backed by Iceberg usage accounting

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -33,7 +33,7 @@ use arrow::array::StringArray;
 
 ```
 OTLP Client (gRPC :4317 / HTTP :4318)
-    -> Acceptor (validates auth, converts OTLP->Arrow, writes to WAL)
+    -> Acceptor (validates auth, enforces rate limits + storage quotas, converts OTLP->Arrow, writes to WAL)
     -> Writer via Flight do_put (transforms v1->v2 schema, writes to WAL)
     -> WalProcessor (background, 5s interval)
     -> Iceberg Tables (Parquet files in object store)

--- a/.claude/skills/configuration/SKILL.md
+++ b/.claude/skills/configuration/SKILL.md
@@ -91,6 +91,7 @@ max_ingest_bytes_per_sec = 10485760   # 10 MiB/s
 max_query_requests_per_sec = 50       # router HTTP query API
 max_api_keys = 10                     # active (non-revoked) keys
 max_datasets = 25
+max_storage_bytes = 107374182400      # 100 GiB live Iceberg data files (eventually consistent)
 burst_seconds = 2.0
 
 [[auth.tenants]]

--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -100,11 +100,16 @@ fields mean unlimited; DB-provisioned tenants get the defaults.
 | `max_query_requests_per_sec` | Router HTTP query API (`/tempo`, `/api/v1`) | 429 |
 | `max_api_keys` (active keys only) | Admin API key creation | 429 `quota_exceeded` |
 | `max_datasets` | Admin API dataset creation | 429 `quota_exceeded` |
+| `max_storage_bytes` | Acceptor (OTLP gRPC, remote_write) | 429 / RESOURCE_EXHAUSTED `quota_exceeded` |
 | `[querier] max_concurrent_queries_per_tenant` | Querier | query rejected |
 
 Token buckets per dimension (`common::ratelimit::TenantRateLimiter`);
-ingest and query budgets are independent. Storage quotas: not yet
-implemented (#610).
+ingest and query budgets are independent. Storage quotas
+(`common::storage_usage::StorageUsageTracker`) compare cached per-tenant
+usage — refreshed from Iceberg manifests every
+`[auth].storage_usage_refresh_interval` (default 60s) — against
+`max_storage_bytes`; enforcement is eventually consistent by design and
+usage is exported as the `signaldb.tenant.storage_usage` gauge.
 
 ## Admin API (Router)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "dashmap",
  "datafusion",
  "figment",
+ "futures",
  "hex",
  "humantime-serde",
  "iceberg-rust",

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -472,6 +472,7 @@ curl http://localhost:3000/health   # Router
 - **API Key Authentication**: SHA-256 hashed keys with config-based and database-backed storage
 - **Internal Flight Auth**: Optional `[auth].internal_service_key` shared secret gates service-to-service Flight calls (writer 50051, router 50053, querier 50054, compactor 50055); when unset, the Flight ports accept unauthenticated calls and must be restricted to a trusted network
 - **Rate Limits**: `[auth].default_limits` sets default per-tenant ingest limits, overridable per tenant
+- **Storage Quotas**: `max_storage_bytes` caps a tenant's live Iceberg data-file bytes; usage is refreshed periodically from table metadata and over-quota ingest is rejected with 429 / RESOURCE_EXHAUSTED (`quota_exceeded`)
 - **Admin API**: Separate admin key for tenant/dataset management
 - **Input Validation**: Tenant/dataset slugs validated against alphanumeric + hyphen pattern; path traversal checks (`../`)
 - **TLS**: Flight supports gRPC-level TLS encryption

--- a/docs/users/prometheus-remote-write.md
+++ b/docs/users/prometheus-remote-write.md
@@ -71,3 +71,4 @@ signaldb-cli query sql "SELECT * FROM metrics_gauge LIMIT 5" \
 | `403` | Key not valid for that tenant/dataset | Use a key issued for the tenant in `X-Tenant-ID` |
 | `400` decode error | Body is not snappy-block-compressed protobuf | Use a standard remote_write client; do not gzip or send framed snappy |
 | `429` | Per-tenant ingest rate limit hit | Prometheus retries automatically; ask your operator about tenant limits |
+| `429` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retries will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |

--- a/docs/users/sending-otlp.md
+++ b/docs/users/sending-otlp.md
@@ -117,4 +117,5 @@ export will appear to succeed but no data is stored.
 | `UNAUTHENTICATED` | API key is wrong or revoked | Check the key with your operator, see [Authentication](authentication.md) |
 | `PERMISSION_DENIED` | Key does not belong to the tenant/dataset you named | Use a key issued for that tenant |
 | `RESOURCE_EXHAUSTED` | Per-tenant ingest rate limit hit | Back off and retry; ask your operator about tenant limits |
+| `RESOURCE_EXHAUSTED` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
 | Exports return 200 but no data is queryable | Exporter uses OTLP/HTTP on :4318 | Switch the exporter to gRPC on :4317 |

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -39,6 +39,10 @@ dsn = "sqlite://.data/signaldb.db"
 # max_query_requests_per_sec = 50       # router HTTP query API
 # max_api_keys = 10                     # active (non-revoked) keys per tenant
 # max_datasets = 25                     # datasets per tenant
+# max_storage_bytes = 107374182400      # 100 GiB of live Iceberg data files;
+#                                       # ingest is rejected while usage is at
+#                                       # or above this cap (eventually
+#                                       # consistent, refreshed periodically)
 # burst_seconds = 2.0                   # burst allowance in seconds of budget
 
 # Tenant definitions with API keys and datasets
@@ -58,6 +62,7 @@ default_dataset = "production"  # Used when X-Dataset-ID header is not provided
 # max_query_requests_per_sec = 200
 # max_api_keys = 20
 # max_datasets = 50
+# max_storage_bytes = 1073741824000     # 1 TiB
 
 # API keys for the Acme tenant
 # Each key can have a descriptive name for auditing

--- a/src/acceptor/src/handler/prometheus_handler.rs
+++ b/src/acceptor/src/handler/prometheus_handler.rs
@@ -32,6 +32,7 @@ use common::{
         transport::InMemoryFlightTransport,
     },
     ratelimit::TenantRateLimiter,
+    storage_usage::StorageUsageTracker,
     wal::{WalOperation, record_batch_to_bytes},
 };
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
@@ -64,6 +65,8 @@ pub struct PrometheusHandler {
     wal_manager: Arc<WalManager>,
     /// Per-tenant ingest rate limiter (no limiting when unset)
     rate_limiter: Option<Arc<TenantRateLimiter>>,
+    /// Per-tenant storage quota enforcement (no quotas when unset)
+    storage_quota: Option<Arc<StorageUsageTracker>>,
 }
 
 impl PrometheusHandler {
@@ -76,12 +79,19 @@ impl PrometheusHandler {
             flight_transport,
             wal_manager,
             rate_limiter: None,
+            storage_quota: None,
         }
     }
 
     /// Enforce per-tenant ingest rate limits on remote_write requests.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
         self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Enforce per-tenant storage quotas on remote_write requests.
+    pub fn with_storage_quota(mut self, storage_quota: Arc<StorageUsageTracker>) -> Self {
+        self.storage_quota = Some(storage_quota);
         self
     }
 
@@ -111,6 +121,14 @@ impl PrometheusHandler {
             limiter
                 .check_ingest(&tenant_context.tenant_id, body.len())
                 .map_err(|e| PrometheusError::RateLimited(e.to_string()))?;
+        }
+
+        // Per-tenant storage quota: a tenant at or over max_storage_bytes
+        // must free space (or get a raised quota) before ingesting more.
+        if let Some(quota) = &self.storage_quota {
+            quota
+                .check_ingest(&tenant_context.tenant_id)
+                .map_err(|e| PrometheusError::QuotaExceeded(e.to_string()))?;
         }
 
         // Log request info
@@ -451,6 +469,7 @@ pub enum PrometheusError {
     WalError(String),
     InternalError(String),
     RateLimited(String),
+    QuotaExceeded(String),
 }
 
 impl std::fmt::Display for PrometheusError {
@@ -461,6 +480,7 @@ impl std::fmt::Display for PrometheusError {
             Self::WalError(msg) => write!(f, "WAL error: {msg}"),
             Self::InternalError(msg) => write!(f, "Internal error: {msg}"),
             Self::RateLimited(msg) => write!(f, "Rate limited: {msg}"),
+            Self::QuotaExceeded(msg) => write!(f, "Quota exceeded: {msg}"),
         }
     }
 }
@@ -475,6 +495,7 @@ impl IntoResponse for PrometheusError {
             Self::WalError(_) => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
             Self::InternalError(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             Self::RateLimited(_) => (StatusCode::TOO_MANY_REQUESTS, self.to_string()),
+            Self::QuotaExceeded(_) => (StatusCode::TOO_MANY_REQUESTS, self.to_string()),
         };
 
         (status, message).into_response()

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -97,6 +97,7 @@ pub struct AcceptorResources {
     pub wal_manager: Arc<WalManager>,
     pub authenticator: Arc<Authenticator>,
     pub rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    pub storage_usage: Arc<common::storage_usage::StorageUsageTracker>,
 }
 
 /// Initialize shared resources for acceptor services
@@ -105,6 +106,10 @@ pub async fn init_acceptor_resources(
     advertise_addr: String,
     wal_dir: std::path::PathBuf,
 ) -> Result<AcceptorResources, anyhow::Error> {
+    // Keep a copy for the storage usage refresher, which needs the full
+    // configuration to open the Iceberg catalog.
+    let full_config = config.clone();
+
     // Initialize service bootstrap for catalog-based discovery
     let service_bootstrap = ServiceBootstrap::new(config, ServiceType::Acceptor, advertise_addr)
         .await
@@ -175,6 +180,37 @@ pub async fn init_acceptor_resources(
         &auth_config,
     ));
 
+    // Per-tenant storage quota enforcement. The tracker itself is a cheap
+    // cache; the Iceberg-metadata accounting loop only runs when at least
+    // one max_storage_bytes quota is configured.
+    let storage_usage =
+        Arc::new(common::storage_usage::StorageUsageTracker::from_auth_config(&auth_config));
+    if storage_usage.quotas_configured() {
+        let refresh_interval = full_config.auth.storage_usage_refresh_interval;
+        // Failing to build the catalog here must fail startup: the
+        // configuration promises storage quotas, and starting without
+        // accounting would silently not enforce them.
+        let catalog_manager = Arc::new(
+            common::catalog_manager::CatalogManager::new(full_config)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "max_storage_bytes is configured but the Iceberg catalog for \
+                         storage usage accounting could not be initialized: {e:#}"
+                    )
+                })?,
+        );
+        common::storage_usage::spawn_usage_refresher(
+            catalog_manager,
+            storage_usage.clone(),
+            refresh_interval,
+        );
+        tracing::info!(
+            refresh_interval = ?refresh_interval,
+            "Started per-tenant storage usage refresher for quota enforcement"
+        );
+    }
+
     // Create Authenticator for multi-tenant authentication
     let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 
@@ -185,6 +221,7 @@ pub async fn init_acceptor_resources(
         wal_manager,
         authenticator,
         rate_limiter,
+        storage_usage,
     })
 }
 
@@ -207,27 +244,32 @@ pub async fn serve_otlp_grpc(
         wal_manager,
         authenticator,
         rate_limiter,
+        storage_usage,
     } = config.resources;
 
     // Set up OTLP/gRPC services with handler pattern, WAL Manager integration, and auth interceptor
     let log_handler = LogHandler::new(flight_transport.clone(), wal_manager.clone());
-    let log_service = LogAcceptorService::new(log_handler).with_rate_limiter(rate_limiter.clone());
+    let log_service = LogAcceptorService::new(log_handler)
+        .with_rate_limiter(rate_limiter.clone())
+        .with_storage_quota(storage_usage.clone());
     let auth_for_logs = authenticator.clone();
     let log_server = LogsServiceServer::with_interceptor(log_service, move |req| {
         grpc_auth_interceptor(auth_for_logs.clone(), req)
     });
 
     let trace_handler = TraceHandler::new(flight_transport.clone(), wal_manager.clone());
-    let trace_service =
-        TraceAcceptorService::new(trace_handler).with_rate_limiter(rate_limiter.clone());
+    let trace_service = TraceAcceptorService::new(trace_handler)
+        .with_rate_limiter(rate_limiter.clone())
+        .with_storage_quota(storage_usage.clone());
     let auth_for_traces = authenticator.clone();
     let trace_server = TraceServiceServer::with_interceptor(trace_service, move |req| {
         grpc_auth_interceptor(auth_for_traces.clone(), req)
     });
 
     let metrics_handler = MetricsHandler::new(flight_transport.clone(), wal_manager.clone());
-    let metrics_service =
-        MetricsAcceptorService::new(metrics_handler).with_rate_limiter(rate_limiter.clone());
+    let metrics_service = MetricsAcceptorService::new(metrics_handler)
+        .with_rate_limiter(rate_limiter.clone())
+        .with_storage_quota(storage_usage.clone());
     let auth_for_metrics = authenticator.clone();
     let metric_server = MetricsServiceServer::with_interceptor(metrics_service, move |req| {
         grpc_auth_interceptor(auth_for_metrics.clone(), req)
@@ -347,6 +389,7 @@ pub struct HttpAcceptorConfig {
     pub wal_manager: Arc<WalManager>,
     pub authenticator: Arc<Authenticator>,
     pub rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    pub storage_usage: Arc<common::storage_usage::StorageUsageTracker>,
 }
 
 pub async fn serve_otlp_http(
@@ -360,7 +403,8 @@ pub async fn serve_otlp_http(
     // Create Prometheus handler with shared resources
     let prometheus_handler = Arc::new(
         PrometheusHandler::new(config.flight_transport.clone(), config.wal_manager.clone())
-            .with_rate_limiter(config.rate_limiter.clone()),
+            .with_rate_limiter(config.rate_limiter.clone())
+            .with_storage_quota(config.storage_usage.clone()),
     );
 
     // Build combined router with health, traces, and Prometheus endpoints

--- a/src/acceptor/src/main.rs
+++ b/src/acceptor/src/main.rs
@@ -126,6 +126,7 @@ async fn main() -> Result<()> {
         wal_manager: Arc::clone(&resources.wal_manager),
         authenticator: Arc::clone(&resources.authenticator),
         rate_limiter: Arc::clone(&resources.rate_limiter),
+        storage_usage: Arc::clone(&resources.storage_usage),
     };
 
     let http_resources = AcceptorResources {
@@ -133,6 +134,7 @@ async fn main() -> Result<()> {
         wal_manager: Arc::clone(&resources.wal_manager),
         authenticator: Arc::clone(&resources.authenticator),
         rate_limiter: Arc::clone(&resources.rate_limiter),
+        storage_usage: Arc::clone(&resources.storage_usage),
     };
 
     // Channels for OTLP/gRPC server signals
@@ -165,6 +167,7 @@ async fn main() -> Result<()> {
         wal_manager: http_resources.wal_manager,
         authenticator: http_resources.authenticator,
         rate_limiter: http_resources.rate_limiter,
+        storage_usage: http_resources.storage_usage,
     };
     let http_handle = tokio::spawn(async move {
         if let Err(e) =

--- a/src/acceptor/src/middleware/auth.rs
+++ b/src/acceptor/src/middleware/auth.rs
@@ -409,9 +409,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/acceptor/src/middleware/grpc_auth.rs
+++ b/src/acceptor/src/middleware/grpc_auth.rs
@@ -300,9 +300,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 
@@ -331,9 +329,7 @@ mod tests {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
             tenants: vec![],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 
@@ -351,9 +347,7 @@ mod tests {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
             tenants: vec![],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/acceptor/src/services/otlp_log_service.rs
+++ b/src/acceptor/src/services/otlp_log_service.rs
@@ -7,6 +7,7 @@ use crate::handler::otlp_log_handler::LogHandler;
 use crate::middleware::get_tenant_context;
 use common::auth::TenantContext;
 use common::ratelimit::TenantRateLimiter;
+use common::storage_usage::StorageUsageTracker;
 use prost::Message;
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ impl LogHandlerTrait for LogHandler {
 pub struct LogAcceptorService<H: LogHandlerTrait> {
     handler: H,
     rate_limiter: Option<Arc<TenantRateLimiter>>,
+    storage_quota: Option<Arc<StorageUsageTracker>>,
 }
 
 impl<H: LogHandlerTrait> LogAcceptorService<H> {
@@ -40,12 +42,19 @@ impl<H: LogHandlerTrait> LogAcceptorService<H> {
         Self {
             handler,
             rate_limiter: None,
+            storage_quota: None,
         }
     }
 
     /// Enforce per-tenant ingest rate limits on this service.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
         self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Enforce per-tenant storage quotas on this service.
+    pub fn with_storage_quota(mut self, storage_quota: Arc<StorageUsageTracker>) -> Self {
+        self.storage_quota = Some(storage_quota);
         self
     }
 }
@@ -66,6 +75,14 @@ impl<H: LogHandlerTrait + Send + Sync + 'static> LogsService for LogAcceptorServ
         if let Some(limiter) = &self.rate_limiter {
             limiter
                 .check_ingest(&tenant_context.tenant_id, request_inner.encoded_len())
+                .map_err(|e| Status::resource_exhausted(e.to_string()))?;
+        }
+
+        // Per-tenant storage quota: a tenant at or over max_storage_bytes
+        // must free space (or get a raised quota) before ingesting more.
+        if let Some(quota) = &self.storage_quota {
+            quota
+                .check_ingest(&tenant_context.tenant_id)
                 .map_err(|e| Status::resource_exhausted(e.to_string()))?;
         }
 

--- a/src/acceptor/src/services/otlp_metric_service.rs
+++ b/src/acceptor/src/services/otlp_metric_service.rs
@@ -8,6 +8,7 @@ use crate::handler::otlp_metrics_handler::MetricsHandler;
 use crate::middleware::get_tenant_context;
 use common::auth::TenantContext;
 use common::ratelimit::TenantRateLimiter;
+use common::storage_usage::StorageUsageTracker;
 use prost::Message;
 use std::sync::Arc;
 
@@ -34,6 +35,7 @@ impl MetricsHandlerTrait for MetricsHandler {
 pub struct MetricsAcceptorService<H: MetricsHandlerTrait> {
     handler: H,
     rate_limiter: Option<Arc<TenantRateLimiter>>,
+    storage_quota: Option<Arc<StorageUsageTracker>>,
 }
 
 impl<H: MetricsHandlerTrait> MetricsAcceptorService<H> {
@@ -41,12 +43,19 @@ impl<H: MetricsHandlerTrait> MetricsAcceptorService<H> {
         Self {
             handler,
             rate_limiter: None,
+            storage_quota: None,
         }
     }
 
     /// Enforce per-tenant ingest rate limits on this service.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
         self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Enforce per-tenant storage quotas on this service.
+    pub fn with_storage_quota(mut self, storage_quota: Arc<StorageUsageTracker>) -> Self {
+        self.storage_quota = Some(storage_quota);
         self
     }
 }
@@ -67,6 +76,14 @@ impl<H: MetricsHandlerTrait + Send + Sync + 'static> MetricsService for MetricsA
         if let Some(limiter) = &self.rate_limiter {
             limiter
                 .check_ingest(&tenant_context.tenant_id, request_inner.encoded_len())
+                .map_err(|e| Status::resource_exhausted(e.to_string()))?;
+        }
+
+        // Per-tenant storage quota: a tenant at or over max_storage_bytes
+        // must free space (or get a raised quota) before ingesting more.
+        if let Some(quota) = &self.storage_quota {
+            quota
+                .check_ingest(&tenant_context.tenant_id)
                 .map_err(|e| Status::resource_exhausted(e.to_string()))?;
         }
 

--- a/src/acceptor/src/services/otlp_trace_service.rs
+++ b/src/acceptor/src/services/otlp_trace_service.rs
@@ -7,6 +7,7 @@ use crate::handler::otlp_grpc::TraceHandler;
 use crate::middleware::get_tenant_context;
 use common::auth::TenantContext;
 use common::ratelimit::TenantRateLimiter;
+use common::storage_usage::StorageUsageTracker;
 use prost::Message;
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ impl TraceHandlerTrait for TraceHandler {
 pub struct TraceAcceptorService<H: TraceHandlerTrait> {
     handler: H,
     rate_limiter: Option<Arc<TenantRateLimiter>>,
+    storage_quota: Option<Arc<StorageUsageTracker>>,
 }
 
 impl<H: TraceHandlerTrait> TraceAcceptorService<H> {
@@ -40,12 +42,19 @@ impl<H: TraceHandlerTrait> TraceAcceptorService<H> {
         Self {
             handler,
             rate_limiter: None,
+            storage_quota: None,
         }
     }
 
     /// Enforce per-tenant ingest rate limits on this service.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
         self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Enforce per-tenant storage quotas on this service.
+    pub fn with_storage_quota(mut self, storage_quota: Arc<StorageUsageTracker>) -> Self {
+        self.storage_quota = Some(storage_quota);
         self
     }
 }
@@ -66,6 +75,14 @@ impl<H: TraceHandlerTrait + Send + Sync + 'static> TraceService for TraceAccepto
         if let Some(limiter) = &self.rate_limiter {
             limiter
                 .check_ingest(&tenant_context.tenant_id, request_inner.encoded_len())
+                .map_err(|e| Status::resource_exhausted(e.to_string()))?;
+        }
+
+        // Per-tenant storage quota: a tenant at or over max_storage_bytes
+        // must free space (or get a raised quota) before ingesting more.
+        if let Some(quota) = &self.storage_quota {
+            quota
+                .check_ingest(&tenant_context.tenant_id)
                 .map_err(|e| Status::resource_exhausted(e.to_string()))?;
         }
 
@@ -237,6 +254,45 @@ mod tests {
 
         assert_eq!(status.code(), tonic::Code::ResourceExhausted);
         assert!(status.message().contains("request rate"));
+    }
+
+    #[tokio::test]
+    async fn export_rejects_with_resource_exhausted_when_over_storage_quota() {
+        use common::config::{AuthConfig, TenantLimits};
+        use common::storage_usage::StorageUsageTracker;
+        use std::collections::HashMap;
+
+        let tenant_id = test_tenant_context().tenant_id;
+        let tracker = Arc::new(StorageUsageTracker::from_auth_config(&AuthConfig {
+            default_limits: TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+        let service =
+            TraceAcceptorService::new(NoopTraceHandler).with_storage_quota(tracker.clone());
+
+        // Under quota: export passes.
+        tracker.replace_all(HashMap::from([(tenant_id.clone(), 999)]));
+        let mut under = Request::new(ExportTraceServiceRequest::default());
+        under.extensions_mut().insert(test_tenant_context());
+        service
+            .export(under)
+            .await
+            .expect("export under quota must pass");
+
+        // Usage refresh reports the tenant at its cap: export is rejected.
+        tracker.replace_all(HashMap::from([(tenant_id, 1_000)]));
+        let mut over = Request::new(ExportTraceServiceRequest::default());
+        over.extensions_mut().insert(test_tenant_context());
+        let status = service
+            .export(over)
+            .await
+            .expect_err("export at quota must be rejected");
+
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert!(status.message().contains("quota_exceeded"));
     }
 
     #[tokio::test]

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -40,6 +40,7 @@ humantime-serde.workspace = true
 sqlx.workspace = true
 uuid.workspace = true
 dashmap.workspace = true
+futures.workspace = true
 chrono = { workspace = true }
 
 arrow-flight.workspace = true

--- a/src/common/src/auth/authenticator.rs
+++ b/src/common/src/auth/authenticator.rs
@@ -272,9 +272,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
 
         let authenticator = Authenticator::new(auth_config, catalog);
@@ -307,9 +305,7 @@ mod tests {
         let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
         let auth_config = AuthConfig {
             tenants: vec![],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -343,9 +339,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -381,9 +375,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 
@@ -413,9 +405,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Authenticator::new(auth_config, catalog);
 

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -322,9 +322,7 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
 

--- a/src/common/src/catalog_manager.rs
+++ b/src/common/src/catalog_manager.rs
@@ -219,9 +219,7 @@ mod tests {
                         limits: None,
                     },
                 ],
-                admin_api_key: None,
-                internal_service_key: None,
-                default_limits: Default::default(),
+                ..Default::default()
             },
             storage: StorageConfig {
                 dsn: "memory://".to_string(),

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -545,6 +545,11 @@ pub struct TenantLimits {
     pub max_api_keys: Option<u32>,
     /// Maximum number of datasets.
     pub max_datasets: Option<u32>,
+    /// Maximum total storage (live Iceberg data-file bytes) the tenant may
+    /// hold. Ingest is rejected while usage is at or above this cap.
+    /// Enforcement is eventually consistent: usage is refreshed
+    /// periodically from table metadata, not on the hot path.
+    pub max_storage_bytes: Option<u64>,
     /// Burst allowance in seconds of budget (minimum 1.0).
     pub burst_seconds: f64,
 }
@@ -557,6 +562,7 @@ impl Default for TenantLimits {
             max_query_requests_per_sec: None,
             max_api_keys: None,
             max_datasets: None,
+            max_storage_bytes: None,
             burst_seconds: 2.0,
         }
     }
@@ -568,12 +574,19 @@ impl Default for TenantLimits {
 /// query surfaces; there is no off switch (the former `enabled` flag was
 /// dead config that never gated anything, issue #553). The internal
 /// Flight mesh is separately controlled by `internal_service_key`.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthConfig {
     /// Default rate limits and quotas applied to every tenant without an
     /// explicit `limits` override. Unset fields mean unlimited.
     #[serde(default)]
     pub default_limits: TenantLimits,
+    /// How often per-tenant storage usage is recomputed from Iceberg table
+    /// metadata when any `max_storage_bytes` quota is configured.
+    #[serde(
+        default = "default_storage_usage_refresh_interval",
+        with = "humantime_serde"
+    )]
+    pub storage_usage_refresh_interval: Duration,
     /// List of configured tenants
     #[serde(default)]
     pub tenants: Vec<TenantConfig>,
@@ -589,6 +602,22 @@ pub struct AuthConfig {
     /// network.
     #[serde(default)]
     pub internal_service_key: Option<String>,
+}
+
+fn default_storage_usage_refresh_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            default_limits: TenantLimits::default(),
+            storage_usage_refresh_interval: default_storage_usage_refresh_interval(),
+            tenants: Vec::new(),
+            admin_api_key: None,
+            internal_service_key: None,
+        }
+    }
 }
 
 impl AuthConfig {

--- a/src/common/src/flight/auth.rs
+++ b/src/common/src/flight/auth.rs
@@ -191,9 +191,8 @@ mod tests {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
             internal_service_key: Some("internal-secret".to_string()),
-            default_limits: Default::default(),
+            ..Default::default()
         };
         let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
         FlightAuthInterceptor::new(authenticator, "internal-secret".to_string())

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod schema;
 pub mod self_monitoring;
 pub mod service_bootstrap;
 pub mod storage;
+pub mod storage_usage;
 pub mod tenant_api;
 pub mod wal;
 

--- a/src/common/src/self_monitoring/app_metrics.rs
+++ b/src/common/src/self_monitoring/app_metrics.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 use opentelemetry::global;
-use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, UpDownCounter};
 
 use super::suppress::is_self_monitoring_tenant;
 
@@ -53,6 +53,9 @@ pub struct AppMetrics {
     pub ingest_metrics_received: Counter<u64>,
     pub ingest_batches_written: Counter<u64>,
     pub ingest_batch_size: Histogram<u64>,
+
+    // Tenant storage accounting
+    pub tenant_storage_usage_bytes: Gauge<u64>,
 }
 
 static APP_METRICS: OnceLock<AppMetrics> = OnceLock::new();
@@ -181,6 +184,11 @@ impl AppMetrics {
                 .u64_histogram("signaldb.ingest.batch_size")
                 .with_description("Rows per forwarded record batch")
                 .with_unit("{row}")
+                .build(),
+            tenant_storage_usage_bytes: meter
+                .u64_gauge("signaldb.tenant.storage_usage")
+                .with_description("Live Iceberg data-file bytes stored per tenant")
+                .with_unit("By")
                 .build(),
         }
     }

--- a/src/common/src/storage_usage.rs
+++ b/src/common/src/storage_usage.rs
@@ -1,0 +1,442 @@
+//! # Per-Tenant Storage Usage Accounting
+//!
+//! Tracks how many bytes of live Iceberg data files each tenant holds and
+//! enforces the optional `max_storage_bytes` quota on the ingest paths.
+//!
+//! Usage is computed from table metadata (manifest entries carry
+//! `file_size_in_bytes`), so replaced or deleted files never double-count:
+//! compaction and retention shrink usage as soon as the next refresh runs.
+//!
+//! Enforcement is deliberately eventually consistent. A periodic refresher
+//! ([`spawn_usage_refresher`]) recomputes usage off the hot path and swaps
+//! it into the [`StorageUsageTracker`]; ingest checks only compare the
+//! cached value against the tenant's quota. A tenant may therefore
+//! overshoot its cap by up to one refresh interval of ingest — that lag is
+//! accepted by design (issue #610).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use futures::StreamExt;
+use iceberg_rust::spec::manifest::Status;
+
+use crate::catalog_manager::CatalogManager;
+use crate::config::{AuthConfig, TenantLimits};
+
+/// Error returned when a tenant is at or over its storage quota.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageQuotaExceeded {
+    pub tenant_id: String,
+    pub usage_bytes: u64,
+    pub limit_bytes: u64,
+}
+
+impl std::fmt::Display for StorageQuotaExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "quota_exceeded: tenant '{}' uses {} bytes of storage, at or over its {} byte quota; \
+             delete data, lower retention, or raise the tenant's max_storage_bytes",
+            self.tenant_id, self.usage_bytes, self.limit_bytes
+        )
+    }
+}
+
+impl std::error::Error for StorageQuotaExceeded {}
+
+/// Cached per-tenant storage usage with quota checks for the ingest paths.
+///
+/// Cheap to check on the hot path: one `DashMap` read. Usage values are
+/// written by the periodic refresher, not by ingest itself.
+pub struct StorageUsageTracker {
+    defaults: TenantLimits,
+    overrides: HashMap<String, TenantLimits>,
+    usage: DashMap<String, u64>,
+}
+
+impl StorageUsageTracker {
+    /// Build a tracker from auth configuration: global `default_limits`
+    /// plus per-tenant overrides.
+    pub fn from_auth_config(auth: &AuthConfig) -> Self {
+        let overrides = auth
+            .tenants
+            .iter()
+            .filter_map(|t| t.limits.clone().map(|l| (t.id.clone(), l)))
+            .collect();
+        Self {
+            defaults: auth.default_limits.clone(),
+            overrides,
+            usage: DashMap::new(),
+        }
+    }
+
+    /// Whether any storage quota is configured at all. When false, no
+    /// usage accounting is needed and the refresher can be skipped.
+    pub fn quotas_configured(&self) -> bool {
+        self.defaults.max_storage_bytes.is_some()
+            || self
+                .overrides
+                .values()
+                .any(|l| l.max_storage_bytes.is_some())
+    }
+
+    /// The storage quota that applies to `tenant_id`, if any.
+    fn limit_for(&self, tenant_id: &str) -> Option<u64> {
+        self.overrides
+            .get(tenant_id)
+            .unwrap_or(&self.defaults)
+            .max_storage_bytes
+    }
+
+    /// Reject ingest for a tenant whose known usage is at or over its
+    /// quota. Tenants without a quota, or whose usage has not been
+    /// computed yet, always pass — accounting lag must not block ingest.
+    pub fn check_ingest(&self, tenant_id: &str) -> Result<(), StorageQuotaExceeded> {
+        let Some(limit_bytes) = self.limit_for(tenant_id) else {
+            return Ok(());
+        };
+        let Some(usage_bytes) = self.usage.get(tenant_id).map(|u| *u) else {
+            return Ok(());
+        };
+        if usage_bytes >= limit_bytes {
+            return Err(StorageQuotaExceeded {
+                tenant_id: tenant_id.to_string(),
+                usage_bytes,
+                limit_bytes,
+            });
+        }
+        Ok(())
+    }
+
+    /// Replace the cached usage for all tenants with a fresh computation.
+    /// Tenants absent from `usage` are removed (their tables are gone).
+    pub fn replace_all(&self, usage: HashMap<String, u64>) {
+        self.usage
+            .retain(|tenant_id, _| usage.contains_key(tenant_id));
+        for (tenant_id, bytes) in usage {
+            self.usage.insert(tenant_id, bytes);
+        }
+    }
+
+    /// Known usage for one tenant, if computed.
+    pub fn usage_bytes(&self, tenant_id: &str) -> Option<u64> {
+        self.usage.get(tenant_id).map(|u| *u)
+    }
+
+    /// Snapshot of all known tenant usages, for metrics and operators.
+    pub fn snapshot(&self) -> Vec<(String, u64)> {
+        self.usage
+            .iter()
+            .map(|e| (e.key().clone(), *e.value()))
+            .collect()
+    }
+}
+
+/// Compute per-tenant storage usage from Iceberg table metadata.
+///
+/// Walks every namespace in the catalog (namespaces are
+/// `[tenant_slug, dataset_slug]`), sums `file_size_in_bytes` over the live
+/// (non-deleted) data files of every table, and groups the totals by tenant
+/// id. Tenant slugs are mapped back to tenant ids via configuration;
+/// runtime-provisioned tenants (no config entry) key by their slug, which
+/// equals their id.
+///
+/// Per-table and per-namespace failures are logged and skipped rather than
+/// failing the whole pass: a partial (under-counted) refresh is more useful
+/// than none, and the next pass retries.
+pub async fn compute_usage(catalog_manager: &CatalogManager) -> Result<HashMap<String, u64>> {
+    let catalog = catalog_manager.catalog();
+    let namespaces = catalog
+        .list_namespaces(None)
+        .await
+        .context("Failed to list namespaces for storage usage accounting")?;
+
+    let slug_to_tenant_id: HashMap<String, String> = catalog_manager
+        .config()
+        .auth
+        .tenants
+        .iter()
+        .map(|t| (t.slug.clone(), t.id.clone()))
+        .collect();
+
+    let mut usage: HashMap<String, u64> = HashMap::new();
+    for namespace in &namespaces {
+        let Some(tenant_slug) = namespace.iter().next() else {
+            continue;
+        };
+        let tenant_id = slug_to_tenant_id
+            .get(tenant_slug.as_str())
+            .cloned()
+            .unwrap_or_else(|| tenant_slug.clone());
+        // A tenant with namespaces but no readable files still gets an
+        // entry, so stale cached usage is replaced by the fresh count.
+        let tenant_usage = usage.entry(tenant_id).or_default();
+
+        let identifiers = match catalog.list_tabulars(namespace).await {
+            Ok(identifiers) => identifiers,
+            Err(e) => {
+                tracing::warn!(
+                    namespace = ?namespace,
+                    error = %e,
+                    "Skipping namespace in storage usage accounting: listing tables failed"
+                );
+                continue;
+            }
+        };
+        for identifier in identifiers {
+            match table_live_bytes(catalog.clone(), &identifier).await {
+                Ok(bytes) => *tenant_usage += bytes,
+                Err(e) => {
+                    tracing::warn!(
+                        table = %identifier,
+                        error = %e,
+                        "Skipping table in storage usage accounting; usage is under-counted \
+                         until the next successful refresh"
+                    );
+                }
+            }
+        }
+    }
+    Ok(usage)
+}
+
+/// Sum of `file_size_in_bytes` over the live data files in the table's
+/// current snapshot.
+async fn table_live_bytes(
+    catalog: Arc<dyn iceberg_rust::catalog::Catalog>,
+    identifier: &iceberg_rust::catalog::identifier::Identifier,
+) -> Result<u64> {
+    let tabular = catalog
+        .load_tabular(identifier)
+        .await
+        .context("Failed to load table")?;
+    let iceberg_rust::catalog::tabular::Tabular::Table(table) = tabular else {
+        // Views and materialized views hold no data files of their own.
+        return Ok(0);
+    };
+
+    let manifests = table
+        .manifests(None, None)
+        .await
+        .context("Failed to read manifest list from current snapshot")?;
+    if manifests.is_empty() {
+        return Ok(0);
+    }
+
+    let file_iter = table
+        .datafiles(&manifests, None, (None, None))
+        .await
+        .context("Failed to read data files from manifests")?;
+
+    let mut total = 0u64;
+    let mut file_iter = std::pin::pin!(file_iter);
+    while let Some(result) = file_iter.next().await {
+        let (_, entry) = result.context("Failed to read manifest entry")?;
+        if *entry.status() != Status::Deleted {
+            total += *entry.data_file().file_size_in_bytes() as u64;
+        }
+    }
+    Ok(total)
+}
+
+/// Spawn the periodic usage refresher: recompute per-tenant usage every
+/// `interval`, publish it to the tracker, and export it as the
+/// `signaldb.tenant.storage_usage` gauge.
+///
+/// The first pass runs immediately so quotas take effect shortly after
+/// startup rather than one full interval later.
+pub fn spawn_usage_refresher(
+    catalog_manager: Arc<CatalogManager>,
+    tracker: Arc<StorageUsageTracker>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            match compute_usage(&catalog_manager).await {
+                Ok(usage) => {
+                    let metrics = crate::self_monitoring::app_metrics();
+                    for (tenant_id, bytes) in &usage {
+                        metrics.tenant_storage_usage_bytes.record(
+                            *bytes,
+                            &[opentelemetry::KeyValue::new("tenant_id", tenant_id.clone())],
+                        );
+                    }
+                    tracing::debug!(tenants = usage.len(), "Refreshed per-tenant storage usage");
+                    tracker.replace_all(usage);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to refresh per-tenant storage usage; keeping previous values"
+                    );
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TenantConfig;
+
+    fn tenant_with_limits(id: &str, limits: TenantLimits) -> TenantConfig {
+        TenantConfig {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: id.to_string(),
+            default_dataset: None,
+            datasets: vec![],
+            api_keys: vec![],
+            schema_config: None,
+            limits: Some(limits),
+        }
+    }
+
+    fn tracker(defaults: TenantLimits, tenants: Vec<TenantConfig>) -> StorageUsageTracker {
+        let auth = AuthConfig {
+            default_limits: defaults,
+            tenants,
+            ..Default::default()
+        };
+        StorageUsageTracker::from_auth_config(&auth)
+    }
+
+    #[test]
+    fn unlimited_without_quota_configuration() {
+        let tracker = tracker(TenantLimits::default(), vec![]);
+        assert!(!tracker.quotas_configured());
+        tracker.replace_all(HashMap::from([("acme".to_string(), u64::MAX)]));
+        assert!(tracker.check_ingest("acme").is_ok());
+    }
+
+    #[test]
+    fn unknown_usage_passes_even_with_quota() {
+        let tracker = tracker(
+            TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            vec![],
+        );
+        assert!(tracker.quotas_configured());
+        // No usage computed yet: accounting lag must not block ingest.
+        assert!(tracker.check_ingest("acme").is_ok());
+    }
+
+    #[test]
+    fn usage_at_or_over_quota_rejects() {
+        let tracker = tracker(
+            TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            vec![],
+        );
+        tracker.replace_all(HashMap::from([
+            ("under".to_string(), 999),
+            ("at".to_string(), 1_000),
+            ("over".to_string(), 1_001),
+        ]));
+
+        assert!(tracker.check_ingest("under").is_ok());
+        let at = tracker.check_ingest("at").unwrap_err();
+        assert_eq!(at.usage_bytes, 1_000);
+        assert_eq!(at.limit_bytes, 1_000);
+        let over = tracker.check_ingest("over").unwrap_err();
+        assert_eq!(over.usage_bytes, 1_001);
+        assert!(over.to_string().contains("quota_exceeded"));
+        assert!(over.to_string().contains("over"));
+    }
+
+    #[test]
+    fn per_tenant_override_beats_default() {
+        let tracker = tracker(
+            TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            vec![tenant_with_limits(
+                "vip",
+                TenantLimits {
+                    max_storage_bytes: Some(1_000_000),
+                    ..Default::default()
+                },
+            )],
+        );
+        tracker.replace_all(HashMap::from([
+            ("vip".to_string(), 500_000),
+            ("acme".to_string(), 500_000),
+        ]));
+
+        assert!(tracker.check_ingest("vip").is_ok());
+        assert!(tracker.check_ingest("acme").is_err());
+    }
+
+    #[test]
+    fn override_without_storage_quota_is_unlimited() {
+        // A tenant override replaces the defaults wholesale, matching the
+        // rate limiter's semantics: an override that leaves
+        // max_storage_bytes unset means unlimited for that tenant.
+        let tracker = tracker(
+            TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            vec![tenant_with_limits(
+                "special",
+                TenantLimits {
+                    max_ingest_requests_per_sec: Some(10),
+                    ..Default::default()
+                },
+            )],
+        );
+        tracker.replace_all(HashMap::from([("special".to_string(), 5_000)]));
+        assert!(tracker.check_ingest("special").is_ok());
+    }
+
+    #[test]
+    fn replace_all_drops_stale_tenants() {
+        let tracker = tracker(
+            TenantLimits {
+                max_storage_bytes: Some(1_000),
+                ..Default::default()
+            },
+            vec![],
+        );
+        tracker.replace_all(HashMap::from([("gone".to_string(), 2_000)]));
+        assert!(tracker.check_ingest("gone").is_err());
+
+        // The tenant's tables were removed; the next refresh no longer
+        // reports it and ingest unblocks.
+        tracker.replace_all(HashMap::new());
+        assert_eq!(tracker.usage_bytes("gone"), None);
+        assert!(tracker.check_ingest("gone").is_ok());
+    }
+
+    #[tokio::test]
+    async fn compute_usage_empty_catalog_reports_nothing() {
+        let manager = CatalogManager::new_in_memory().await.unwrap();
+        let usage = compute_usage(&manager).await.unwrap();
+        assert!(usage.is_empty());
+    }
+
+    #[tokio::test]
+    async fn compute_usage_counts_empty_tables_as_zero() {
+        let manager = CatalogManager::new_in_memory().await.unwrap();
+        // Creates the namespace and an empty traces table for the default
+        // tenant/dataset.
+        manager
+            .ensure_table("default", "default", "traces")
+            .await
+            .unwrap();
+        let usage = compute_usage(&manager).await.unwrap();
+        assert_eq!(usage.get("default"), Some(&0));
+    }
+}

--- a/src/signaldb-bin/src/main.rs
+++ b/src/signaldb-bin/src/main.rs
@@ -310,6 +310,7 @@ async fn main() -> Result<()> {
         wal_manager: Arc::clone(&acceptor_resources.wal_manager),
         authenticator: Arc::clone(&acceptor_resources.authenticator),
         rate_limiter: Arc::clone(&acceptor_resources.rate_limiter),
+        storage_usage: Arc::clone(&acceptor_resources.storage_usage),
     };
 
     let http_resources = AcceptorResources {
@@ -317,6 +318,7 @@ async fn main() -> Result<()> {
         wal_manager: Arc::clone(&acceptor_resources.wal_manager),
         authenticator: Arc::clone(&acceptor_resources.authenticator),
         rate_limiter: Arc::clone(&acceptor_resources.rate_limiter),
+        storage_usage: Arc::clone(&acceptor_resources.storage_usage),
     };
 
     // Start OTLP/gRPC server
@@ -342,6 +344,7 @@ async fn main() -> Result<()> {
         wal_manager: http_resources.wal_manager,
         authenticator: http_resources.authenticator,
         rate_limiter: http_resources.rate_limiter,
+        storage_usage: http_resources.storage_usage,
     };
     let http_handle = tokio::spawn(async move {
         serve_otlp_http(

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -63,6 +63,10 @@ name = "self_monitoring"
 path = "tests/self_monitoring.rs"
 
 [[test]]
+name = "storage_quota"
+path = "tests/storage_quota.rs"
+
+[[test]]
 name = "iceberg_integration"
 path = "tests/writer/iceberg_integration.rs"
 

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -114,6 +114,7 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
         admin_api_key: None,
         internal_service_key: None,
         default_limits: Default::default(),
+        storage_usage_refresh_interval: std::time::Duration::from_secs(60),
         tenants: vec![common::config::TenantConfig {
             id: "test-tenant".to_string(),
             slug: "test-tenant".to_string(),

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -108,6 +108,7 @@ async fn setup_test_services() -> TestServices {
         admin_api_key: None,
         internal_service_key: None,
         default_limits: Default::default(),
+        storage_usage_refresh_interval: std::time::Duration::from_secs(60),
     };
 
     let wal_config = WalConfig {
@@ -758,6 +759,7 @@ async fn test_tempo_v2_trace_endpoint() {
         admin_api_key: None,
         internal_service_key: None,
         default_limits: Default::default(),
+        storage_usage_refresh_interval: std::time::Duration::from_secs(60),
     };
     let state = InMemoryStateImpl::new(catalog, config);
 
@@ -871,6 +873,7 @@ async fn setup_multi_tenant_test_services() -> TestServices {
         admin_api_key: None,
         internal_service_key: None,
         default_limits: Default::default(),
+        storage_usage_refresh_interval: std::time::Duration::from_secs(60),
     };
 
     // Create WAL configs for both tenants

--- a/tests-integration/tests/storage_quota.rs
+++ b/tests-integration/tests/storage_quota.rs
@@ -1,0 +1,115 @@
+//! Per-tenant storage quota integration test (issue #610)
+//!
+//! Exercises the real accounting path: writes actual Parquet data files
+//! into an Iceberg table, computes per-tenant usage from table metadata,
+//! cross-checks it against the manifest reader, and verifies that the
+//! quota gate rejects ingest for a tenant over its `max_storage_bytes`.
+
+use anyhow::Result;
+use common::catalog_manager::CatalogManager;
+use common::storage_usage::{StorageUsageTracker, compute_usage};
+use object_store::memory::InMemory;
+use std::sync::Arc;
+use tests_integration::fixtures::{DataGeneratorConfig, PartitionGranularity};
+use tests_integration::generators;
+use writer::IcebergTableWriter;
+
+/// The tenant slug (== id here) whose usage the test tracks.
+const TENANT: &str = "quota-tenant";
+const DATASET: &str = "quota-dataset";
+
+async fn write_traces(catalog_manager: &Arc<CatalogManager>, writes: usize) -> Result<()> {
+    let object_store = Arc::new(InMemory::new());
+    let mut writer = IcebergTableWriter::new(
+        catalog_manager,
+        object_store,
+        TENANT.to_string(),
+        DATASET.to_string(),
+        "traces".to_string(),
+    )
+    .await
+    .expect("Failed to create Iceberg writer");
+
+    let config = DataGeneratorConfig {
+        partition_count: 1,
+        files_per_partition: 1,
+        rows_per_file: 100,
+        base_timestamp: chrono::Utc::now().timestamp_millis() - (60 * 60 * 1000),
+        partition_granularity: PartitionGranularity::Hour,
+    };
+    for _ in 0..writes {
+        generators::generate_traces(&mut writer, &config).await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn storage_usage_is_accounted_from_live_files_and_enforced() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut config = common::testing::TestConfigBuilder::new()
+        .in_memory()
+        .with_tenant(TENANT, DATASET)
+        .build();
+    config.auth.default_limits.max_storage_bytes = Some(1); // 1 byte: any data is over quota
+    let catalog_manager = Arc::new(CatalogManager::new(config.clone()).await?);
+
+    // Before any data lands, the tenant has no usage and passes the gate
+    // even though a quota is configured (accounting lag must not block).
+    let tracker = StorageUsageTracker::from_auth_config(&config.auth);
+    assert!(tracker.quotas_configured());
+    tracker.replace_all(compute_usage(&catalog_manager).await?);
+    assert!(tracker.check_ingest(TENANT).is_ok());
+
+    // Write real Parquet data files into the tenant's traces table.
+    write_traces(&catalog_manager, 3).await?;
+
+    // The accounting must match the live data-file sizes in the manifests.
+    let usage = compute_usage(&catalog_manager).await?;
+    let counted = *usage
+        .get(TENANT)
+        .expect("tenant with data must appear in the usage map");
+    let table_identifier = catalog_manager.build_table_identifier(TENANT, DATASET, "traces");
+    let table = match catalog_manager
+        .catalog()
+        .load_tabular(&table_identifier)
+        .await
+        .expect("Failed to load table")
+    {
+        iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
+        _ => panic!("Expected table"),
+    };
+    let manifest_bytes: u64 = compactor::iceberg::ManifestReader::new()
+        .get_snapshot_files(&table)
+        .await?
+        .iter()
+        .map(|f| f.file_size_bytes)
+        .sum();
+    assert!(counted > 0, "real data files must produce non-zero usage");
+    assert_eq!(
+        counted, manifest_bytes,
+        "usage accounting must equal the sum of live data-file sizes"
+    );
+
+    // Publish the refreshed usage: the tenant is now over its 1-byte quota
+    // and ingest is rejected with a quota_exceeded error.
+    tracker.replace_all(usage);
+    let err = tracker
+        .check_ingest(TENANT)
+        .expect_err("tenant over quota must be rejected");
+    assert!(err.to_string().contains("quota_exceeded"));
+    assert_eq!(err.usage_bytes, counted);
+
+    // A tenant without data stays unaffected by someone else's usage.
+    assert!(tracker.check_ingest("other-tenant").is_ok());
+
+    // More data grows the count monotonically (no double-count assertions
+    // here, just that the fresh snapshot supersedes the old one).
+    write_traces(&catalog_manager, 2).await?;
+    let usage_after = compute_usage(&catalog_manager).await?;
+    assert!(
+        usage_after[TENANT] > counted,
+        "additional writes must increase accounted usage"
+    );
+    Ok(())
+}

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -148,9 +148,7 @@ async fn test_iceberg_namespace_slug_based() -> Result<()> {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         },
         ..Default::default()
     };
@@ -310,9 +308,7 @@ async fn test_write_and_query_with_slugs() -> Result<()> {
                 schema_config: None,
                 limits: None,
             }],
-            admin_api_key: None,
-            internal_service_key: None,
-            default_limits: Default::default(),
+            ..Default::default()
         },
         ..Default::default()
     };


### PR DESCRIPTION
Closes #610. Final item of the production-readiness hardening epic #563.

## What

A tenant that stays under its ingest rate limits can no longer grow its Iceberg tables without bound: `max_storage_bytes` (in `[auth.default_limits]` / per-tenant `limits`) now caps the live data-file bytes a tenant may hold.

- **Accounting** (`common::storage_usage`): walks catalog namespaces (`[tenant_slug, dataset_slug]`), sums `file_size_in_bytes` over non-deleted manifest entries of the current snapshot — so compaction and retention shrink usage on the next refresh, and replaced files never double-count. Slugs map back to tenant ids via config; runtime-provisioned tenants key by slug (== id).
- **Refresh loop**: periodic task (`[auth].storage_usage_refresh_interval`, default 60s) recomputes usage off the hot path and swaps it into a `DashMap`-backed tracker. Per-table/namespace read failures are logged and skipped (under-count, retried next pass). Spawned only when a quota is actually configured; startup fails if quotas are configured but the accounting catalog can't be opened.
- **Enforcement**: OTLP gRPC (traces/logs/metrics) and Prometheus remote_write reject over-quota ingest with `RESOURCE_EXHAUSTED` / HTTP 429 carrying a `quota_exceeded` message. Hot-path cost is one map read. Unknown usage always passes — accounting lag must not block ingest (eventually consistent by design, per the issue).
- **Operator surface**: `signaldb.tenant.storage_usage` gauge (bytes, `tenant_id` attribute) exported each refresh; `StorageUsageTracker::snapshot()` for future admin-API use.

## Tests

- 8 unit tests on the tracker/accounting semantics (quota boundaries, override-beats-default, stale-tenant eviction, empty-catalog and empty-table accounting against a real in-memory catalog).
- gRPC service test: export passes under quota, rejects at quota with `RESOURCE_EXHAUSTED`.
- New integration test target `storage_quota`: writes real Parquet files through the Iceberg writer and asserts `compute_usage` equals the manifest-reader byte sum, then exercises the gate end-to-end.
- `cargo clippy --workspace --all-targets --all-features` and `cargo machete` clean; touched test targets (`prometheus_remote_write_test`, `router_tempo_endpoints`, `iceberg_integration`, `common`, `acceptor`) all green.