### PR TITLE
feat(querier): sql_profiles Flight ticket

### DIFF
--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -199,6 +199,11 @@ enum TicketRequest {
         dataset_slug: String,
         params: ProfileDiffParams,
     },
+    SqlProfiles {
+        tenant_slug: String,
+        dataset_slug: String,
+        sql: String,
+    },
 }
 
 /// Flight service for query execution against stored data
@@ -614,6 +619,28 @@ impl QuerierFlightService {
             ));
         }
 
+        if let Some(remainder) = ticket_content.strip_prefix("sql_profiles:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let sql = parts[2].trim();
+                let lowered = sql.trim_start().to_ascii_lowercase();
+                // Read-only entry point: only SELECT/WITH statements.
+                if !(lowered.starts_with("select") || lowered.starts_with("with")) {
+                    return Err(Status::invalid_argument(
+                        "sql_profiles only accepts SELECT or WITH statements",
+                    ));
+                }
+                return Ok(TicketRequest::SqlProfiles {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    sql: sql.to_string(),
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid sql_profiles ticket format. Expected: sql_profiles:tenant_slug:dataset_slug:sql",
+            ));
+        }
+
         // Fall back to raw SQL query
         Ok(TicketRequest::SqlQuery {
             sql: ticket_content.to_string(),
@@ -907,7 +934,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileLabelNames { tenant_slug, .. }
                     | TicketRequest::ProfileLabelValues { tenant_slug, .. }
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
-                    | TicketRequest::ProfileDiff { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::ProfileDiff { tenant_slug, .. }
+                    | TicketRequest::SqlProfiles { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -933,6 +961,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::ProfileLabelValues { .. } => "profile_label_values",
                 TicketRequest::ProfileFlamegraph { .. } => "profile_flamegraph",
                 TicketRequest::ProfileDiff { .. } => "profile_diff",
+                TicketRequest::SqlProfiles { .. } => "sql_profiles",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -952,7 +981,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileLabelNames { tenant_slug, .. }
                     | TicketRequest::ProfileLabelValues { tenant_slug, .. }
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
-                    | TicketRequest::ProfileDiff { tenant_slug, .. } => Some(tenant_slug.clone()),
+                    | TicketRequest::ProfileDiff { tenant_slug, .. }
+                    | TicketRequest::SqlProfiles { tenant_slug, .. } => Some(tenant_slug.clone()),
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1178,6 +1208,28 @@ impl FlightService for QuerierFlightService {
                             .await
                             .map_err(querier_error_to_status)?;
                         vec![json_to_batch("diff", &diff)?]
+                    }
+                    TicketRequest::SqlProfiles {
+                        tenant_slug,
+                        dataset_slug,
+                        sql,
+                    } => {
+                        tracing::info!(
+                            tenant_slug = %tenant_slug,
+                            dataset_slug = %dataset_slug,
+                            sql = %sql,
+                            "Executing sql_profiles"
+                        );
+                        // Pin the session defaults to the ticket's
+                        // tenant/dataset so unqualified table names like
+                        // `profiles` resolve inside the tenant's catalog.
+                        let request_ctx =
+                            self.session_for_request(Some(&tenant_slug), Some(&dataset_slug));
+                        self.execute_distributed_query(&request_ctx, &sql)
+                            .await
+                            .map_err(|e| {
+                                Status::internal(format!("Profiles SQL query failed: {e}"))
+                            })?
                     }
                     TicketRequest::SqlQuery { sql } => {
                         // Tenant-scoped callers are pinned to their


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–4 | merged | ✅ |
| 5–10 | #633 #636 #637 #638 #639 #641 | 🔁 in flight |
| 11 | SQL query support | 👀 **← this PR** |
| 12+ | Pyroscope types + API, OTLP HTTP, correlation | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-10-diff`), not main.

## This PR only
`sql_profiles:{tenant}:{dataset}:{sql}` ticket: read-only (SELECT/WITH enforced at parse), tenant-guarded like every profile ticket, executes with session defaults pinned to the ticket's tenant/dataset so `SELECT sample_type, count(*) FROM profiles GROUP BY 1` just works. Inherits the existing SQL row cap, per-tenant permits, timeout, and metrics.

Example queries (also destined for the docs layer):
- Top services by profile volume: `SELECT service_name, count(*) AS profiles, sum(duration_nano) AS total_ns FROM profiles GROUP BY 1 ORDER BY 3 DESC`
- Profile types present: `SELECT DISTINCT sample_type, sample_unit FROM profiles`

The profiles table was already reachable through tenant catalogs; this adds the scoped, validated entry point.

Closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running read-only SQL profile queries through Flight tickets.
  * Queries can now target a specific tenant and dataset.
  * Added tenant-scoped authorization and concurrency handling for SQL profile requests.

* **Bug Fixes**
  * Invalid or non-read-only SQL statements are rejected with a clear request error.
  * Query execution failures are returned with appropriate service error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->