### PR TITLE
feat(acceptor): OTLP profiles ingestion over gRPC and HTTP

### DIFF
--- a/src/acceptor/src/handler/mod.rs
+++ b/src/acceptor/src/handler/mod.rs
@@ -2,6 +2,7 @@ pub mod forward;
 pub mod otlp_grpc;
 pub mod otlp_log_handler;
 pub mod otlp_metrics_handler;
+pub mod otlp_profiles_handler;
 pub mod prometheus_handler;
 pub mod wal_manager;
 pub mod wal_retry;

--- a/src/acceptor/src/handler/otlp_profiles_handler.rs
+++ b/src/acceptor/src/handler/otlp_profiles_handler.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use common::auth::TenantContext;
+use common::flight::conversion::otlp_profiles_to_arrow;
+use common::flight::transport::InMemoryFlightTransport;
+use common::wal::{WalOperation, record_batch_to_bytes};
+use opentelemetry_proto::tonic::collector::profiles::v1development::ExportProfilesServiceRequest;
+
+use super::WalManager;
+use super::forward::forward_batch_to_writer;
+
+pub struct ProfileHandler {
+    /// Flight transport for forwarding telemetry
+    flight_transport: Arc<InMemoryFlightTransport>,
+    /// WAL manager for multi-tenant WAL isolation
+    wal_manager: Arc<WalManager>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+pub struct MockProfileHandler {
+    pub handle_grpc_otlp_profiles_calls: tokio::sync::Mutex<Vec<ExportProfilesServiceRequest>>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl Default for MockProfileHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl MockProfileHandler {
+    pub fn new() -> Self {
+        Self {
+            handle_grpc_otlp_profiles_calls: tokio::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn handle_grpc_otlp_profiles(
+        &self,
+        _tenant_context: &TenantContext,
+        request: ExportProfilesServiceRequest,
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_profiles_calls
+            .lock()
+            .await
+            .push(request);
+        Ok(())
+    }
+
+    pub fn expect_handle_grpc_otlp_profiles(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl ProfileHandler {
+    /// Create a new handler with Flight transport and WAL manager
+    pub fn new(
+        flight_transport: Arc<InMemoryFlightTransport>,
+        wal_manager: Arc<WalManager>,
+    ) -> Self {
+        Self {
+            flight_transport,
+            wal_manager,
+        }
+    }
+
+    /// Handle an OTLP profiles export.
+    ///
+    /// Returns `Ok(())` once the data is durably accepted: written and
+    /// flushed to the WAL. A failed Flight forward after that point is not
+    /// an error — the WAL retry consumer re-forwards the entry.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            tenant_id = %tenant_context.tenant_id,
+            dataset_id = %tenant_context.dataset_id
+        )
+    )]
+    pub async fn handle_grpc_otlp_profiles(
+        &self,
+        tenant_context: &TenantContext,
+        request: ExportProfilesServiceRequest,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            tenant_id = %tenant_context.tenant_id,
+            dataset_id = %tenant_context.dataset_id,
+            "Handling OTLP profiles request"
+        );
+
+        // Get tenant/dataset-specific WAL
+        let wal = self
+            .wal_manager
+            .get_wal(
+                &tenant_context.tenant_id,
+                &tenant_context.dataset_id,
+                "profiles",
+            )
+            .await
+            .context("Failed to get WAL")?;
+
+        // Convert OTLP profiles to Arrow RecordBatch (resolves the dictionary)
+        let record_batch = otlp_profiles_to_arrow(&request);
+
+        // Add schema version metadata (v1 for OTLP conversion)
+        let mut metadata = serde_json::json!({
+            "schema_version": "v1",
+            "signal_type": "profiles",
+            "tenant_id": tenant_context.tenant_id,
+            "dataset_id": tenant_context.dataset_id,
+        });
+        if let Some((traceparent, tracestate)) =
+            common::flight::trace_context::current_trace_context_fields()
+        {
+            metadata["traceparent"] = traceparent.into();
+            if let Some(tracestate) = tracestate {
+                metadata["tracestate"] = tracestate.into();
+            }
+        }
+
+        // Serialize metadata for WAL storage (enables background processor routing)
+        let metadata_str = serde_json::to_string(&metadata).ok();
+
+        // Step 1: Write to WAL first for durability
+        let batch_bytes =
+            record_batch_to_bytes(&record_batch).context("Failed to serialize record batch")?;
+
+        let wal_entry_id = wal
+            .append(
+                WalOperation::WriteProfiles,
+                batch_bytes.clone(),
+                metadata_str,
+            )
+            .await
+            .context("Failed to write profiles to WAL")?;
+
+        // Flush WAL to ensure durability
+        wal.flush().await.context("Failed to flush WAL")?;
+
+        tracing::debug!(entry_id = %wal_entry_id, "Profiles written to WAL");
+
+        // Step 2: Forward from WAL to writer via Flight
+        match forward_batch_to_writer(
+            &self.flight_transport,
+            record_batch,
+            Some(&metadata.to_string()),
+        )
+        .await
+        {
+            Ok(()) => {
+                tracing::debug!("Successfully forwarded profiles via Flight protocol");
+                // Mark WAL entry as processed after successful forwarding
+                if let Err(e) = wal.mark_processed(wal_entry_id).await {
+                    tracing::warn!(entry_id = %wal_entry_id, error = %e, "Failed to mark WAL entry as processed");
+                }
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to forward profiles - data remains in WAL for retry");
+            }
+        }
+
+        // Data is durable in the WAL at this point; forward failures are
+        // recovered by the retry consumer, so the export is acknowledged.
+        Ok(())
+    }
+}

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -17,6 +17,7 @@ use datafusion::parquet::{
 use opentelemetry_proto::tonic::collector::{
     logs::v1::logs_service_server::LogsServiceServer,
     metrics::v1::metrics_service_server::MetricsServiceServer,
+    profiles::v1development::profiles_service_server::ProfilesServiceServer,
     trace::v1::trace_service_server::TraceServiceServer,
 };
 use tokio::net::TcpListener;
@@ -35,13 +36,14 @@ use common::wal::WalConfig;
 use crate::handler::otlp_grpc::TraceHandler;
 use crate::handler::otlp_log_handler::LogHandler;
 use crate::handler::otlp_metrics_handler::MetricsHandler;
+use crate::handler::otlp_profiles_handler::ProfileHandler;
 use crate::handler::{PrometheusHandler, PrometheusHandlerState};
 use crate::handler::{WalManager, WalRetryConsumer};
 use crate::middleware::auth_middleware;
 use crate::middleware::grpc_auth::grpc_auth_interceptor;
 use crate::services::{
     otlp_log_service::LogAcceptorService, otlp_metric_service::MetricsAcceptorService,
-    otlp_trace_service::TraceAcceptorService,
+    otlp_profile_service::ProfileAcceptorService, otlp_trace_service::TraceAcceptorService,
 };
 use common::auth::Authenticator;
 
@@ -282,6 +284,14 @@ pub async fn serve_otlp_grpc(
         grpc_auth_interceptor(auth_for_metrics.clone(), req)
     });
 
+    let profile_handler = ProfileHandler::new(flight_transport.clone(), wal_manager.clone());
+    let profile_service =
+        ProfileAcceptorService::new(profile_handler).with_rate_limiter(rate_limiter.clone());
+    let auth_for_profiles = authenticator.clone();
+    let profile_server = ProfilesServiceServer::with_interceptor(profile_service, move |req| {
+        grpc_auth_interceptor(auth_for_profiles.clone(), req)
+    });
+
     init_tx
         .send(())
         .expect("Unable to send init signal for OTLP/gRPC");
@@ -290,6 +300,7 @@ pub async fn serve_otlp_grpc(
         .add_service(log_server)
         .add_service(trace_server)
         .add_service(metric_server)
+        .add_service(profile_server)
         .serve_with_shutdown(config.addr, async {
             shutdown_rx.await.ok();
             tracing::info!("Shutting down OTLP/gRPC acceptor");
@@ -347,6 +358,116 @@ pub fn prometheus_router(
         .layer(middleware::from_fn(
             common::self_monitoring::http_metrics_middleware,
         ))
+}
+
+/// Shared state for the OTLP/HTTP profiles endpoint
+#[derive(Clone)]
+pub struct ProfilesHandlerState {
+    pub handler: Arc<ProfileHandler>,
+}
+
+/// Create a router for the OTLP/HTTP profiles ingestion endpoint with authentication
+///
+/// Handles `POST /v1development/profiles` (the OTLP development endpoint for
+/// the profiles signal) with protobuf or JSON request bodies.
+pub fn profiles_http_router(
+    authenticator: Arc<Authenticator>,
+    profile_handler: Arc<ProfileHandler>,
+) -> Router {
+    use axum::middleware;
+
+    let state = ProfilesHandlerState {
+        handler: profile_handler,
+    };
+
+    Router::new()
+        .route("/v1development/profiles", post(handle_http_profiles))
+        .layer(Extension(state))
+        .layer(middleware::from_fn(move |req, next| {
+            let auth = authenticator.clone();
+            async move { auth_middleware(auth, req, next).await }
+        }))
+        .layer(middleware::from_fn(
+            common::self_monitoring::http_metrics_middleware,
+        ))
+}
+
+/// OTLP/HTTP profiles export: decode by content type, hand off to the
+/// profile handler, and answer with an empty export response.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        tenant_id = %tenant_context.tenant_id,
+        dataset_id = %tenant_context.dataset_id
+    )
+)]
+async fn handle_http_profiles(
+    Extension(state): Extension<ProfilesHandlerState>,
+    headers: axum::http::HeaderMap,
+    crate::middleware::TenantContextExtractor(tenant_context): crate::middleware::TenantContextExtractor,
+    body: axum::body::Bytes,
+) -> axum::response::Response<axum::body::Body> {
+    use opentelemetry_proto::tonic::collector::profiles::v1development::ExportProfilesServiceRequest;
+    use prost::Message;
+
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/x-protobuf");
+
+    let request = if content_type.starts_with("application/json") {
+        match serde_json::from_slice::<ExportProfilesServiceRequest>(&body) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/JSON profiles payload: {e}"),
+                );
+            }
+        }
+    } else {
+        match ExportProfilesServiceRequest::decode(body.as_ref()) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/protobuf profiles payload: {e}"),
+                );
+            }
+        }
+    };
+
+    match state
+        .handler
+        .handle_grpc_otlp_profiles(&tenant_context, request)
+        .await
+    {
+        Ok(()) => axum::response::Response::builder()
+            .status(axum::http::StatusCode::OK)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from("{}"))
+            .expect("static response must build"),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to durably accept profiles export via HTTP");
+            otlp_http_error(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                format!("failed to durably accept profiles export: {e:#}"),
+            )
+        }
+    }
+}
+
+fn otlp_http_error(
+    status: axum::http::StatusCode,
+    message: String,
+) -> axum::response::Response<axum::body::Body> {
+    axum::response::Response::builder()
+        .status(status)
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({ "message": message }).to_string(),
+        ))
+        .expect("error response must build")
 }
 
 /// Handler variant using Extension instead of State for simpler router composition
@@ -414,13 +535,25 @@ pub async fn serve_otlp_http(
             .with_storage_quota(config.storage_usage.clone()),
     );
 
-    // Build combined router with health, traces, and Prometheus endpoints
-    let app = acceptor_router().merge(prometheus_router(
-        config.authenticator.clone(),
-        prometheus_handler,
+    // Create profiles handler with shared resources
+    let profile_handler = Arc::new(ProfileHandler::new(
+        config.flight_transport.clone(),
+        config.wal_manager.clone(),
     ));
 
+    // Build combined router with health, traces, Prometheus, and profiles endpoints
+    let app = acceptor_router()
+        .merge(prometheus_router(
+            config.authenticator.clone(),
+            prometheus_handler,
+        ))
+        .merge(profiles_http_router(
+            config.authenticator.clone(),
+            profile_handler,
+        ));
+
     tracing::info!("Prometheus remote_write endpoint enabled at POST /api/v1/write");
+    tracing::info!("OTLP profiles endpoint enabled at POST /v1development/profiles");
 
     init_tx
         .send(())

--- a/src/acceptor/src/services/mod.rs
+++ b/src/acceptor/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod otlp_log_service;
 pub mod otlp_metric_service;
+pub mod otlp_profile_service;
 pub mod otlp_trace_service;

--- a/src/acceptor/src/services/otlp_profile_service.rs
+++ b/src/acceptor/src/services/otlp_profile_service.rs
@@ -1,0 +1,193 @@
+use opentelemetry_proto::tonic::collector::profiles::v1development::{
+    ExportProfilesServiceRequest, ExportProfilesServiceResponse,
+    profiles_service_server::ProfilesService,
+};
+use tonic::{Request, Response, Status};
+
+use crate::handler::otlp_profiles_handler::ProfileHandler;
+use crate::middleware::get_tenant_context;
+use common::auth::TenantContext;
+use common::ratelimit::TenantRateLimiter;
+use prost::Message;
+use std::sync::Arc;
+
+#[async_trait::async_trait]
+pub trait ProfileHandlerTrait {
+    async fn handle_grpc_otlp_profiles(
+        &self,
+        tenant_context: &TenantContext,
+        request: ExportProfilesServiceRequest,
+    ) -> anyhow::Result<()>;
+}
+
+#[async_trait::async_trait]
+impl ProfileHandlerTrait for ProfileHandler {
+    async fn handle_grpc_otlp_profiles(
+        &self,
+        tenant_context: &TenantContext,
+        request: ExportProfilesServiceRequest,
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_profiles(tenant_context, request)
+            .await
+    }
+}
+
+pub struct ProfileAcceptorService<H: ProfileHandlerTrait> {
+    handler: H,
+    rate_limiter: Option<Arc<TenantRateLimiter>>,
+}
+
+impl<H: ProfileHandlerTrait> ProfileAcceptorService<H> {
+    pub fn new(handler: H) -> Self {
+        Self {
+            handler,
+            rate_limiter: None,
+        }
+    }
+
+    /// Enforce per-tenant ingest rate limits on this service.
+    pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
+        self.rate_limiter = Some(rate_limiter);
+        self
+    }
+}
+
+#[tonic::async_trait]
+impl<H: ProfileHandlerTrait + Send + Sync + 'static> ProfilesService for ProfileAcceptorService<H> {
+    async fn export(
+        &self,
+        request: Request<ExportProfilesServiceRequest>,
+    ) -> Result<Response<ExportProfilesServiceResponse>, Status> {
+        // Extract tenant context from request extensions (added by auth middleware)
+        let tenant_context = get_tenant_context(&request)?;
+
+        let request_inner = request.into_inner();
+
+        // Per-tenant ingest rate limiting: RESOURCE_EXHAUSTED is the gRPC
+        // analog of HTTP 429 and OTLP clients treat it as retryable.
+        if let Some(limiter) = &self.rate_limiter {
+            limiter
+                .check_ingest(&tenant_context.tenant_id, request_inner.encoded_len())
+                .map_err(|e| Status::resource_exhausted(e.to_string()))?;
+        }
+
+        let profile_count: u64 = request_inner
+            .resource_profiles
+            .iter()
+            .flat_map(|rp| rp.scope_profiles.iter())
+            .map(|sp| sp.profiles.len() as u64)
+            .sum();
+        let rpc_start = std::time::Instant::now();
+
+        // Anti-loop guard: processing the _system tenant's own telemetry must
+        // not generate more self-monitoring telemetry.
+        let handle = self
+            .handler
+            .handle_grpc_otlp_profiles(&tenant_context, request_inner);
+        let result =
+            if common::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
+                common::self_monitoring::suppress_self_telemetry(handle).await
+            } else {
+                handle.await
+            };
+
+        // Reject the export if the data was not durably accepted, so the
+        // client retries instead of dropping its copy (OTLP treats
+        // UNAVAILABLE as retryable).
+        if let Err(e) = result {
+            tracing::error!(error = %e, "Failed to durably accept profiles export");
+            return Err(Status::unavailable(format!(
+                "failed to durably accept profiles export: {e:#}"
+            )));
+        }
+
+        // Anti-loop guard: _system traffic is SignalDB's own telemetry and
+        // must not be measured (would feed back into the export pipeline).
+        if !common::self_monitoring::should_count_tenant(&tenant_context.tenant_id) {
+            return Ok(Response::new(Default::default()));
+        }
+        let app_metrics = common::self_monitoring::app_metrics();
+        app_metrics.rpc_server_duration.record(
+            rpc_start.elapsed().as_secs_f64() * 1000.0,
+            &[
+                opentelemetry::KeyValue::new("rpc.system", "grpc"),
+                opentelemetry::KeyValue::new(
+                    "rpc.service",
+                    "opentelemetry.proto.collector.profiles.v1development.ProfilesService",
+                ),
+                opentelemetry::KeyValue::new("rpc.method", "Export"),
+            ],
+        );
+        app_metrics.ingest_profiles_received.add(
+            profile_count,
+            &[opentelemetry::KeyValue::new(
+                "tenant_id",
+                tenant_context.tenant_id.clone(),
+            )],
+        );
+
+        Ok(Response::new(ExportProfilesServiceResponse::default()))
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+#[async_trait::async_trait]
+impl ProfileHandlerTrait for crate::handler::otlp_profiles_handler::MockProfileHandler {
+    async fn handle_grpc_otlp_profiles(
+        &self,
+        tenant_context: &TenantContext,
+        request: ExportProfilesServiceRequest,
+    ) -> anyhow::Result<()> {
+        self.handle_grpc_otlp_profiles(tenant_context, request)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::otlp_profiles_handler::MockProfileHandler;
+    use opentelemetry_proto::tonic::profiles::v1development::{
+        Profile, ResourceProfiles, ScopeProfiles,
+    };
+
+    #[tokio::test]
+    async fn test_profile_acceptor_service() {
+        let mut mock_handler = MockProfileHandler::new();
+        mock_handler.expect_handle_grpc_otlp_profiles();
+
+        let service = ProfileAcceptorService::new(mock_handler);
+
+        let request = ExportProfilesServiceRequest {
+            resource_profiles: vec![ResourceProfiles {
+                resource: None,
+                scope_profiles: vec![ScopeProfiles {
+                    scope: None,
+                    profiles: vec![Profile {
+                        time_unix_nano: 1234567890,
+                        profile_id: vec![1; 16],
+                        ..Profile::default()
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+            dictionary: None,
+        };
+
+        // Add TenantContext to request extensions (normally added by auth middleware)
+        let mut tonic_request = Request::new(request);
+        tonic_request.extensions_mut().insert(TenantContext {
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            tenant_slug: "test-tenant".to_string(),
+            dataset_slug: "test-dataset".to_string(),
+            api_key_name: Some("test-key".to_string()),
+            source: common::auth::TenantSource::Config,
+        });
+
+        let response = service.export(tonic_request).await;
+
+        assert!(response.is_ok());
+    }
+}

--- a/src/common/src/self_monitoring/app_metrics.rs
+++ b/src/common/src/self_monitoring/app_metrics.rs
@@ -51,6 +51,7 @@ pub struct AppMetrics {
     pub ingest_spans_received: Counter<u64>,
     pub ingest_logs_received: Counter<u64>,
     pub ingest_metrics_received: Counter<u64>,
+    pub ingest_profiles_received: Counter<u64>,
     pub ingest_batches_written: Counter<u64>,
     pub ingest_batch_size: Histogram<u64>,
 
@@ -174,6 +175,11 @@ impl AppMetrics {
                 .u64_counter("signaldb.ingest.metrics_received")
                 .with_description("OTLP metric points received")
                 .with_unit("{metric}")
+                .build(),
+            ingest_profiles_received: meter
+                .u64_counter("signaldb.ingest.profiles_received")
+                .with_description("OTLP profiles received")
+                .with_unit("{profile}")
                 .build(),
             ingest_batches_written: meter
                 .u64_counter("signaldb.ingest.batches_written")


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–2 | #618 #619 proto, model, schema | ✅ merged |
| 3 | #623 conversion | ⏳ auto-merge armed |
| 4 | #632 WAL | 🔁 in review |
| 5 | #633 Iceberg + config | 🔁 in review |
| 6 | acceptor ingestion | 👀 **← this PR** |
| 7+ | writer, query, APIs | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-05-iceberg`), not main.

## This PR only
Two commits:
- **ProfileHandler** (#349): WAL-first durability — convert to Arrow, append+flush the tenant/dataset profiles WAL before acknowledging, then Flight-forward to the writer with retry-consumer recovery.
- **Services** (#350): `ProfilesService` registered on gRPC :4317 behind the tenant auth interceptor and per-tenant rate limits; `POST /v1development/profiles` on HTTP :4318 (protobuf + JSON bodies, authenticated). Adds `signaldb.ingest.profiles_received` self-monitoring counter.

Closes #349
Closes #350

**Also closes #360**: `POST /v1development/profiles` on the acceptor's HTTP port (4318) is the OTLP/HTTP ingestion path for profiles — protobuf + JSON bodies, tenant-authenticated, WAL-first durability, OTLP-shaped JSON errors. The router has no OTLP ingest surface for any signal (traces/logs/metrics all ingest via the acceptor), so the `router/endpoints/otlp.rs` file the issue referenced was never the right home; a router-side OTLP proxy would be a separate cross-signal decision.

Closes #360