### PR TITLE
feat(querier): profile diff and flamegraph queries

### DIFF
--- a/src/common/src/profile/aggregation.rs
+++ b/src/common/src/profile/aggregation.rs
@@ -165,6 +165,197 @@ fn flatten(root: &Node) -> Flamegraph {
     }
 }
 
+/// A differential flamegraph in Pyroscope "double" flamebearer encoding:
+/// every block carries baseline (left) and comparison (right) values.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffFlamegraph {
+    /// Function name table referenced by the blocks' name indices.
+    pub names: Vec<String>,
+    /// One entry per depth level; each level is a flat sequence of
+    /// `[offset_delta_left, total_left, self_left,
+    ///   offset_delta_right, total_right, self_right, name_index]`
+    /// septuples, offsets delta-encoded per side.
+    pub levels: Vec<Vec<i64>>,
+    /// Total baseline value.
+    pub left_ticks: i64,
+    /// Total comparison value.
+    pub right_ticks: i64,
+    /// Combined total (left + right), the root block width.
+    pub total: i64,
+    /// Largest self value of any block on either side.
+    pub max_self: i64,
+}
+
+/// Merged two-sided aggregation node.
+#[derive(Default)]
+struct DiffNode {
+    left_total: i64,
+    left_self: i64,
+    right_total: i64,
+    right_self: i64,
+    children: Vec<(String, DiffNode)>,
+}
+
+impl DiffNode {
+    fn child_mut(&mut self, name: &str) -> &mut DiffNode {
+        if let Some(index) = self.children.iter().position(|(n, _)| n == name) {
+            return &mut self.children[index].1;
+        }
+        self.children.push((name.to_string(), DiffNode::default()));
+        &mut self
+            .children
+            .last_mut()
+            .expect("children cannot be empty after push")
+            .1
+    }
+}
+
+fn frame_name(frame: &crate::model::profile::Frame) -> String {
+    if frame.function_name.is_empty() {
+        if frame.address != 0 {
+            format!("{:#x}", frame.address)
+        } else {
+            "<unknown>".to_string()
+        }
+    } else {
+        frame.function_name.clone()
+    }
+}
+
+fn accumulate_into_diff(root: &mut DiffNode, profiles: &[Profile], right: bool) {
+    for profile in profiles {
+        for sample in &profile.samples {
+            let value = sample
+                .values
+                .first()
+                .copied()
+                .unwrap_or(sample.timestamps_unix_nano.len() as i64);
+            if value <= 0 {
+                continue;
+            }
+            let Some(stacktrace) = profile.stacktraces.get(sample.stacktrace_index) else {
+                continue;
+            };
+
+            if right {
+                root.right_total += value;
+            } else {
+                root.left_total += value;
+            }
+            let mut node = &mut *root;
+            for frame in stacktrace.frames.iter().rev() {
+                let name = frame_name(frame);
+                node = node.child_mut(&name);
+                if right {
+                    node.right_total += value;
+                } else {
+                    node.left_total += value;
+                }
+            }
+            if right {
+                node.right_self += value;
+            } else {
+                node.left_self += value;
+            }
+        }
+    }
+}
+
+/// Aggregate a baseline and a comparison profile set into a differential
+/// flamegraph. Stacks present on only one side get zero values on the
+/// other, which renderers show as pure growth/regression.
+pub fn aggregate_profiles_to_diff_flamegraph(
+    baseline: &[Profile],
+    comparison: &[Profile],
+) -> DiffFlamegraph {
+    let mut root = DiffNode::default();
+    accumulate_into_diff(&mut root, baseline, false);
+    accumulate_into_diff(&mut root, comparison, true);
+
+    root.left_self = root.left_total - root.children.iter().map(|(_, c)| c.left_total).sum::<i64>();
+    root.right_self = root.right_total
+        - root
+            .children
+            .iter()
+            .map(|(_, c)| c.right_total)
+            .sum::<i64>();
+
+    flatten_diff(&root)
+}
+
+fn flatten_diff(root: &DiffNode) -> DiffFlamegraph {
+    let mut names = Vec::new();
+    let mut name_indices: HashMap<String, usize> = HashMap::new();
+    let mut intern = |name: &str, names: &mut Vec<String>| -> i64 {
+        if let Some(&index) = name_indices.get(name) {
+            return index as i64;
+        }
+        let index = names.len();
+        names.push(name.to_string());
+        name_indices.insert(name.to_string(), index);
+        index as i64
+    };
+
+    let mut max_self = root.left_self.max(root.right_self);
+    let root_index = intern("total", &mut names);
+    let mut levels: Vec<Vec<i64>> = vec![vec![
+        0,
+        root.left_total,
+        root.left_self,
+        0,
+        root.right_total,
+        root.right_self,
+        root_index,
+    ]];
+
+    // Blocks to lay out: (left absolute offset, right absolute offset, node).
+    let mut current: Vec<(i64, i64, &DiffNode)> = vec![(0, 0, root)];
+
+    while !current.is_empty() {
+        let mut next: Vec<(i64, i64, &DiffNode)> = Vec::new();
+        let mut level: Vec<i64> = Vec::new();
+        let mut previous_left_end: i64 = 0;
+        let mut previous_right_end: i64 = 0;
+
+        for (left_offset, right_offset, node) in &current {
+            let mut left_x = *left_offset;
+            let mut right_x = *right_offset;
+            for (name, child) in &node.children {
+                let name_index = intern(name, &mut names);
+                level.extend_from_slice(&[
+                    left_x - previous_left_end,
+                    child.left_total,
+                    child.left_self,
+                    right_x - previous_right_end,
+                    child.right_total,
+                    child.right_self,
+                    name_index,
+                ]);
+                max_self = max_self.max(child.left_self).max(child.right_self);
+                next.push((left_x, right_x, child));
+                previous_left_end = left_x + child.left_total;
+                previous_right_end = right_x + child.right_total;
+                left_x += child.left_total;
+                right_x += child.right_total;
+            }
+        }
+
+        if !level.is_empty() {
+            levels.push(level);
+        }
+        current = next;
+    }
+
+    DiffFlamegraph {
+        names,
+        levels,
+        left_ticks: root.left_total,
+        right_ticks: root.right_total,
+        total: root.left_total + root.right_total,
+        max_self,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,6 +471,43 @@ mod tests {
         assert_eq!(flamegraph.total, 0);
         assert_eq!(flamegraph.levels.len(), 1);
         assert_eq!(flamegraph.names, vec!["total".to_string()]);
+    }
+
+    #[test]
+    fn diff_flamegraph_carries_both_sides() {
+        let baseline = sample_profile(); // work 100, idle 50, other_root 25
+        let mut comparison = sample_profile();
+        comparison.samples[0].values = vec![200]; // work regressed to 200
+        comparison.samples.remove(2); // other_root gone in comparison
+
+        let diff = aggregate_profiles_to_diff_flamegraph(&[baseline], &[comparison]);
+        assert_eq!(diff.left_ticks, 175);
+        assert_eq!(diff.right_ticks, 250);
+        assert_eq!(diff.total, 425);
+
+        // Root block: [0, 175, selfL, 0, 250, selfR, 0]
+        assert_eq!(diff.levels[0][1], 175);
+        assert_eq!(diff.levels[0][4], 250);
+
+        // Find the "work" block on level 2 and check both sides.
+        let work_index = diff.names.iter().position(|n| n == "work").unwrap() as i64;
+        let level2 = &diff.levels[2];
+        let block = level2
+            .chunks(7)
+            .find(|c| c[6] == work_index)
+            .expect("work block");
+        assert_eq!(block[1], 100); // baseline total
+        assert_eq!(block[4], 200); // comparison total
+
+        // other_root exists only in baseline: right side is zero.
+        let other_index = diff.names.iter().position(|n| n == "other_root").unwrap() as i64;
+        let level1 = &diff.levels[1];
+        let block = level1
+            .chunks(7)
+            .find(|c| c[6] == other_index)
+            .expect("other_root block");
+        assert_eq!(block[1], 25);
+        assert_eq!(block[4], 0);
     }
 
     #[test]

--- a/src/common/src/profile/mod.rs
+++ b/src/common/src/profile/mod.rs
@@ -5,4 +5,7 @@
 
 pub mod aggregation;
 
-pub use aggregation::{Flamegraph, aggregate_profiles_to_flamegraph};
+pub use aggregation::{
+    DiffFlamegraph, Flamegraph, aggregate_profiles_to_diff_flamegraph,
+    aggregate_profiles_to_flamegraph,
+};

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -26,7 +26,8 @@ use tonic::{Request, Response, Status};
 use tracing::Instrument;
 
 use crate::query::profile::{
-    FindProfileByIdParams, ProfileDiscoveryParams, ProfileSearchParams, ProfileService,
+    FindProfileByIdParams, ProfileDiffParams, ProfileDiscoveryParams, ProfileSearchParams,
+    ProfileService,
 };
 use crate::query::trace::TraceService;
 use crate::query::{FindTraceByIdParams, SearchQueryParams};
@@ -187,6 +188,16 @@ enum TicketRequest {
         dataset_slug: String,
         label_name: String,
         params: ProfileDiscoveryParams,
+    },
+    ProfileFlamegraph {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: ProfileSearchParams,
+    },
+    ProfileDiff {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: ProfileDiffParams,
     },
 }
 
@@ -553,6 +564,40 @@ impl QuerierFlightService {
             ));
         }
 
+        if let Some(remainder) = ticket_content.strip_prefix("profile_flamegraph:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: ProfileSearchParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid flamegraph parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::ProfileFlamegraph {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid profile_flamegraph ticket format. Expected: profile_flamegraph:tenant_slug:dataset_slug:params",
+            ));
+        }
+
+        if let Some(remainder) = ticket_content.strip_prefix("profile_diff:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: ProfileDiffParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid profile diff parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::ProfileDiff {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid profile_diff ticket format. Expected: profile_diff:tenant_slug:dataset_slug:params",
+            ));
+        }
+
         if let Some(remainder) = ticket_content.strip_prefix("label_values:") {
             let parts: Vec<&str> = remainder.splitn(4, ':').collect();
             if parts.len() >= 3 {
@@ -860,7 +905,9 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::SearchProfiles { tenant_slug, .. }
                     | TicketRequest::ProfileTypes { tenant_slug, .. }
                     | TicketRequest::ProfileLabelNames { tenant_slug, .. }
-                    | TicketRequest::ProfileLabelValues { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::ProfileLabelValues { tenant_slug, .. }
+                    | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
+                    | TicketRequest::ProfileDiff { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -884,6 +931,8 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::ProfileTypes { .. } => "profile_types",
                 TicketRequest::ProfileLabelNames { .. } => "profile_label_names",
                 TicketRequest::ProfileLabelValues { .. } => "profile_label_values",
+                TicketRequest::ProfileFlamegraph { .. } => "profile_flamegraph",
+                TicketRequest::ProfileDiff { .. } => "profile_diff",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -901,9 +950,9 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::SearchProfiles { tenant_slug, .. }
                     | TicketRequest::ProfileTypes { tenant_slug, .. }
                     | TicketRequest::ProfileLabelNames { tenant_slug, .. }
-                    | TicketRequest::ProfileLabelValues { tenant_slug, .. } => {
-                        Some(tenant_slug.clone())
-                    }
+                    | TicketRequest::ProfileLabelValues { tenant_slug, .. }
+                    | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
+                    | TicketRequest::ProfileDiff { tenant_slug, .. } => Some(tenant_slug.clone()),
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1106,6 +1155,30 @@ impl FlightService for QuerierFlightService {
                             .map_err(querier_error_to_status)?;
                         vec![strings_to_batch("label_value", values)?]
                     }
+                    TicketRequest::ProfileFlamegraph {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        let flamegraph = self
+                            .profile_service
+                            .flamegraph_with_tenant(params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![json_to_batch("flamegraph", &flamegraph)?]
+                    }
+                    TicketRequest::ProfileDiff {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        let diff = self
+                            .profile_service
+                            .diff_with_tenant(params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![json_to_batch("diff", &diff)?]
+                    }
                     TicketRequest::SqlQuery { sql } => {
                         // Tenant-scoped callers are pinned to their
                         // authenticated tenant/dataset; only internal or
@@ -1255,6 +1328,14 @@ fn strings_to_batch(column_name: &str, values: Vec<String>) -> Result<RecordBatc
     )]));
     RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))])
         .map_err(|e| Status::internal(format!("Failed to build result batch: {e}")))
+}
+
+/// Encode a serializable value as a single-row, single-column JSON batch.
+#[allow(clippy::result_large_err)]
+fn json_to_batch<T: serde::Serialize>(column_name: &str, value: &T) -> Result<RecordBatch, Status> {
+    let json = serde_json::to_string(value)
+        .map_err(|e| Status::internal(format!("Failed to serialize result: {e}")))?;
+    strings_to_batch(column_name, vec![json])
 }
 
 /// Map querier errors onto gRPC statuses: caller errors surface as

--- a/src/querier/src/query/profile.rs
+++ b/src/querier/src/query/profile.rs
@@ -19,6 +19,12 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
+use common::model::profile::{Profile, ProfileLink, Sample, Stacktrace, ValueType};
+use common::profile::{
+    DiffFlamegraph, Flamegraph, aggregate_profiles_to_diff_flamegraph,
+    aggregate_profiles_to_flamegraph,
+};
+
 use super::{error::QuerierError, table_ref::build_table_reference};
 
 /// Parameters for single-profile lookup.
@@ -52,6 +58,14 @@ pub struct ProfileDiscoveryParams {
     pub start: Option<i64>,
     /// Window end (unix seconds, inclusive).
     pub end: Option<i64>,
+}
+
+/// Parameters carried in the `profile_diff` Flight ticket: two profile
+/// selections to compare.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct ProfileDiffParams {
+    pub baseline: ProfileSearchParams,
+    pub comparison: ProfileSearchParams,
 }
 
 /// Upper bound on distinct attribute documents scanned when deriving
@@ -371,6 +385,201 @@ impl ProfileService {
     }
 }
 
+impl ProfileService {
+    /// Fetch full profile rows matching the search selection and decode
+    /// them into model profiles for aggregation.
+    async fn fetch_models(
+        &self,
+        params: &ProfileSearchParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<Profile>, QuerierError> {
+        let mut df = self.profiles_table(tenant_slug, dataset_slug).await?;
+        if let Some(service_name) = &params.service_name {
+            df = df
+                .filter(col("service_name").eq(lit(service_name)))
+                .map_err(QuerierError::QueryFailed)?;
+        }
+        if let Some(sample_type) = &params.sample_type {
+            df = df
+                .filter(col("sample_type").eq(lit(sample_type)))
+                .map_err(QuerierError::QueryFailed)?;
+        }
+        df = Self::apply_time_window(df, params.start, params.end)?;
+
+        let limit = params
+            .limit
+            .and_then(|l| usize::try_from(l).ok())
+            .filter(|l| *l > 0)
+            .unwrap_or(self.max_search_limit)
+            .min(self.max_search_limit);
+        let df = df
+            .sort(vec![col("timestamp").sort(false, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(limit))
+            .map_err(QuerierError::QueryFailed)?;
+
+        let batches = df.collect().await.map_err(QuerierError::QueryFailed)?;
+        Ok(batches.iter().flat_map(batch_to_models).collect())
+    }
+
+    /// Aggregate the selected profiles into a flamegraph.
+    pub async fn flamegraph_with_tenant(
+        &self,
+        params: ProfileSearchParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Flamegraph, QuerierError> {
+        let profiles = self
+            .fetch_models(&params, tenant_slug, dataset_slug)
+            .await?;
+        Ok(aggregate_profiles_to_flamegraph(&profiles))
+    }
+
+    /// Compare two profile selections as a differential flamegraph.
+    pub async fn diff_with_tenant(
+        &self,
+        params: ProfileDiffParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<DiffFlamegraph, QuerierError> {
+        let baseline = self
+            .fetch_models(&params.baseline, tenant_slug, dataset_slug)
+            .await?;
+        let comparison = self
+            .fetch_models(&params.comparison, tenant_slug, dataset_slug)
+            .await?;
+        Ok(aggregate_profiles_to_diff_flamegraph(
+            &baseline,
+            &comparison,
+        ))
+    }
+}
+
+/// Decode storage-format profile rows into model profiles. Rows with
+/// unparseable payload columns are skipped with a warning rather than
+/// failing the whole aggregation.
+fn batch_to_models(batch: &RecordBatch) -> Vec<Profile> {
+    use datafusion::arrow::array::{Int64Array, TimestampNanosecondArray};
+
+    let Some(profile_ids) = batch
+        .column_by_name("profile_id")
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+    else {
+        return Vec::new();
+    };
+    let timestamps = batch
+        .column_by_name("timestamp")
+        .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>());
+    let durations = batch
+        .column_by_name("duration_nano")
+        .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+    let get_string = |name: &str| {
+        batch
+            .column_by_name(name)
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+    };
+    let sample_types = get_string("sample_type");
+    let sample_units = get_string("sample_unit");
+    let period_types = get_string("period_type");
+    let period_units = get_string("period_unit");
+    let periods = batch
+        .column_by_name("period")
+        .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+    let service_names = get_string("service_name");
+    let stacktraces_col = get_string("stacktraces_json");
+    let samples_col = get_string("samples_json");
+    let trace_ids = get_string("trace_id");
+    let span_ids = get_string("span_id");
+    let profile_attrs = get_string("profile_attributes");
+    let resource_attrs = get_string("resource_attributes");
+    let scope_attrs = get_string("scope_attributes");
+
+    let opt_str = |col: Option<&StringArray>, i: usize| -> Option<String> {
+        col.and_then(|c| {
+            if c.is_null(i) || c.value(i).is_empty() {
+                None
+            } else {
+                Some(c.value(i).to_string())
+            }
+        })
+    };
+
+    let mut profiles = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        let stacktraces: Vec<Stacktrace> =
+            match opt_str(stacktraces_col, i).map(|s| serde_json::from_str(&s)) {
+                Some(Ok(stacktraces)) => stacktraces,
+                Some(Err(e)) => {
+                    log::warn!("Skipping profile row with invalid stacktraces_json: {e}");
+                    continue;
+                }
+                None => Vec::new(),
+            };
+        let samples: Vec<Sample> = match opt_str(samples_col, i).map(|s| serde_json::from_str(&s)) {
+            Some(Ok(samples)) => samples,
+            Some(Err(e)) => {
+                log::warn!("Skipping profile row with invalid samples_json: {e}");
+                continue;
+            }
+            None => Vec::new(),
+        };
+
+        let mut profile_id = [0u8; 16];
+        if !profile_ids.is_null(i)
+            && let Ok(bytes) = hex::decode(profile_ids.value(i))
+            && bytes.len() == 16
+        {
+            profile_id.copy_from_slice(&bytes);
+        }
+
+        let mut links = Vec::new();
+        if let (Some(trace_hex), Some(span_hex)) = (opt_str(trace_ids, i), opt_str(span_ids, i))
+            && let (Ok(trace_bytes), Ok(span_bytes)) =
+                (hex::decode(&trace_hex), hex::decode(&span_hex))
+            && trace_bytes.len() == 16
+            && span_bytes.len() == 8
+        {
+            let mut trace_id = [0u8; 16];
+            trace_id.copy_from_slice(&trace_bytes);
+            let mut span_id = [0u8; 8];
+            span_id.copy_from_slice(&span_bytes);
+            links.push(ProfileLink { trace_id, span_id });
+        }
+
+        profiles.push(Profile {
+            profile_id,
+            time_unix_nano: timestamps
+                .map(|t| if t.is_null(i) { 0 } else { t.value(i) as u64 })
+                .unwrap_or(0),
+            duration_nano: durations
+                .map(|d| if d.is_null(i) { 0 } else { d.value(i) as u64 })
+                .unwrap_or(0),
+            sample_type: ValueType {
+                type_: opt_str(sample_types, i).unwrap_or_default(),
+                unit: opt_str(sample_units, i).unwrap_or_default(),
+            },
+            period_type: opt_str(period_types, i).map(|type_| ValueType {
+                type_,
+                unit: opt_str(period_units, i).unwrap_or_default(),
+            }),
+            period: periods
+                .map(|p| if p.is_null(i) { 0 } else { p.value(i) })
+                .unwrap_or(0),
+            service_name: opt_str(service_names, i).unwrap_or_default(),
+            stacktraces,
+            samples,
+            links,
+            resource_attributes: opt_str(resource_attrs, i)
+                .and_then(|s| serde_json::from_str(&s).ok()),
+            scope_attributes: opt_str(scope_attrs, i).and_then(|s| serde_json::from_str(&s).ok()),
+            attributes: opt_str(profile_attrs, i).and_then(|s| serde_json::from_str(&s).ok()),
+            dropped_attributes_count: 0,
+        });
+    }
+    profiles
+}
+
 fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, QuerierError> {
     batch
         .column_by_name(name)
@@ -463,8 +672,14 @@ mod tests {
                 Arc::new(StringArray::from(vec![None::<&str>, None])),
                 Arc::new(Int64Array::from(vec![None::<i64>, None])),
                 Arc::new(StringArray::from(vec!["checkout", "billing"])),
-                Arc::new(StringArray::from(vec!["[]", "[]"])),
-                Arc::new(StringArray::from(vec!["[]", "[]"])),
+                Arc::new(StringArray::from(vec![
+                    r#"[{"frames":[{"function_name":"work"},{"function_name":"main"}]}]"#,
+                    r#"[{"frames":[{"function_name":"alloc"},{"function_name":"main"}]}]"#,
+                ])),
+                Arc::new(StringArray::from(vec![
+                    r#"[{"stacktrace_index":0,"values":[100]}]"#,
+                    r#"[{"stacktrace_index":0,"values":[40]}]"#,
+                ])),
                 Arc::new(StringArray::from(vec![None::<&str>, None])),
                 Arc::new(StringArray::from(vec![None::<&str>, None])),
                 Arc::new(StringArray::from(vec![
@@ -574,6 +789,46 @@ mod tests {
             .await
             .expect("windowed search");
         assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    }
+
+    #[tokio::test]
+    async fn aggregates_flamegraph_and_diff_from_registered_table() {
+        let service = ProfileService::new(context_with_profiles().await);
+
+        let flamegraph = service
+            .flamegraph_with_tenant(
+                ProfileSearchParams {
+                    service_name: Some("checkout".to_string()),
+                    ..ProfileSearchParams::default()
+                },
+                "acme",
+                "prod",
+            )
+            .await
+            .expect("flamegraph");
+        assert_eq!(flamegraph.total, 100);
+        assert!(flamegraph.names.iter().any(|n| n == "work"));
+
+        let diff = service
+            .diff_with_tenant(
+                ProfileDiffParams {
+                    baseline: ProfileSearchParams {
+                        service_name: Some("checkout".to_string()),
+                        ..ProfileSearchParams::default()
+                    },
+                    comparison: ProfileSearchParams {
+                        service_name: Some("billing".to_string()),
+                        ..ProfileSearchParams::default()
+                    },
+                },
+                "acme",
+                "prod",
+            )
+            .await
+            .expect("diff");
+        assert_eq!(diff.left_ticks, 100);
+        assert_eq!(diff.right_ticks, 40);
+        assert!(diff.names.iter().any(|n| n == "alloc"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–4 | merged | ✅ |
| 5–9 | #633 #636 #637 #638 #639 | 🔁 in flight |
| 10 | diff + flamegraph queries | 👀 **← this PR** |
| 11+ | SQL, Pyroscope API, correlation | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-09-flamegraph`), not main.

## This PR only
- **common**: `aggregate_profiles_to_diff_flamegraph` producing Pyroscope's "double" flamebearer format — 7-value blocks carrying baseline (left) and comparison (right) totals/selfs, delta-encoded per side; one-sided stacks show as pure growth/regression.
- **querier**: `batch_to_models` decodes storage rows back into model profiles (hex ids, JSON stacktraces/samples, link reconstruction; malformed rows skipped with a warning). `flamegraph_with_tenant` / `diff_with_tenant` aggregate selections server-side.
- **Flight**: `profile_flamegraph:{t}:{d}:{params}` and `profile_diff:{t}:{d}:{params}` tickets with the standard tenant guard/permit/metrics treatment, returning single-value JSON batches.

MemTable-backed tests cover flamegraph totals and a two-sided diff.

Closes #357