### PR TITLE
feat(router): Pyroscope-compatible HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6021,6 +6021,7 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
+ "pyroscope-api",
  "serde",
  "serde_json",
  "signaldb-api",

--- a/api/admin-api.json
+++ b/api/admin-api.json
@@ -193,6 +193,182 @@
         ],
         "type": "object"
       },
+      "PyroscopeFlamebearer": {
+        "description": "Flamegraph payload in flamebearer encoding",
+        "properties": {
+          "levels": {
+            "description": "One flat array per depth level; single format uses [offset_delta, total, self, name_index] quadruples, double format uses septuples carrying baseline and comparison values",
+            "items": {
+              "items": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "maxSelf": {
+            "description": "Largest self value of any block",
+            "format": "int64",
+            "type": "integer"
+          },
+          "names": {
+            "description": "Function name table referenced by block name indices",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "numTicks": {
+            "description": "Total number of ticks (root width)",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "names",
+          "levels",
+          "numTicks",
+          "maxSelf"
+        ],
+        "type": "object"
+      },
+      "PyroscopeFlamebearerMetadata": {
+        "description": "How to interpret flamebearer values",
+        "properties": {
+          "format": {
+            "description": "single for one profile set, double for a diff",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the rendered query",
+            "type": "string"
+          },
+          "sampleRate": {
+            "description": "Sample rate in Hz",
+            "format": "int32",
+            "type": "integer"
+          },
+          "spyName": {
+            "description": "Profiler that produced the data",
+            "type": "string"
+          },
+          "units": {
+            "description": "Value units (samples, objects, bytes)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "sampleRate",
+          "units",
+          "name"
+        ],
+        "type": "object"
+      },
+      "PyroscopeLabelsResponse": {
+        "description": "Label names or values",
+        "properties": {
+          "names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "names"
+        ],
+        "type": "object"
+      },
+      "PyroscopeProfileType": {
+        "description": "An available profile type",
+        "properties": {
+          "ID": {
+            "description": "Canonical profile type ID",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "periodType": {
+            "type": "string"
+          },
+          "periodUnit": {
+            "type": "string"
+          },
+          "sampleType": {
+            "type": "string"
+          },
+          "sampleUnit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ID",
+          "name",
+          "sampleType",
+          "sampleUnit"
+        ],
+        "type": "object"
+      },
+      "PyroscopeRenderResponse": {
+        "description": "Response of the render and render-diff endpoints",
+        "properties": {
+          "flamebearer": {
+            "$ref": "#/components/schemas/PyroscopeFlamebearer"
+          },
+          "leftTicks": {
+            "description": "Total baseline ticks (double format only)",
+            "format": "int64",
+            "type": "integer"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PyroscopeFlamebearerMetadata"
+          },
+          "rightTicks": {
+            "description": "Total comparison ticks (double format only)",
+            "format": "int64",
+            "type": "integer"
+          },
+          "timeline": {
+            "$ref": "#/components/schemas/PyroscopeTimeline"
+          }
+        },
+        "required": [
+          "flamebearer",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PyroscopeTimeline": {
+        "description": "Per-interval sample counts for the render timeline",
+        "properties": {
+          "durationDelta": {
+            "description": "Interval width in seconds",
+            "format": "int64",
+            "type": "integer"
+          },
+          "samples": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "startTime": {
+            "description": "Start of the timeline, unix seconds",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "startTime",
+          "samples",
+          "durationDelta"
+        ],
+        "type": "object"
+      },
       "TenantResponse": {
         "description": "Tenant information returned by the API",
         "properties": {
@@ -260,6 +436,277 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/pyroscope/label-names": {
+      "get": {
+        "operationId": "list_profile_label_names",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PyroscopeLabelsResponse"
+                }
+              }
+            },
+            "description": "Available label names"
+          }
+        },
+        "summary": "List label names present on stored profiles",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
+    "/pyroscope/label-values": {
+      "get": {
+        "operationId": "list_profile_label_values",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "label",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PyroscopeLabelsResponse"
+                }
+              }
+            },
+            "description": "Values for the label"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Missing label parameter"
+          }
+        },
+        "summary": "List values for a profile label",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
+    "/pyroscope/profile-types": {
+      "get": {
+        "operationId": "list_profile_types",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PyroscopeProfileType"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Available profile types"
+          }
+        },
+        "summary": "List available profile types",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
+    "/pyroscope/render": {
+      "get": {
+        "operationId": "render_profile_flamegraph",
+        "parameters": [
+          {
+            "description": "Pyroscope query, e.g. process_cpu:cpu:nanoseconds{service_name=\"checkout\"}",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Range start (unix seconds, unix milliseconds, or now-<N><s|m|h|d>)",
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Range end (same formats as from)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PyroscopeRenderResponse"
+                }
+              }
+            },
+            "description": "Flamegraph in flamebearer encoding"
+          }
+        },
+        "summary": "Render a flamegraph for a profile query and time range",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
+    "/pyroscope/render-diff": {
+      "get": {
+        "operationId": "render_profile_diff",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Baseline range start",
+            "in": "query",
+            "name": "leftFrom",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Baseline range end",
+            "in": "query",
+            "name": "leftUntil",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comparison range start",
+            "in": "query",
+            "name": "rightFrom",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comparison range end",
+            "in": "query",
+            "name": "rightUntil",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PyroscopeRenderResponse"
+                }
+              }
+            },
+            "description": "Differential flamegraph in double flamebearer encoding"
+          }
+        },
+        "summary": "Render a differential flamegraph between two time ranges",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
     "/tenants": {
       "get": {
         "operationId": "list_tenants",
@@ -727,6 +1174,10 @@
     {
       "description": "Dataset management",
       "name": "datasets"
+    },
+    {
+      "description": "Pyroscope-compatible profile queries",
+      "name": "profiles"
     }
   ]
 }

--- a/api/admin-api.yaml
+++ b/api/admin-api.yaml
@@ -15,6 +15,8 @@ tags:
     description: API key management
   - name: datasets
     description: Dataset management
+  - name: profiles
+    description: Pyroscope-compatible profile queries
 paths:
   /tenants:
     get:
@@ -280,6 +282,162 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /pyroscope/render:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: render_profile_flamegraph
+      summary: Render a flamegraph for a profile query and time range
+      tags: [profiles]
+      parameters:
+        - name: query
+          in: query
+          description: "Pyroscope query, e.g. process_cpu:cpu:nanoseconds{service_name=\"checkout\"}"
+          schema:
+            type: string
+        - name: from
+          in: query
+          description: Range start (unix seconds, unix milliseconds, or now-<N><s|m|h|d>)
+          schema:
+            type: string
+        - name: until
+          in: query
+          description: Range end (same formats as from)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Flamegraph in flamebearer encoding
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PyroscopeRenderResponse"
+  /pyroscope/render-diff:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: render_profile_diff
+      summary: Render a differential flamegraph between two time ranges
+      tags: [profiles]
+      parameters:
+        - name: query
+          in: query
+          schema:
+            type: string
+        - name: leftFrom
+          in: query
+          description: Baseline range start
+          schema:
+            type: string
+        - name: leftUntil
+          in: query
+          description: Baseline range end
+          schema:
+            type: string
+        - name: rightFrom
+          in: query
+          description: Comparison range start
+          schema:
+            type: string
+        - name: rightUntil
+          in: query
+          description: Comparison range end
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Differential flamegraph in double flamebearer encoding
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PyroscopeRenderResponse"
+  /pyroscope/label-names:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: list_profile_label_names
+      summary: List label names present on stored profiles
+      tags: [profiles]
+      parameters:
+        - name: from
+          in: query
+          schema:
+            type: string
+        - name: until
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Available label names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PyroscopeLabelsResponse"
+  /pyroscope/label-values:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: list_profile_label_values
+      summary: List values for a profile label
+      tags: [profiles]
+      parameters:
+        - name: label
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: from
+          in: query
+          schema:
+            type: string
+        - name: until
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Values for the label
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PyroscopeLabelsResponse"
+        "400":
+          description: Missing label parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /pyroscope/profile-types:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: list_profile_types
+      summary: List available profile types
+      tags: [profiles]
+      parameters:
+        - name: from
+          in: query
+          schema:
+            type: string
+        - name: until
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Available profile types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PyroscopeProfileType"
 components:
   securitySchemes:
     bearerAuth:
@@ -463,3 +621,136 @@ components:
           description: List of dataset records
           items:
             $ref: "#/components/schemas/DatasetResponse"
+
+    PyroscopeFlamebearer:
+      type: object
+      description: Flamegraph payload in flamebearer encoding
+      required:
+        - names
+        - levels
+        - numTicks
+        - maxSelf
+      properties:
+        names:
+          type: array
+          description: Function name table referenced by block name indices
+          items:
+            type: string
+        levels:
+          type: array
+          description: >-
+            One flat array per depth level; single format uses
+            [offset_delta, total, self, name_index] quadruples, double format
+            uses septuples carrying baseline and comparison values
+          items:
+            type: array
+            items:
+              type: integer
+              format: int64
+        numTicks:
+          type: integer
+          format: int64
+          description: Total number of ticks (root width)
+        maxSelf:
+          type: integer
+          format: int64
+          description: Largest self value of any block
+    PyroscopeFlamebearerMetadata:
+      type: object
+      description: How to interpret flamebearer values
+      required:
+        - format
+        - sampleRate
+        - units
+        - name
+      properties:
+        format:
+          type: string
+          description: single for one profile set, double for a diff
+        spyName:
+          type: string
+          description: Profiler that produced the data
+        sampleRate:
+          type: integer
+          format: int32
+          description: Sample rate in Hz
+        units:
+          type: string
+          description: Value units (samples, objects, bytes)
+        name:
+          type: string
+          description: Display name of the rendered query
+    PyroscopeTimeline:
+      type: object
+      description: Per-interval sample counts for the render timeline
+      required:
+        - startTime
+        - samples
+        - durationDelta
+      properties:
+        startTime:
+          type: integer
+          format: int64
+          description: Start of the timeline, unix seconds
+        samples:
+          type: array
+          items:
+            type: integer
+            format: int64
+        durationDelta:
+          type: integer
+          format: int64
+          description: Interval width in seconds
+    PyroscopeRenderResponse:
+      type: object
+      description: Response of the render and render-diff endpoints
+      required:
+        - flamebearer
+        - metadata
+      properties:
+        flamebearer:
+          $ref: "#/components/schemas/PyroscopeFlamebearer"
+        metadata:
+          $ref: "#/components/schemas/PyroscopeFlamebearerMetadata"
+        timeline:
+          $ref: "#/components/schemas/PyroscopeTimeline"
+        leftTicks:
+          type: integer
+          format: int64
+          description: Total baseline ticks (double format only)
+        rightTicks:
+          type: integer
+          format: int64
+          description: Total comparison ticks (double format only)
+    PyroscopeProfileType:
+      type: object
+      description: An available profile type
+      required:
+        - ID
+        - name
+        - sampleType
+        - sampleUnit
+      properties:
+        ID:
+          type: string
+          description: Canonical profile type ID
+        name:
+          type: string
+        sampleType:
+          type: string
+        sampleUnit:
+          type: string
+        periodType:
+          type: string
+        periodUnit:
+          type: string
+    PyroscopeLabelsResponse:
+      type: object
+      description: Label names or values
+      required:
+        - names
+      properties:
+        names:
+          type: array
+          items:
+            type: string

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 common.workspace = true
 signaldb-api.workspace = true
+pyroscope-api.workspace = true
 tempo-api.workspace = true
 arrow-flight.workspace = true
 datafusion.workspace = true

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
 pub mod flight;
+pub mod pyroscope;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/endpoints/pyroscope.rs
+++ b/src/router/src/endpoints/pyroscope.rs
@@ -1,0 +1,464 @@
+//! # Pyroscope-Compatible HTTP API
+//!
+//! Query endpoints for the profiles signal in the format Grafana's
+//! Pyroscope datasource expects:
+//!
+//! - `GET /render` — flamegraph for a query and time range
+//! - `GET /render-diff` — differential flamegraph (baseline vs comparison)
+//! - `GET /label-names`, `GET /label-values` — label discovery
+//! - `GET /profile-types` — available profile types
+//!
+//! Handlers forward tenant-scoped Flight tickets to the querier and shape
+//! the JSON results into `pyroscope-api` types.
+
+use crate::RouterState;
+use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use axum::{
+    Router,
+    extract::{Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use common::auth::TenantContextExtractor;
+use common::flight::transport::ServiceCapability;
+use datafusion::arrow::array::{Array, StringArray};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use pyroscope_api::{
+    Flamebearer, FlamebearerMetadata, LabelsResponse, ProfileType, RenderResponse,
+};
+use serde::Deserialize;
+
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new()
+        .route("/render", get(render::<S>))
+        .route("/render-diff", get(render_diff::<S>))
+        .route("/label-names", get(label_names::<S>))
+        .route("/label-values", get(label_values::<S>))
+        .route("/profile-types", get(profile_types::<S>))
+}
+
+/// Query parameters for `/render` and `/render-diff`.
+#[derive(Debug, Default, Deserialize)]
+pub struct RenderParams {
+    /// Pyroscope query: `{app}` or `{type}{label="value",...}`.
+    pub query: Option<String>,
+    pub from: Option<String>,
+    pub until: Option<String>,
+    /// Diff-only: baseline range.
+    #[serde(rename = "leftFrom")]
+    pub left_from: Option<String>,
+    #[serde(rename = "leftUntil")]
+    pub left_until: Option<String>,
+    /// Diff-only: comparison range.
+    #[serde(rename = "rightFrom")]
+    pub right_from: Option<String>,
+    #[serde(rename = "rightUntil")]
+    pub right_until: Option<String>,
+}
+
+/// Query parameters for the discovery endpoints.
+#[derive(Debug, Default, Deserialize)]
+pub struct DiscoveryParams {
+    pub from: Option<String>,
+    pub until: Option<String>,
+    /// Label name for `/label-values`.
+    pub label: Option<String>,
+}
+
+/// The selector part of a Pyroscope query, resolved to querier filters.
+#[derive(Debug, Default, PartialEq)]
+struct ParsedQuery {
+    sample_type: Option<String>,
+    service_name: Option<String>,
+}
+
+/// Parse a Pyroscope query like `process_cpu:cpu:nanoseconds{service_name="checkout"}`
+/// or a bare app/type name. The first ID segment maps to our sample type;
+/// a `service_name` matcher narrows the service.
+fn parse_query(query: &str) -> ParsedQuery {
+    let query = query.trim();
+    if query.is_empty() {
+        return ParsedQuery::default();
+    }
+
+    let (id_part, selector_part) = match query.split_once('{') {
+        Some((id, rest)) => (id.trim(), rest.strip_suffix('}').unwrap_or(rest)),
+        None => (query, ""),
+    };
+
+    // Profile type IDs are colon-separated; our sample_type is the second
+    // segment when present (`{name}:{sample_type}:{unit}...`), else the
+    // whole ID.
+    let sample_type = if id_part.is_empty() {
+        None
+    } else {
+        let segments: Vec<&str> = id_part.split(':').collect();
+        Some(
+            segments
+                .get(1)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&segments[0])
+                .to_string(),
+        )
+    };
+
+    let mut service_name = None;
+    for matcher in selector_part.split(',') {
+        let Some((key, value)) = matcher.split_once('=') else {
+            continue;
+        };
+        if key.trim() == "service_name" {
+            service_name = Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+
+    ParsedQuery {
+        sample_type,
+        service_name,
+    }
+}
+
+/// Parse a Pyroscope time parameter: unix seconds, unix milliseconds, or
+/// relative `now[-<N><s|m|h|d>]`. Returns unix seconds.
+fn parse_time(value: &str) -> Option<i64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Ok(number) = value.parse::<i64>() {
+        // Values this large are unix milliseconds.
+        return Some(if number > 100_000_000_000 {
+            number / 1000
+        } else {
+            number
+        });
+    }
+    if let Some(rest) = value.strip_prefix("now") {
+        let now = chrono::Utc::now().timestamp();
+        if rest.is_empty() {
+            return Some(now);
+        }
+        let rest = rest.strip_prefix('-')?;
+        let (digits, unit) = rest.split_at(rest.len().saturating_sub(1));
+        let amount: i64 = digits.parse().ok()?;
+        let seconds = match unit {
+            "s" => amount,
+            "m" => amount * 60,
+            "h" => amount * 3600,
+            "d" => amount * 86400,
+            _ => return None,
+        };
+        return Some(now - seconds);
+    }
+    None
+}
+
+/// Build the JSON search-params object for the querier's profile tickets.
+fn search_params_json(parsed: &ParsedQuery, from: Option<i64>, until: Option<i64>) -> String {
+    serde_json::json!({
+        "service_name": parsed.service_name,
+        "sample_type": parsed.sample_type,
+        "start": from,
+        "end": until,
+    })
+    .to_string()
+}
+
+/// Execute a Flight ticket against a querier and collect the batches.
+async fn execute_ticket<S: RouterState>(
+    state: &S,
+    ticket_content: String,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let mut client = state
+        .service_registry()
+        .get_flight_client_for_capability(ServiceCapability::QueryExecution)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to get Flight client for profile query");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    let ticket = Ticket::new(ticket_content);
+    let mut flight_request = tonic::Request::new(ticket);
+    common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
+
+    let mut stream = client
+        .do_get(flight_request)
+        .await
+        .map_err(|e| flight_status_to_http(&e))?
+        .into_inner();
+
+    let mut data = Vec::new();
+    while let Some(flight_data) = stream.next().await {
+        data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
+    }
+
+    flight_data_to_batches(&data).map_err(|e| {
+        tracing::error!(error = %e, "Failed to decode profile Flight data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+fn flight_status_to_http(status: &tonic::Status) -> StatusCode {
+    match status.code() {
+        tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        _ => {
+            tracing::error!(error = %status, "Profile Flight query failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// Collect every value of the (single) string column across batches.
+fn string_values(batches: &[RecordBatch]) -> Vec<String> {
+    let mut values = Vec::new();
+    for batch in batches {
+        if batch.num_columns() == 0 {
+            continue;
+        }
+        if let Some(column) = batch.column(0).as_any().downcast_ref::<StringArray>() {
+            for i in 0..column.len() {
+                if !column.is_null(i) {
+                    values.push(column.value(i).to_string());
+                }
+            }
+        }
+    }
+    values
+}
+
+/// Decode the single JSON document returned by flamegraph/diff tickets.
+fn decode_json_result<T: serde::de::DeserializeOwned>(
+    batches: &[RecordBatch],
+) -> Result<T, StatusCode> {
+    let values = string_values(batches);
+    let json = values.first().ok_or_else(|| {
+        tracing::error!("Profile query returned no result document");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    serde_json::from_str(json).map_err(|e| {
+        tracing::error!(error = %e, "Failed to parse profile query result");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+/// GET /pyroscope/render — aggregate profiles into a flamegraph.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn render<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RenderParams>,
+) -> Result<axum::Json<RenderResponse>, StatusCode> {
+    let parsed = parse_query(params.query.as_deref().unwrap_or(""));
+    let from = params.from.as_deref().and_then(parse_time);
+    let until = params.until.as_deref().and_then(parse_time);
+
+    let ticket = format!(
+        "profile_flamegraph:{}:{}:{}",
+        tenant_ctx.0.tenant_slug,
+        tenant_ctx.0.dataset_slug,
+        search_params_json(&parsed, from, until)
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    let flamegraph: common::profile::Flamegraph = decode_json_result(&batches)?;
+
+    Ok(axum::Json(RenderResponse {
+        flamebearer: Flamebearer {
+            names: flamegraph.names,
+            levels: flamegraph.levels,
+            num_ticks: flamegraph.total,
+            max_self: flamegraph.max_self,
+        },
+        metadata: FlamebearerMetadata {
+            format: "single".to_string(),
+            spy_name: None,
+            sample_rate: 100,
+            units: "samples".to_string(),
+            name: params.query.unwrap_or_default(),
+        },
+        timeline: None,
+        left_ticks: None,
+        right_ticks: None,
+    }))
+}
+
+/// GET /pyroscope/render-diff — differential flamegraph between two ranges.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn render_diff<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RenderParams>,
+) -> Result<axum::Json<RenderResponse>, StatusCode> {
+    let parsed = parse_query(params.query.as_deref().unwrap_or(""));
+    let left_from = params.left_from.as_deref().and_then(parse_time);
+    let left_until = params.left_until.as_deref().and_then(parse_time);
+    let right_from = params.right_from.as_deref().and_then(parse_time);
+    let right_until = params.right_until.as_deref().and_then(parse_time);
+
+    let diff_params = serde_json::json!({
+        "baseline": serde_json::from_str::<serde_json::Value>(
+            &search_params_json(&parsed, left_from, left_until)
+        ).unwrap_or_default(),
+        "comparison": serde_json::from_str::<serde_json::Value>(
+            &search_params_json(&parsed, right_from, right_until)
+        ).unwrap_or_default(),
+    });
+
+    let ticket = format!(
+        "profile_diff:{}:{}:{}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug, diff_params
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    let diff: common::profile::DiffFlamegraph = decode_json_result(&batches)?;
+
+    Ok(axum::Json(RenderResponse {
+        flamebearer: Flamebearer {
+            names: diff.names,
+            levels: diff.levels,
+            num_ticks: diff.total,
+            max_self: diff.max_self,
+        },
+        metadata: FlamebearerMetadata {
+            format: "double".to_string(),
+            spy_name: None,
+            sample_rate: 100,
+            units: "samples".to_string(),
+            name: params.query.unwrap_or_default(),
+        },
+        timeline: None,
+        left_ticks: Some(diff.left_ticks),
+        right_ticks: Some(diff.right_ticks),
+    }))
+}
+
+/// Build the discovery-window JSON tail for discovery tickets.
+fn discovery_params_json(params: &DiscoveryParams) -> String {
+    serde_json::json!({
+        "start": params.from.as_deref().and_then(parse_time),
+        "end": params.until.as_deref().and_then(parse_time),
+    })
+    .to_string()
+}
+
+/// GET /pyroscope/label-names
+#[tracing::instrument(skip(state, tenant_ctx, params))]
+pub async fn label_names<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<DiscoveryParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    let ticket = format!(
+        "label_names:{}:{}:{}",
+        tenant_ctx.0.tenant_slug,
+        tenant_ctx.0.dataset_slug,
+        discovery_params_json(&params)
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse {
+        names: string_values(&batches),
+    }))
+}
+
+/// GET /pyroscope/label-values?label=<name>
+#[tracing::instrument(skip(state, tenant_ctx, params))]
+pub async fn label_values<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<DiscoveryParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    let label = params.label.clone().filter(|l| !l.is_empty()).ok_or(
+        // Pyroscope requires the label parameter here.
+        StatusCode::BAD_REQUEST,
+    )?;
+    let ticket = format!(
+        "label_values:{}:{}:{}:{}",
+        tenant_ctx.0.tenant_slug,
+        tenant_ctx.0.dataset_slug,
+        label,
+        discovery_params_json(&params)
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse {
+        names: string_values(&batches),
+    }))
+}
+
+/// GET /pyroscope/profile-types
+#[tracing::instrument(skip(state, tenant_ctx, params))]
+pub async fn profile_types<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<DiscoveryParams>,
+) -> Result<axum::Json<Vec<ProfileType>>, StatusCode> {
+    let ticket = format!(
+        "profile_types:{}:{}:{}",
+        tenant_ctx.0.tenant_slug,
+        tenant_ctx.0.dataset_slug,
+        discovery_params_json(&params)
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    let types = string_values(&batches)
+        .iter()
+        .map(|entry| {
+            let (sample_type, sample_unit) = entry.split_once(':').unwrap_or((entry.as_str(), ""));
+            ProfileType::from_type_unit(sample_type, sample_unit)
+        })
+        .collect();
+    Ok(axum::Json(types))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_pyroscope_query() {
+        let parsed =
+            parse_query(r#"process_cpu:cpu:nanoseconds{service_name="checkout",env="prod"}"#);
+        assert_eq!(parsed.sample_type.as_deref(), Some("cpu"));
+        assert_eq!(parsed.service_name.as_deref(), Some("checkout"));
+    }
+
+    #[test]
+    fn parses_bare_app_query() {
+        let parsed = parse_query("cpu");
+        assert_eq!(parsed.sample_type.as_deref(), Some("cpu"));
+        assert_eq!(parsed.service_name, None);
+    }
+
+    #[test]
+    fn parses_empty_query() {
+        assert_eq!(parse_query(""), ParsedQuery::default());
+    }
+
+    #[test]
+    fn parses_absolute_and_relative_times() {
+        assert_eq!(parse_time("1700000000"), Some(1_700_000_000));
+        // Milliseconds are detected and converted.
+        assert_eq!(parse_time("1700000000000"), Some(1_700_000_000));
+        let now = chrono::Utc::now().timestamp();
+        let one_hour_ago = parse_time("now-1h").expect("relative time");
+        assert!((now - 3600 - one_hour_ago).abs() <= 2);
+        assert!(parse_time("later").is_none());
+    }
+}

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -201,6 +201,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Pyroscope-compatible profile query API
+        .nest(
+            "/pyroscope",
+            endpoints::pyroscope::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Admin routes with admin authentication
         .nest("/api/v1/admin", admin_router)
         .nest(

--- a/src/signaldb-api/src/generated.rs
+++ b/src/signaldb-api/src/generated.rs
@@ -374,6 +374,314 @@ pub struct ListTenantsResponse {
     ///List of tenant records
     pub tenants: ::std::vec::Vec<TenantResponse>,
 }
+///Flamegraph payload in flamebearer encoding
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "Flamegraph payload in flamebearer encoding",
+///  "type": "object",
+///  "required": [
+///    "levels",
+///    "maxSelf",
+///    "names",
+///    "numTicks"
+///  ],
+///  "properties": {
+///    "levels": {
+///      "description": "One flat array per depth level; single format uses [offset_delta, total, self, name_index] quadruples, double format uses septuples carrying baseline and comparison values",
+///      "type": "array",
+///      "items": {
+///        "type": "array",
+///        "items": {
+///          "type": "integer",
+///          "format": "int64"
+///        }
+///      }
+///    },
+///    "maxSelf": {
+///      "description": "Largest self value of any block",
+///      "type": "integer",
+///      "format": "int64"
+///    },
+///    "names": {
+///      "description": "Function name table referenced by block name indices",
+///      "type": "array",
+///      "items": {
+///        "type": "string"
+///      }
+///    },
+///    "numTicks": {
+///      "description": "Total number of ticks (root width)",
+///      "type": "integer",
+///      "format": "int64"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeFlamebearer {
+    ///One flat array per depth level; single format uses [offset_delta, total, self, name_index] quadruples, double format uses septuples carrying baseline and comparison values
+    pub levels: ::std::vec::Vec<::std::vec::Vec<i64>>,
+    ///Largest self value of any block
+    #[serde(rename = "maxSelf")]
+    pub max_self: i64,
+    ///Function name table referenced by block name indices
+    pub names: ::std::vec::Vec<::std::string::String>,
+    ///Total number of ticks (root width)
+    #[serde(rename = "numTicks")]
+    pub num_ticks: i64,
+}
+///How to interpret flamebearer values
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "How to interpret flamebearer values",
+///  "type": "object",
+///  "required": [
+///    "format",
+///    "name",
+///    "sampleRate",
+///    "units"
+///  ],
+///  "properties": {
+///    "format": {
+///      "description": "single for one profile set, double for a diff",
+///      "type": "string"
+///    },
+///    "name": {
+///      "description": "Display name of the rendered query",
+///      "type": "string"
+///    },
+///    "sampleRate": {
+///      "description": "Sample rate in Hz",
+///      "type": "integer",
+///      "format": "int32"
+///    },
+///    "spyName": {
+///      "description": "Profiler that produced the data",
+///      "type": "string"
+///    },
+///    "units": {
+///      "description": "Value units (samples, objects, bytes)",
+///      "type": "string"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeFlamebearerMetadata {
+    ///single for one profile set, double for a diff
+    pub format: ::std::string::String,
+    ///Display name of the rendered query
+    pub name: ::std::string::String,
+    ///Sample rate in Hz
+    #[serde(rename = "sampleRate")]
+    pub sample_rate: i32,
+    ///Profiler that produced the data
+    #[serde(
+        rename = "spyName",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub spy_name: ::std::option::Option<::std::string::String>,
+    ///Value units (samples, objects, bytes)
+    pub units: ::std::string::String,
+}
+///Label names or values
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "Label names or values",
+///  "type": "object",
+///  "required": [
+///    "names"
+///  ],
+///  "properties": {
+///    "names": {
+///      "type": "array",
+///      "items": {
+///        "type": "string"
+///      }
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeLabelsResponse {
+    pub names: ::std::vec::Vec<::std::string::String>,
+}
+///An available profile type
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "An available profile type",
+///  "type": "object",
+///  "required": [
+///    "ID",
+///    "name",
+///    "sampleType",
+///    "sampleUnit"
+///  ],
+///  "properties": {
+///    "ID": {
+///      "description": "Canonical profile type ID",
+///      "type": "string"
+///    },
+///    "name": {
+///      "type": "string"
+///    },
+///    "periodType": {
+///      "type": "string"
+///    },
+///    "periodUnit": {
+///      "type": "string"
+///    },
+///    "sampleType": {
+///      "type": "string"
+///    },
+///    "sampleUnit": {
+///      "type": "string"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeProfileType {
+    ///Canonical profile type ID
+    #[serde(rename = "ID")]
+    pub id: ::std::string::String,
+    pub name: ::std::string::String,
+    #[serde(
+        rename = "periodType",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub period_type: ::std::option::Option<::std::string::String>,
+    #[serde(
+        rename = "periodUnit",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub period_unit: ::std::option::Option<::std::string::String>,
+    #[serde(rename = "sampleType")]
+    pub sample_type: ::std::string::String,
+    #[serde(rename = "sampleUnit")]
+    pub sample_unit: ::std::string::String,
+}
+///Response of the render and render-diff endpoints
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "Response of the render and render-diff endpoints",
+///  "type": "object",
+///  "required": [
+///    "flamebearer",
+///    "metadata"
+///  ],
+///  "properties": {
+///    "flamebearer": {
+///      "$ref": "#/definitions/PyroscopeFlamebearer"
+///    },
+///    "leftTicks": {
+///      "description": "Total baseline ticks (double format only)",
+///      "type": "integer",
+///      "format": "int64"
+///    },
+///    "metadata": {
+///      "$ref": "#/definitions/PyroscopeFlamebearerMetadata"
+///    },
+///    "rightTicks": {
+///      "description": "Total comparison ticks (double format only)",
+///      "type": "integer",
+///      "format": "int64"
+///    },
+///    "timeline": {
+///      "$ref": "#/definitions/PyroscopeTimeline"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeRenderResponse {
+    pub flamebearer: PyroscopeFlamebearer,
+    ///Total baseline ticks (double format only)
+    #[serde(
+        rename = "leftTicks",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub left_ticks: ::std::option::Option<i64>,
+    pub metadata: PyroscopeFlamebearerMetadata,
+    ///Total comparison ticks (double format only)
+    #[serde(
+        rename = "rightTicks",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub right_ticks: ::std::option::Option<i64>,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub timeline: ::std::option::Option<PyroscopeTimeline>,
+}
+///Per-interval sample counts for the render timeline
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "Per-interval sample counts for the render timeline",
+///  "type": "object",
+///  "required": [
+///    "durationDelta",
+///    "samples",
+///    "startTime"
+///  ],
+///  "properties": {
+///    "durationDelta": {
+///      "description": "Interval width in seconds",
+///      "type": "integer",
+///      "format": "int64"
+///    },
+///    "samples": {
+///      "type": "array",
+///      "items": {
+///        "type": "integer",
+///        "format": "int64"
+///      }
+///    },
+///    "startTime": {
+///      "description": "Start of the timeline, unix seconds",
+///      "type": "integer",
+///      "format": "int64"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct PyroscopeTimeline {
+    ///Interval width in seconds
+    #[serde(rename = "durationDelta")]
+    pub duration_delta: i64,
+    pub samples: ::std::vec::Vec<i64>,
+    ///Start of the timeline, unix seconds
+    #[serde(rename = "startTime")]
+    pub start_time: i64,
+}
 ///Tenant information returned by the API
 ///
 /// <details><summary>JSON schema</summary>

--- a/src/signaldb-sdk/src/generated.rs
+++ b/src/signaldb-sdk/src/generated.rs
@@ -431,6 +431,344 @@ pub mod types {
             Default::default()
         }
     }
+    ///Flamegraph payload in flamebearer encoding
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Flamegraph payload in flamebearer encoding",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "levels",
+    ///    "maxSelf",
+    ///    "names",
+    ///    "numTicks"
+    ///  ],
+    ///  "properties": {
+    ///    "levels": {
+    ///      "description": "One flat array per depth level; single format uses [offset_delta, total, self, name_index] quadruples, double format uses septuples carrying baseline and comparison values",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "array",
+    ///        "items": {
+    ///          "type": "integer",
+    ///          "format": "int64"
+    ///        }
+    ///      }
+    ///    },
+    ///    "maxSelf": {
+    ///      "description": "Largest self value of any block",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    },
+    ///    "names": {
+    ///      "description": "Function name table referenced by block name indices",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    },
+    ///    "numTicks": {
+    ///      "description": "Total number of ticks (root width)",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeFlamebearer {
+        ///One flat array per depth level; single format uses [offset_delta, total, self, name_index] quadruples, double format uses septuples carrying baseline and comparison values
+        pub levels: ::std::vec::Vec<::std::vec::Vec<i64>>,
+        ///Largest self value of any block
+        #[serde(rename = "maxSelf")]
+        pub max_self: i64,
+        ///Function name table referenced by block name indices
+        pub names: ::std::vec::Vec<::std::string::String>,
+        ///Total number of ticks (root width)
+        #[serde(rename = "numTicks")]
+        pub num_ticks: i64,
+    }
+    impl PyroscopeFlamebearer {
+        pub fn builder() -> builder::PyroscopeFlamebearer {
+            Default::default()
+        }
+    }
+    ///How to interpret flamebearer values
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "How to interpret flamebearer values",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "format",
+    ///    "name",
+    ///    "sampleRate",
+    ///    "units"
+    ///  ],
+    ///  "properties": {
+    ///    "format": {
+    ///      "description": "single for one profile set, double for a diff",
+    ///      "type": "string"
+    ///    },
+    ///    "name": {
+    ///      "description": "Display name of the rendered query",
+    ///      "type": "string"
+    ///    },
+    ///    "sampleRate": {
+    ///      "description": "Sample rate in Hz",
+    ///      "type": "integer",
+    ///      "format": "int32"
+    ///    },
+    ///    "spyName": {
+    ///      "description": "Profiler that produced the data",
+    ///      "type": "string"
+    ///    },
+    ///    "units": {
+    ///      "description": "Value units (samples, objects, bytes)",
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeFlamebearerMetadata {
+        ///single for one profile set, double for a diff
+        pub format: ::std::string::String,
+        ///Display name of the rendered query
+        pub name: ::std::string::String,
+        ///Sample rate in Hz
+        #[serde(rename = "sampleRate")]
+        pub sample_rate: i32,
+        ///Profiler that produced the data
+        #[serde(
+            rename = "spyName",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub spy_name: ::std::option::Option<::std::string::String>,
+        ///Value units (samples, objects, bytes)
+        pub units: ::std::string::String,
+    }
+    impl PyroscopeFlamebearerMetadata {
+        pub fn builder() -> builder::PyroscopeFlamebearerMetadata {
+            Default::default()
+        }
+    }
+    ///Label names or values
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Label names or values",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "names"
+    ///  ],
+    ///  "properties": {
+    ///    "names": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeLabelsResponse {
+        pub names: ::std::vec::Vec<::std::string::String>,
+    }
+    impl PyroscopeLabelsResponse {
+        pub fn builder() -> builder::PyroscopeLabelsResponse {
+            Default::default()
+        }
+    }
+    ///An available profile type
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An available profile type",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "ID",
+    ///    "name",
+    ///    "sampleType",
+    ///    "sampleUnit"
+    ///  ],
+    ///  "properties": {
+    ///    "ID": {
+    ///      "description": "Canonical profile type ID",
+    ///      "type": "string"
+    ///    },
+    ///    "name": {
+    ///      "type": "string"
+    ///    },
+    ///    "periodType": {
+    ///      "type": "string"
+    ///    },
+    ///    "periodUnit": {
+    ///      "type": "string"
+    ///    },
+    ///    "sampleType": {
+    ///      "type": "string"
+    ///    },
+    ///    "sampleUnit": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeProfileType {
+        ///Canonical profile type ID
+        #[serde(rename = "ID")]
+        pub id: ::std::string::String,
+        pub name: ::std::string::String,
+        #[serde(
+            rename = "periodType",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub period_type: ::std::option::Option<::std::string::String>,
+        #[serde(
+            rename = "periodUnit",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub period_unit: ::std::option::Option<::std::string::String>,
+        #[serde(rename = "sampleType")]
+        pub sample_type: ::std::string::String,
+        #[serde(rename = "sampleUnit")]
+        pub sample_unit: ::std::string::String,
+    }
+    impl PyroscopeProfileType {
+        pub fn builder() -> builder::PyroscopeProfileType {
+            Default::default()
+        }
+    }
+    ///Response of the render and render-diff endpoints
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Response of the render and render-diff endpoints",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "flamebearer",
+    ///    "metadata"
+    ///  ],
+    ///  "properties": {
+    ///    "flamebearer": {
+    ///      "$ref": "#/components/schemas/PyroscopeFlamebearer"
+    ///    },
+    ///    "leftTicks": {
+    ///      "description": "Total baseline ticks (double format only)",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    },
+    ///    "metadata": {
+    ///      "$ref": "#/components/schemas/PyroscopeFlamebearerMetadata"
+    ///    },
+    ///    "rightTicks": {
+    ///      "description": "Total comparison ticks (double format only)",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    },
+    ///    "timeline": {
+    ///      "$ref": "#/components/schemas/PyroscopeTimeline"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeRenderResponse {
+        pub flamebearer: PyroscopeFlamebearer,
+        ///Total baseline ticks (double format only)
+        #[serde(
+            rename = "leftTicks",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub left_ticks: ::std::option::Option<i64>,
+        pub metadata: PyroscopeFlamebearerMetadata,
+        ///Total comparison ticks (double format only)
+        #[serde(
+            rename = "rightTicks",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub right_ticks: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub timeline: ::std::option::Option<PyroscopeTimeline>,
+    }
+    impl PyroscopeRenderResponse {
+        pub fn builder() -> builder::PyroscopeRenderResponse {
+            Default::default()
+        }
+    }
+    ///Per-interval sample counts for the render timeline
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Per-interval sample counts for the render timeline",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "durationDelta",
+    ///    "samples",
+    ///    "startTime"
+    ///  ],
+    ///  "properties": {
+    ///    "durationDelta": {
+    ///      "description": "Interval width in seconds",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    },
+    ///    "samples": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "integer",
+    ///        "format": "int64"
+    ///      }
+    ///    },
+    ///    "startTime": {
+    ///      "description": "Start of the timeline, unix seconds",
+    ///      "type": "integer",
+    ///      "format": "int64"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PyroscopeTimeline {
+        ///Interval width in seconds
+        #[serde(rename = "durationDelta")]
+        pub duration_delta: i64,
+        pub samples: ::std::vec::Vec<i64>,
+        ///Start of the timeline, unix seconds
+        #[serde(rename = "startTime")]
+        pub start_time: i64,
+    }
+    impl PyroscopeTimeline {
+        pub fn builder() -> builder::PyroscopeTimeline {
+            Default::default()
+        }
+    }
     ///Tenant information returned by the API
     ///
     /// <details><summary>JSON schema</summary>
@@ -1130,6 +1468,518 @@ pub mod types {
             }
         }
         #[derive(Clone, Debug)]
+        pub struct PyroscopeFlamebearer {
+            levels:
+                ::std::result::Result<::std::vec::Vec<::std::vec::Vec<i64>>, ::std::string::String>,
+            max_self: ::std::result::Result<i64, ::std::string::String>,
+            names: ::std::result::Result<
+                ::std::vec::Vec<::std::string::String>,
+                ::std::string::String,
+            >,
+            num_ticks: ::std::result::Result<i64, ::std::string::String>,
+        }
+        impl ::std::default::Default for PyroscopeFlamebearer {
+            fn default() -> Self {
+                Self {
+                    levels: Err("no value supplied for levels".to_string()),
+                    max_self: Err("no value supplied for max_self".to_string()),
+                    names: Err("no value supplied for names".to_string()),
+                    num_ticks: Err("no value supplied for num_ticks".to_string()),
+                }
+            }
+        }
+        impl PyroscopeFlamebearer {
+            pub fn levels<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<::std::vec::Vec<i64>>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.levels = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for levels: {e}"));
+                self
+            }
+            pub fn max_self<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.max_self = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for max_self: {e}"));
+                self
+            }
+            pub fn names<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.names = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for names: {e}"));
+                self
+            }
+            pub fn num_ticks<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.num_ticks = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for num_ticks: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeFlamebearer> for super::PyroscopeFlamebearer {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeFlamebearer,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    levels: value.levels?,
+                    max_self: value.max_self?,
+                    names: value.names?,
+                    num_ticks: value.num_ticks?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeFlamebearer> for PyroscopeFlamebearer {
+            fn from(value: super::PyroscopeFlamebearer) -> Self {
+                Self {
+                    levels: Ok(value.levels),
+                    max_self: Ok(value.max_self),
+                    names: Ok(value.names),
+                    num_ticks: Ok(value.num_ticks),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PyroscopeFlamebearerMetadata {
+            format: ::std::result::Result<::std::string::String, ::std::string::String>,
+            name: ::std::result::Result<::std::string::String, ::std::string::String>,
+            sample_rate: ::std::result::Result<i32, ::std::string::String>,
+            spy_name: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+            units: ::std::result::Result<::std::string::String, ::std::string::String>,
+        }
+        impl ::std::default::Default for PyroscopeFlamebearerMetadata {
+            fn default() -> Self {
+                Self {
+                    format: Err("no value supplied for format".to_string()),
+                    name: Err("no value supplied for name".to_string()),
+                    sample_rate: Err("no value supplied for sample_rate".to_string()),
+                    spy_name: Ok(Default::default()),
+                    units: Err("no value supplied for units".to_string()),
+                }
+            }
+        }
+        impl PyroscopeFlamebearerMetadata {
+            pub fn format<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.format = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for format: {e}"));
+                self
+            }
+            pub fn name<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
+                self
+            }
+            pub fn sample_rate<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i32>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sample_rate = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sample_rate: {e}"));
+                self
+            }
+            pub fn spy_name<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.spy_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for spy_name: {e}"));
+                self
+            }
+            pub fn units<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.units = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for units: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeFlamebearerMetadata> for super::PyroscopeFlamebearerMetadata {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeFlamebearerMetadata,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    format: value.format?,
+                    name: value.name?,
+                    sample_rate: value.sample_rate?,
+                    spy_name: value.spy_name?,
+                    units: value.units?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeFlamebearerMetadata> for PyroscopeFlamebearerMetadata {
+            fn from(value: super::PyroscopeFlamebearerMetadata) -> Self {
+                Self {
+                    format: Ok(value.format),
+                    name: Ok(value.name),
+                    sample_rate: Ok(value.sample_rate),
+                    spy_name: Ok(value.spy_name),
+                    units: Ok(value.units),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PyroscopeLabelsResponse {
+            names: ::std::result::Result<
+                ::std::vec::Vec<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PyroscopeLabelsResponse {
+            fn default() -> Self {
+                Self {
+                    names: Err("no value supplied for names".to_string()),
+                }
+            }
+        }
+        impl PyroscopeLabelsResponse {
+            pub fn names<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.names = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for names: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeLabelsResponse> for super::PyroscopeLabelsResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeLabelsResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    names: value.names?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeLabelsResponse> for PyroscopeLabelsResponse {
+            fn from(value: super::PyroscopeLabelsResponse) -> Self {
+                Self {
+                    names: Ok(value.names),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PyroscopeProfileType {
+            id: ::std::result::Result<::std::string::String, ::std::string::String>,
+            name: ::std::result::Result<::std::string::String, ::std::string::String>,
+            period_type: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+            period_unit: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+            sample_type: ::std::result::Result<::std::string::String, ::std::string::String>,
+            sample_unit: ::std::result::Result<::std::string::String, ::std::string::String>,
+        }
+        impl ::std::default::Default for PyroscopeProfileType {
+            fn default() -> Self {
+                Self {
+                    id: Err("no value supplied for id".to_string()),
+                    name: Err("no value supplied for name".to_string()),
+                    period_type: Ok(Default::default()),
+                    period_unit: Ok(Default::default()),
+                    sample_type: Err("no value supplied for sample_type".to_string()),
+                    sample_unit: Err("no value supplied for sample_unit".to_string()),
+                }
+            }
+        }
+        impl PyroscopeProfileType {
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn name<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for name: {e}"));
+                self
+            }
+            pub fn period_type<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.period_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for period_type: {e}"));
+                self
+            }
+            pub fn period_unit<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.period_unit = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for period_unit: {e}"));
+                self
+            }
+            pub fn sample_type<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sample_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sample_type: {e}"));
+                self
+            }
+            pub fn sample_unit<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sample_unit = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sample_unit: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeProfileType> for super::PyroscopeProfileType {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeProfileType,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    id: value.id?,
+                    name: value.name?,
+                    period_type: value.period_type?,
+                    period_unit: value.period_unit?,
+                    sample_type: value.sample_type?,
+                    sample_unit: value.sample_unit?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeProfileType> for PyroscopeProfileType {
+            fn from(value: super::PyroscopeProfileType) -> Self {
+                Self {
+                    id: Ok(value.id),
+                    name: Ok(value.name),
+                    period_type: Ok(value.period_type),
+                    period_unit: Ok(value.period_unit),
+                    sample_type: Ok(value.sample_type),
+                    sample_unit: Ok(value.sample_unit),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PyroscopeRenderResponse {
+            flamebearer: ::std::result::Result<super::PyroscopeFlamebearer, ::std::string::String>,
+            left_ticks: ::std::result::Result<::std::option::Option<i64>, ::std::string::String>,
+            metadata:
+                ::std::result::Result<super::PyroscopeFlamebearerMetadata, ::std::string::String>,
+            right_ticks: ::std::result::Result<::std::option::Option<i64>, ::std::string::String>,
+            timeline: ::std::result::Result<
+                ::std::option::Option<super::PyroscopeTimeline>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PyroscopeRenderResponse {
+            fn default() -> Self {
+                Self {
+                    flamebearer: Err("no value supplied for flamebearer".to_string()),
+                    left_ticks: Ok(Default::default()),
+                    metadata: Err("no value supplied for metadata".to_string()),
+                    right_ticks: Ok(Default::default()),
+                    timeline: Ok(Default::default()),
+                }
+            }
+        }
+        impl PyroscopeRenderResponse {
+            pub fn flamebearer<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PyroscopeFlamebearer>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.flamebearer = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for flamebearer: {e}"));
+                self
+            }
+            pub fn left_ticks<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.left_ticks = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for left_ticks: {e}"));
+                self
+            }
+            pub fn metadata<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PyroscopeFlamebearerMetadata>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.metadata = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for metadata: {e}"));
+                self
+            }
+            pub fn right_ticks<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.right_ticks = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for right_ticks: {e}"));
+                self
+            }
+            pub fn timeline<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::PyroscopeTimeline>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.timeline = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for timeline: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeRenderResponse> for super::PyroscopeRenderResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeRenderResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    flamebearer: value.flamebearer?,
+                    left_ticks: value.left_ticks?,
+                    metadata: value.metadata?,
+                    right_ticks: value.right_ticks?,
+                    timeline: value.timeline?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeRenderResponse> for PyroscopeRenderResponse {
+            fn from(value: super::PyroscopeRenderResponse) -> Self {
+                Self {
+                    flamebearer: Ok(value.flamebearer),
+                    left_ticks: Ok(value.left_ticks),
+                    metadata: Ok(value.metadata),
+                    right_ticks: Ok(value.right_ticks),
+                    timeline: Ok(value.timeline),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PyroscopeTimeline {
+            duration_delta: ::std::result::Result<i64, ::std::string::String>,
+            samples: ::std::result::Result<::std::vec::Vec<i64>, ::std::string::String>,
+            start_time: ::std::result::Result<i64, ::std::string::String>,
+        }
+        impl ::std::default::Default for PyroscopeTimeline {
+            fn default() -> Self {
+                Self {
+                    duration_delta: Err("no value supplied for duration_delta".to_string()),
+                    samples: Err("no value supplied for samples".to_string()),
+                    start_time: Err("no value supplied for start_time".to_string()),
+                }
+            }
+        }
+        impl PyroscopeTimeline {
+            pub fn duration_delta<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.duration_delta = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for duration_delta: {e}")
+                });
+                self
+            }
+            pub fn samples<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.samples = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for samples: {e}"));
+                self
+            }
+            pub fn start_time<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.start_time = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for start_time: {e}"));
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PyroscopeTimeline> for super::PyroscopeTimeline {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PyroscopeTimeline,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    duration_delta: value.duration_delta?,
+                    samples: value.samples?,
+                    start_time: value.start_time?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PyroscopeTimeline> for PyroscopeTimeline {
+            fn from(value: super::PyroscopeTimeline) -> Self {
+                Self {
+                    duration_delta: Ok(value.duration_delta),
+                    samples: Ok(value.samples),
+                    start_time: Ok(value.start_time),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
         pub struct TenantResponse {
             created_at: ::std::result::Result<::std::string::String, ::std::string::String>,
             default_dataset: ::std::result::Result<
@@ -1361,6 +2211,91 @@ impl ClientInfo<()> for Client {
 }
 impl ClientHooks<()> for &Client {}
 impl Client {
+    /**List label names present on stored profiles
+
+    Sends a `GET` request to `/pyroscope/label-names`
+
+    ```ignore
+    let response = client.list_profile_label_names()
+        .from(from)
+        .until(until)
+        .send()
+        .await;
+    ```*/
+    pub fn list_profile_label_names(&self) -> builder::ListProfileLabelNames<'_> {
+        builder::ListProfileLabelNames::new(self)
+    }
+    /**List values for a profile label
+
+    Sends a `GET` request to `/pyroscope/label-values`
+
+    ```ignore
+    let response = client.list_profile_label_values()
+        .from(from)
+        .label(label)
+        .until(until)
+        .send()
+        .await;
+    ```*/
+    pub fn list_profile_label_values(&self) -> builder::ListProfileLabelValues<'_> {
+        builder::ListProfileLabelValues::new(self)
+    }
+    /**List available profile types
+
+    Sends a `GET` request to `/pyroscope/profile-types`
+
+    ```ignore
+    let response = client.list_profile_types()
+        .from(from)
+        .until(until)
+        .send()
+        .await;
+    ```*/
+    pub fn list_profile_types(&self) -> builder::ListProfileTypes<'_> {
+        builder::ListProfileTypes::new(self)
+    }
+    /**Render a flamegraph for a profile query and time range
+
+    Sends a `GET` request to `/pyroscope/render`
+
+    Arguments:
+    - `from`: Range start (unix seconds, unix milliseconds, or now-<N><s|m|h|d>)
+    - `query`: Pyroscope query, e.g. process_cpu:cpu:nanoseconds{service_name="checkout"}
+    - `until`: Range end (same formats as from)
+    ```ignore
+    let response = client.render_profile_flamegraph()
+        .from(from)
+        .query(query)
+        .until(until)
+        .send()
+        .await;
+    ```*/
+    pub fn render_profile_flamegraph(&self) -> builder::RenderProfileFlamegraph<'_> {
+        builder::RenderProfileFlamegraph::new(self)
+    }
+    /**Render a differential flamegraph between two time ranges
+
+    Sends a `GET` request to `/pyroscope/render-diff`
+
+    Arguments:
+    - `left_from`: Baseline range start
+    - `left_until`: Baseline range end
+    - `query`
+    - `right_from`: Comparison range start
+    - `right_until`: Comparison range end
+    ```ignore
+    let response = client.render_profile_diff()
+        .left_from(left_from)
+        .left_until(left_until)
+        .query(query)
+        .right_from(right_from)
+        .right_until(right_until)
+        .send()
+        .await;
+    ```*/
+    pub fn render_profile_diff(&self) -> builder::RenderProfileDiff<'_> {
+        builder::RenderProfileDiff::new(self)
+    }
     /**List all tenants
 
     Sends a `GET` request to `/tenants`
@@ -1541,6 +2476,474 @@ pub mod builder {
         ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
         ResponseValue, encode_path,
     };
+    /**Builder for [`Client::list_profile_label_names`]
+
+    [`Client::list_profile_label_names`]: super::Client::list_profile_label_names*/
+    #[derive(Debug, Clone)]
+    pub struct ListProfileLabelNames<'a> {
+        client: &'a super::Client,
+        from: Result<Option<::std::string::String>, String>,
+        until: Result<Option<::std::string::String>, String>,
+    }
+    impl<'a> ListProfileLabelNames<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                from: Ok(None),
+                until: Ok(None),
+            }
+        }
+        pub fn from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for from failed".to_string()
+            });
+            self
+        }
+        pub fn until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for until failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/pyroscope/label-names`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::PyroscopeLabelsResponse>, Error<()>> {
+            let Self {
+                client,
+                from,
+                until,
+            } = self;
+            let from = from.map_err(Error::InvalidRequest)?;
+            let until = until.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/pyroscope/label-names", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("from", &from))
+                .query(&progenitor_client::QueryParam::new("until", &until))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "list_profile_label_names",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::list_profile_label_values`]
+
+    [`Client::list_profile_label_values`]: super::Client::list_profile_label_values*/
+    #[derive(Debug, Clone)]
+    pub struct ListProfileLabelValues<'a> {
+        client: &'a super::Client,
+        from: Result<Option<::std::string::String>, String>,
+        label: Result<::std::string::String, String>,
+        until: Result<Option<::std::string::String>, String>,
+    }
+    impl<'a> ListProfileLabelValues<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                from: Ok(None),
+                label: Err("label was not initialized".to_string()),
+                until: Ok(None),
+            }
+        }
+        pub fn from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for from failed".to_string()
+            });
+            self
+        }
+        pub fn label<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.label = value.try_into().map_err(|_| {
+                "conversion to `:: std :: string :: String` for label failed".to_string()
+            });
+            self
+        }
+        pub fn until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for until failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/pyroscope/label-values`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::PyroscopeLabelsResponse>, Error<types::ApiError>> {
+            let Self {
+                client,
+                from,
+                label,
+                until,
+            } = self;
+            let from = from.map_err(Error::InvalidRequest)?;
+            let label = label.map_err(Error::InvalidRequest)?;
+            let until = until.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/pyroscope/label-values", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("from", &from))
+                .query(&progenitor_client::QueryParam::new("label", &label))
+                .query(&progenitor_client::QueryParam::new("until", &until))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "list_profile_label_values",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::list_profile_types`]
+
+    [`Client::list_profile_types`]: super::Client::list_profile_types*/
+    #[derive(Debug, Clone)]
+    pub struct ListProfileTypes<'a> {
+        client: &'a super::Client,
+        from: Result<Option<::std::string::String>, String>,
+        until: Result<Option<::std::string::String>, String>,
+    }
+    impl<'a> ListProfileTypes<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                from: Ok(None),
+                until: Ok(None),
+            }
+        }
+        pub fn from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for from failed".to_string()
+            });
+            self
+        }
+        pub fn until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for until failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/pyroscope/profile-types`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<::std::vec::Vec<types::PyroscopeProfileType>>, Error<()>>
+        {
+            let Self {
+                client,
+                from,
+                until,
+            } = self;
+            let from = from.map_err(Error::InvalidRequest)?;
+            let until = until.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/pyroscope/profile-types", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("from", &from))
+                .query(&progenitor_client::QueryParam::new("until", &until))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "list_profile_types",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::render_profile_flamegraph`]
+
+    [`Client::render_profile_flamegraph`]: super::Client::render_profile_flamegraph*/
+    #[derive(Debug, Clone)]
+    pub struct RenderProfileFlamegraph<'a> {
+        client: &'a super::Client,
+        from: Result<Option<::std::string::String>, String>,
+        query: Result<Option<::std::string::String>, String>,
+        until: Result<Option<::std::string::String>, String>,
+    }
+    impl<'a> RenderProfileFlamegraph<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                from: Ok(None),
+                query: Ok(None),
+                until: Ok(None),
+            }
+        }
+        pub fn from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for from failed".to_string()
+            });
+            self
+        }
+        pub fn query<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.query = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for query failed".to_string()
+            });
+            self
+        }
+        pub fn until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for until failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/pyroscope/render`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::PyroscopeRenderResponse>, Error<()>> {
+            let Self {
+                client,
+                from,
+                query,
+                until,
+            } = self;
+            let from = from.map_err(Error::InvalidRequest)?;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let until = until.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/pyroscope/render", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("from", &from))
+                .query(&progenitor_client::QueryParam::new("query", &query))
+                .query(&progenitor_client::QueryParam::new("until", &until))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "render_profile_flamegraph",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::render_profile_diff`]
+
+    [`Client::render_profile_diff`]: super::Client::render_profile_diff*/
+    #[derive(Debug, Clone)]
+    pub struct RenderProfileDiff<'a> {
+        client: &'a super::Client,
+        left_from: Result<Option<::std::string::String>, String>,
+        left_until: Result<Option<::std::string::String>, String>,
+        query: Result<Option<::std::string::String>, String>,
+        right_from: Result<Option<::std::string::String>, String>,
+        right_until: Result<Option<::std::string::String>, String>,
+    }
+    impl<'a> RenderProfileDiff<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                left_from: Ok(None),
+                left_until: Ok(None),
+                query: Ok(None),
+                right_from: Ok(None),
+                right_until: Ok(None),
+            }
+        }
+        pub fn left_from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.left_from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for left_from failed".to_string()
+            });
+            self
+        }
+        pub fn left_until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.left_until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for left_until failed".to_string()
+            });
+            self
+        }
+        pub fn query<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.query = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for query failed".to_string()
+            });
+            self
+        }
+        pub fn right_from<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.right_from = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for right_from failed".to_string()
+            });
+            self
+        }
+        pub fn right_until<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.right_until = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for right_until failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/pyroscope/render-diff`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::PyroscopeRenderResponse>, Error<()>> {
+            let Self {
+                client,
+                left_from,
+                left_until,
+                query,
+                right_from,
+                right_until,
+            } = self;
+            let left_from = left_from.map_err(Error::InvalidRequest)?;
+            let left_until = left_until.map_err(Error::InvalidRequest)?;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let right_from = right_from.map_err(Error::InvalidRequest)?;
+            let right_until = right_until.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/pyroscope/render-diff", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("leftFrom", &left_from))
+                .query(&progenitor_client::QueryParam::new(
+                    "leftUntil",
+                    &left_until,
+                ))
+                .query(&progenitor_client::QueryParam::new("query", &query))
+                .query(&progenitor_client::QueryParam::new(
+                    "rightFrom",
+                    &right_from,
+                ))
+                .query(&progenitor_client::QueryParam::new(
+                    "rightUntil",
+                    &right_until,
+                ))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "render_profile_diff",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
     /**Builder for [`Client::list_tenants`]
 
     [`Client::list_tenants`]: super::Client::list_tenants*/


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–5 | merged | ✅ |
| 6–12 | #636 #637 #638 #639 #641 #642 #643 | 🔁 in flight |
| 13 | Pyroscope HTTP API | 👀 **← this PR** |
| 14+ | OTLP HTTP, correlation, Grafana, docs | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-12-pyroscope-types`), not main.

## This PR only
Two commits:
- **Endpoints**: `GET /pyroscope/render`, `/render-diff`, `/label-names`, `/label-values`, `/profile-types` — Pyroscope query parsing (`type{service_name="x"}`), time expressions (unix s/ms, `now-1h`), tenant-scoped Flight tickets to the querier, flamebearer-shaped responses. Nested under the same auth + per-tenant query-rate layers as `/tempo`.
- **OpenAPI**: the five paths and their schemas added to `api/admin-api.yaml` (path-level `servers` override since they're served at the router root); `admin-api.json`, `signaldb-api` types, and the `signaldb-sdk` client regenerated via `cargo xtask generate` (check passes).

Closes #359