### PR TITLE
feat(profiles): profile-to-trace correlation

### DIFF
--- a/api/admin-api.json
+++ b/api/admin-api.json
@@ -406,6 +406,45 @@
         ],
         "type": "object"
       },
+      "TraceProfileSummary": {
+        "description": "Summary of a stored profile linked to a trace",
+        "properties": {
+          "durationNano": {
+            "description": "Profile duration in nanoseconds as string",
+            "type": "string"
+          },
+          "profileID": {
+            "description": "Hex-encoded profile ID",
+            "type": "string"
+          },
+          "sampleType": {
+            "type": "string"
+          },
+          "sampleUnit": {
+            "type": "string"
+          },
+          "serviceName": {
+            "type": "string"
+          },
+          "spanID": {
+            "description": "Hex-encoded span ID when the link names a span",
+            "type": "string"
+          },
+          "timeUnixNano": {
+            "description": "Collection time, unix nanoseconds as string",
+            "type": "string"
+          }
+        },
+        "required": [
+          "profileID",
+          "timeUnixNano",
+          "durationNano",
+          "sampleType",
+          "sampleUnit",
+          "serviceName"
+        ],
+        "type": "object"
+      },
       "UpdateTenantRequest": {
         "description": "Request body for updating an existing tenant",
         "properties": {
@@ -436,6 +475,57 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/api/profiles/trace/{trace_id}": {
+      "get": {
+        "operationId": "list_profiles_for_trace",
+        "parameters": [
+          {
+            "description": "Hex-encoded trace ID",
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TraceProfileSummary"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Profiles linked to the trace"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid trace ID"
+          }
+        },
+        "summary": "List summaries of profiles linked to a trace",
+        "tags": [
+          "profiles"
+        ]
+      },
+      "servers": [
+        {
+          "description": "Served at the router root, not under the admin prefix",
+          "url": "/"
+        }
+      ]
+    },
     "/pyroscope/label-names": {
       "get": {
         "operationId": "list_profile_label_names",

--- a/api/admin-api.yaml
+++ b/api/admin-api.yaml
@@ -438,6 +438,36 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/PyroscopeProfileType"
+  /api/profiles/trace/{trace_id}:
+    servers:
+      - url: /
+        description: Served at the router root, not under the admin prefix
+    get:
+      operationId: list_profiles_for_trace
+      summary: List summaries of profiles linked to a trace
+      tags: [profiles]
+      parameters:
+        - name: trace_id
+          in: path
+          required: true
+          description: Hex-encoded trace ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Profiles linked to the trace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TraceProfileSummary"
+        "400":
+          description: Invalid trace ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
 components:
   securitySchemes:
     bearerAuth:
@@ -754,3 +784,33 @@ components:
           type: array
           items:
             type: string
+
+    TraceProfileSummary:
+      type: object
+      description: Summary of a stored profile linked to a trace
+      required:
+        - profileID
+        - timeUnixNano
+        - durationNano
+        - sampleType
+        - sampleUnit
+        - serviceName
+      properties:
+        profileID:
+          type: string
+          description: Hex-encoded profile ID
+        timeUnixNano:
+          type: string
+          description: Collection time, unix nanoseconds as string
+        durationNano:
+          type: string
+          description: Profile duration in nanoseconds as string
+        sampleType:
+          type: string
+        sampleUnit:
+          type: string
+        serviceName:
+          type: string
+        spanID:
+          type: string
+          description: Hex-encoded span ID when the link names a span

--- a/src/common/src/model/trace.rs
+++ b/src/common/src/model/trace.rs
@@ -26,6 +26,7 @@ impl From<Trace> for tempo_api::Trace {
             start_time_unix_nano: root_span.start_time_unix_nano.to_string(),
             duration_ms,
             span_sets: vec![],
+            profiles: None,
         }
     }
 }

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -204,6 +204,12 @@ enum TicketRequest {
         dataset_slug: String,
         sql: String,
     },
+    ProfilesByTrace {
+        tenant_slug: String,
+        dataset_slug: String,
+        trace_id: String,
+        span_id: Option<String>,
+    },
 }
 
 /// Flight service for query execution against stored data
@@ -619,6 +625,24 @@ impl QuerierFlightService {
             ));
         }
 
+        if let Some(remainder) = ticket_content.strip_prefix("profiles_by_trace:") {
+            let parts: Vec<&str> = remainder.splitn(4, ':').collect();
+            if parts.len() >= 3 {
+                return Ok(TicketRequest::ProfilesByTrace {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    trace_id: parts[2].to_string(),
+                    span_id: parts
+                        .get(3)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string()),
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid profiles_by_trace ticket format. Expected: profiles_by_trace:tenant_slug:dataset_slug:trace_id[:span_id]",
+            ));
+        }
+
         if let Some(remainder) = ticket_content.strip_prefix("sql_profiles:") {
             let parts: Vec<&str> = remainder.splitn(3, ':').collect();
             if parts.len() == 3 {
@@ -935,7 +959,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileLabelValues { tenant_slug, .. }
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
                     | TicketRequest::ProfileDiff { tenant_slug, .. }
-                    | TicketRequest::SqlProfiles { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::SqlProfiles { tenant_slug, .. }
+                    | TicketRequest::ProfilesByTrace { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -962,6 +987,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::ProfileFlamegraph { .. } => "profile_flamegraph",
                 TicketRequest::ProfileDiff { .. } => "profile_diff",
                 TicketRequest::SqlProfiles { .. } => "sql_profiles",
+                TicketRequest::ProfilesByTrace { .. } => "profiles_by_trace",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -982,7 +1008,10 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileLabelValues { tenant_slug, .. }
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
                     | TicketRequest::ProfileDiff { tenant_slug, .. }
-                    | TicketRequest::SqlProfiles { tenant_slug, .. } => Some(tenant_slug.clone()),
+                    | TicketRequest::SqlProfiles { tenant_slug, .. }
+                    | TicketRequest::ProfilesByTrace { tenant_slug, .. } => {
+                        Some(tenant_slug.clone())
+                    }
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1208,6 +1237,29 @@ impl FlightService for QuerierFlightService {
                             .await
                             .map_err(querier_error_to_status)?;
                         vec![json_to_batch("diff", &diff)?]
+                    }
+                    TicketRequest::ProfilesByTrace {
+                        tenant_slug,
+                        dataset_slug,
+                        trace_id,
+                        span_id,
+                    } => {
+                        tracing::info!(
+                            tenant_slug = %tenant_slug,
+                            dataset_slug = %dataset_slug,
+                            trace_id = %trace_id,
+                            span_id = ?span_id,
+                            "Executing profiles_by_trace"
+                        );
+                        self.profile_service
+                            .find_by_trace_with_tenant(
+                                &trace_id,
+                                span_id.as_deref(),
+                                &tenant_slug,
+                                &dataset_slug,
+                            )
+                            .await
+                            .map_err(querier_error_to_status)?
                     }
                     TicketRequest::SqlProfiles {
                         tenant_slug,

--- a/src/querier/src/query/profile.rs
+++ b/src/querier/src/query/profile.rs
@@ -386,6 +386,60 @@ impl ProfileService {
 }
 
 impl ProfileService {
+    /// Find profile summaries linked to a trace (and optionally a span).
+    /// Returns the same summary columns as search, newest first.
+    pub async fn find_by_trace_with_tenant(
+        &self,
+        trace_id: &str,
+        span_id: Option<&str>,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        if trace_id.is_empty() || !trace_id.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(QuerierError::InvalidInput(format!(
+                "trace_id must be a hex string, got '{trace_id}'"
+            )));
+        }
+        if let Some(span_id) = span_id
+            && (span_id.is_empty() || !span_id.chars().all(|c| c.is_ascii_hexdigit()))
+        {
+            return Err(QuerierError::InvalidInput(format!(
+                "span_id must be a hex string, got '{span_id}'"
+            )));
+        }
+
+        let mut df = self
+            .profiles_table(tenant_slug, dataset_slug)
+            .await?
+            .filter(col("trace_id").eq(lit(trace_id)))
+            .map_err(QuerierError::QueryFailed)?;
+        if let Some(span_id) = span_id {
+            df = df
+                .filter(col("span_id").eq(lit(span_id)))
+                .map_err(QuerierError::QueryFailed)?;
+        }
+
+        let df = df
+            .select_columns(&[
+                "profile_id",
+                "timestamp",
+                "duration_nano",
+                "sample_type",
+                "sample_unit",
+                "period",
+                "service_name",
+                "trace_id",
+                "span_id",
+            ])
+            .map_err(QuerierError::QueryFailed)?
+            .sort(vec![col("timestamp").sort(false, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(self.max_search_limit))
+            .map_err(QuerierError::QueryFailed)?;
+
+        df.collect().await.map_err(QuerierError::QueryFailed)
+    }
+
     /// Fetch full profile rows matching the search selection and decode
     /// them into model profiles for aggregation.
     async fn fetch_models(

--- a/src/router/src/endpoints/pyroscope.rs
+++ b/src/router/src/endpoints/pyroscope.rs
@@ -38,6 +38,11 @@ pub fn router<S: RouterState>() -> Router<S> {
         .route("/profile-types", get(profile_types::<S>))
 }
 
+/// Routes for trace-to-profile correlation, nested at `/api/profiles`.
+pub fn profiles_router<S: RouterState>() -> Router<S> {
+    Router::new().route("/trace/{trace_id}", get(profiles_by_trace::<S>))
+}
+
 /// Query parameters for `/render` and `/render-diff`.
 #[derive(Debug, Default, Deserialize)]
 pub struct RenderParams {
@@ -425,6 +430,107 @@ pub async fn profile_types<S: RouterState>(
         })
         .collect();
     Ok(axum::Json(types))
+}
+
+/// Decode profile summary batches (the querier's search/by-trace column
+/// set) into API summaries.
+pub(crate) fn batches_to_profile_summaries(
+    batches: &[RecordBatch],
+) -> Vec<tempo_api::ProfileSummary> {
+    use datafusion::arrow::array::{Int64Array, TimestampNanosecondArray};
+
+    let mut summaries = Vec::new();
+    for batch in batches {
+        let get_string = |name: &str| {
+            batch
+                .column_by_name(name)
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+        };
+        let Some(profile_ids) = get_string("profile_id") else {
+            continue;
+        };
+        let timestamps = batch
+            .column_by_name("timestamp")
+            .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>());
+        let durations = batch
+            .column_by_name("duration_nano")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+        let sample_types = get_string("sample_type");
+        let sample_units = get_string("sample_unit");
+        let service_names = get_string("service_name");
+        let span_ids = get_string("span_id");
+
+        let value = |col: Option<&StringArray>, i: usize| -> String {
+            col.map(|c| {
+                if c.is_null(i) {
+                    String::new()
+                } else {
+                    c.value(i).to_string()
+                }
+            })
+            .unwrap_or_default()
+        };
+
+        for i in 0..batch.num_rows() {
+            summaries.push(tempo_api::ProfileSummary {
+                profile_id: value(Some(profile_ids), i),
+                time_unix_nano: timestamps
+                    .map(|t| if t.is_null(i) { 0 } else { t.value(i) })
+                    .unwrap_or(0)
+                    .to_string(),
+                duration_nano: durations
+                    .map(|d| if d.is_null(i) { 0 } else { d.value(i) })
+                    .unwrap_or(0)
+                    .to_string(),
+                sample_type: value(sample_types, i),
+                sample_unit: value(sample_units, i),
+                service_name: value(service_names, i),
+                span_id: span_ids.and_then(|c| {
+                    if c.is_null(i) || c.value(i).is_empty() {
+                        None
+                    } else {
+                        Some(c.value(i).to_string())
+                    }
+                }),
+            });
+        }
+    }
+    summaries
+}
+
+/// Fetch summaries of profiles linked to a trace via the querier.
+pub(crate) async fn fetch_profiles_for_trace<S: RouterState>(
+    state: &S,
+    tenant_slug: &str,
+    dataset_slug: &str,
+    trace_id: &str,
+) -> Result<Vec<tempo_api::ProfileSummary>, StatusCode> {
+    let ticket = format!("profiles_by_trace:{tenant_slug}:{dataset_slug}:{trace_id}");
+    let batches = execute_ticket(state, ticket).await?;
+    Ok(batches_to_profile_summaries(&batches))
+}
+
+/// GET /api/profiles/trace/{trace_id} — profiles linked to a trace.
+#[tracing::instrument(
+    skip(state, tenant_ctx),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn profiles_by_trace<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    axum::extract::Path(trace_id): axum::extract::Path<String>,
+) -> Result<axum::Json<Vec<tempo_api::ProfileSummary>>, StatusCode> {
+    let summaries = fetch_profiles_for_trace(
+        &state,
+        &tenant_ctx.0.tenant_slug,
+        &tenant_ctx.0.dataset_slug,
+        &trace_id,
+    )
+    .await?;
+    Ok(axum::Json(summaries))
 }
 
 #[cfg(test)]

--- a/src/router/src/endpoints/tempo.rs
+++ b/src/router/src/endpoints/tempo.rs
@@ -353,6 +353,7 @@ fn internal_trace_to_tempo(
         start_time_unix_nano: earliest_start.to_string(),
         duration_ms,
         span_sets: vec![span_set],
+        profiles: None,
     }
 }
 
@@ -615,8 +616,29 @@ pub async fn query_single_trace<S: RouterState>(
 
             // Convert flight data to trace format
             match flight_data_to_tempo_trace(trace_data, &trace_id) {
-                Ok(Some(trace)) => {
+                Ok(Some(mut trace)) => {
                     tracing::info!(trace_id = %trace_id, "Successfully converted trace to Tempo format");
+                    // Optionally attach linked profile summaries. A failed
+                    // profile lookup must not fail the trace response.
+                    if params.include_profiles.unwrap_or(false) {
+                        match super::pyroscope::fetch_profiles_for_trace(
+                            &state.0,
+                            &tenant_ctx.0.tenant_slug,
+                            &tenant_ctx.0.dataset_slug,
+                            &trace_id,
+                        )
+                        .await
+                        {
+                            Ok(profiles) => trace.profiles = Some(profiles),
+                            Err(status) => {
+                                tracing::warn!(
+                                    trace_id = %trace_id,
+                                    status = ?status,
+                                    "Failed to fetch linked profiles for trace"
+                                );
+                            }
+                        }
+                    }
                     return Ok(axum::Json(trace));
                 }
                 Ok(None) => {

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -208,6 +208,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Trace-to-profile correlation
+        .nest(
+            "/api/profiles",
+            endpoints::pyroscope::profiles_router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Admin routes with admin authentication
         .nest("/api/v1/admin", admin_router)
         .nest(

--- a/src/signaldb-api/src/generated.rs
+++ b/src/signaldb-api/src/generated.rs
@@ -742,6 +742,77 @@ pub struct TenantResponse {
     ///ISO 8601 last-updated timestamp
     pub updated_at: ::std::string::String,
 }
+///Summary of a stored profile linked to a trace
+///
+/// <details><summary>JSON schema</summary>
+///
+/// ```json
+///{
+///  "description": "Summary of a stored profile linked to a trace",
+///  "type": "object",
+///  "required": [
+///    "durationNano",
+///    "profileID",
+///    "sampleType",
+///    "sampleUnit",
+///    "serviceName",
+///    "timeUnixNano"
+///  ],
+///  "properties": {
+///    "durationNano": {
+///      "description": "Profile duration in nanoseconds as string",
+///      "type": "string"
+///    },
+///    "profileID": {
+///      "description": "Hex-encoded profile ID",
+///      "type": "string"
+///    },
+///    "sampleType": {
+///      "type": "string"
+///    },
+///    "sampleUnit": {
+///      "type": "string"
+///    },
+///    "serviceName": {
+///      "type": "string"
+///    },
+///    "spanID": {
+///      "description": "Hex-encoded span ID when the link names a span",
+///      "type": "string"
+///    },
+///    "timeUnixNano": {
+///      "description": "Collection time, unix nanoseconds as string",
+///      "type": "string"
+///    }
+///  }
+///}
+/// ```
+/// </details>
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct TraceProfileSummary {
+    ///Profile duration in nanoseconds as string
+    #[serde(rename = "durationNano")]
+    pub duration_nano: ::std::string::String,
+    ///Hex-encoded profile ID
+    #[serde(rename = "profileID")]
+    pub profile_id: ::std::string::String,
+    #[serde(rename = "sampleType")]
+    pub sample_type: ::std::string::String,
+    #[serde(rename = "sampleUnit")]
+    pub sample_unit: ::std::string::String,
+    #[serde(rename = "serviceName")]
+    pub service_name: ::std::string::String,
+    ///Hex-encoded span ID when the link names a span
+    #[serde(
+        rename = "spanID",
+        default,
+        skip_serializing_if = "::std::option::Option::is_none"
+    )]
+    pub span_id: ::std::option::Option<::std::string::String>,
+    ///Collection time, unix nanoseconds as string
+    #[serde(rename = "timeUnixNano")]
+    pub time_unix_nano: ::std::string::String,
+}
 ///Request body for updating an existing tenant
 ///
 /// <details><summary>JSON schema</summary>

--- a/src/signaldb-sdk/src/generated.rs
+++ b/src/signaldb-sdk/src/generated.rs
@@ -834,6 +834,82 @@ pub mod types {
             Default::default()
         }
     }
+    ///Summary of a stored profile linked to a trace
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Summary of a stored profile linked to a trace",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "durationNano",
+    ///    "profileID",
+    ///    "sampleType",
+    ///    "sampleUnit",
+    ///    "serviceName",
+    ///    "timeUnixNano"
+    ///  ],
+    ///  "properties": {
+    ///    "durationNano": {
+    ///      "description": "Profile duration in nanoseconds as string",
+    ///      "type": "string"
+    ///    },
+    ///    "profileID": {
+    ///      "description": "Hex-encoded profile ID",
+    ///      "type": "string"
+    ///    },
+    ///    "sampleType": {
+    ///      "type": "string"
+    ///    },
+    ///    "sampleUnit": {
+    ///      "type": "string"
+    ///    },
+    ///    "serviceName": {
+    ///      "type": "string"
+    ///    },
+    ///    "spanID": {
+    ///      "description": "Hex-encoded span ID when the link names a span",
+    ///      "type": "string"
+    ///    },
+    ///    "timeUnixNano": {
+    ///      "description": "Collection time, unix nanoseconds as string",
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct TraceProfileSummary {
+        ///Profile duration in nanoseconds as string
+        #[serde(rename = "durationNano")]
+        pub duration_nano: ::std::string::String,
+        ///Hex-encoded profile ID
+        #[serde(rename = "profileID")]
+        pub profile_id: ::std::string::String,
+        #[serde(rename = "sampleType")]
+        pub sample_type: ::std::string::String,
+        #[serde(rename = "sampleUnit")]
+        pub sample_unit: ::std::string::String,
+        #[serde(rename = "serviceName")]
+        pub service_name: ::std::string::String,
+        ///Hex-encoded span ID when the link names a span
+        #[serde(
+            rename = "spanID",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub span_id: ::std::option::Option<::std::string::String>,
+        ///Collection time, unix nanoseconds as string
+        #[serde(rename = "timeUnixNano")]
+        pub time_unix_nano: ::std::string::String,
+    }
+    impl TraceProfileSummary {
+        pub fn builder() -> builder::TraceProfileSummary {
+            Default::default()
+        }
+    }
     ///Request body for updating an existing tenant
     ///
     /// <details><summary>JSON schema</summary>
@@ -2093,6 +2169,133 @@ pub mod types {
             }
         }
         #[derive(Clone, Debug)]
+        pub struct TraceProfileSummary {
+            duration_nano: ::std::result::Result<::std::string::String, ::std::string::String>,
+            profile_id: ::std::result::Result<::std::string::String, ::std::string::String>,
+            sample_type: ::std::result::Result<::std::string::String, ::std::string::String>,
+            sample_unit: ::std::result::Result<::std::string::String, ::std::string::String>,
+            service_name: ::std::result::Result<::std::string::String, ::std::string::String>,
+            span_id: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+            time_unix_nano: ::std::result::Result<::std::string::String, ::std::string::String>,
+        }
+        impl ::std::default::Default for TraceProfileSummary {
+            fn default() -> Self {
+                Self {
+                    duration_nano: Err("no value supplied for duration_nano".to_string()),
+                    profile_id: Err("no value supplied for profile_id".to_string()),
+                    sample_type: Err("no value supplied for sample_type".to_string()),
+                    sample_unit: Err("no value supplied for sample_unit".to_string()),
+                    service_name: Err("no value supplied for service_name".to_string()),
+                    span_id: Ok(Default::default()),
+                    time_unix_nano: Err("no value supplied for time_unix_nano".to_string()),
+                }
+            }
+        }
+        impl TraceProfileSummary {
+            pub fn duration_nano<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.duration_nano = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for duration_nano: {e}"));
+                self
+            }
+            pub fn profile_id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.profile_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for profile_id: {e}"));
+                self
+            }
+            pub fn sample_type<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sample_type = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sample_type: {e}"));
+                self
+            }
+            pub fn sample_unit<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sample_unit = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sample_unit: {e}"));
+                self
+            }
+            pub fn service_name<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.service_name = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for service_name: {e}"));
+                self
+            }
+            pub fn span_id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.span_id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for span_id: {e}"));
+                self
+            }
+            pub fn time_unix_nano<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::string::String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.time_unix_nano = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for time_unix_nano: {e}")
+                });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<TraceProfileSummary> for super::TraceProfileSummary {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: TraceProfileSummary,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    duration_nano: value.duration_nano?,
+                    profile_id: value.profile_id?,
+                    sample_type: value.sample_type?,
+                    sample_unit: value.sample_unit?,
+                    service_name: value.service_name?,
+                    span_id: value.span_id?,
+                    time_unix_nano: value.time_unix_nano?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::TraceProfileSummary> for TraceProfileSummary {
+            fn from(value: super::TraceProfileSummary) -> Self {
+                Self {
+                    duration_nano: Ok(value.duration_nano),
+                    profile_id: Ok(value.profile_id),
+                    sample_type: Ok(value.sample_type),
+                    sample_unit: Ok(value.sample_unit),
+                    service_name: Ok(value.service_name),
+                    span_id: Ok(value.span_id),
+                    time_unix_nano: Ok(value.time_unix_nano),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
         pub struct UpdateTenantRequest {
             default_dataset: ::std::result::Result<
                 ::std::option::Option<::std::string::String>,
@@ -2211,6 +2414,21 @@ impl ClientInfo<()> for Client {
 }
 impl ClientHooks<()> for &Client {}
 impl Client {
+    /**List summaries of profiles linked to a trace
+
+    Sends a `GET` request to `/api/profiles/trace/{trace_id}`
+
+    Arguments:
+    - `trace_id`: Hex-encoded trace ID
+    ```ignore
+    let response = client.list_profiles_for_trace()
+        .trace_id(trace_id)
+        .send()
+        .await;
+    ```*/
+    pub fn list_profiles_for_trace(&self) -> builder::ListProfilesForTrace<'_> {
+        builder::ListProfilesForTrace::new(self)
+    }
     /**List label names present on stored profiles
 
     Sends a `GET` request to `/pyroscope/label-names`
@@ -2476,6 +2694,75 @@ pub mod builder {
         ByteStream, ClientHooks, ClientInfo, Error, OperationInfo, RequestBuilderExt,
         ResponseValue, encode_path,
     };
+    /**Builder for [`Client::list_profiles_for_trace`]
+
+    [`Client::list_profiles_for_trace`]: super::Client::list_profiles_for_trace*/
+    #[derive(Debug, Clone)]
+    pub struct ListProfilesForTrace<'a> {
+        client: &'a super::Client,
+        trace_id: Result<::std::string::String, String>,
+    }
+    impl<'a> ListProfilesForTrace<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                trace_id: Err("trace_id was not initialized".to_string()),
+            }
+        }
+        pub fn trace_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.trace_id = value.try_into().map_err(|_| {
+                "conversion to `:: std :: string :: String` for trace_id failed".to_string()
+            });
+            self
+        }
+        ///Sends a `GET` request to `/api/profiles/trace/{trace_id}`
+        pub async fn send(
+            self,
+        ) -> Result<
+            ResponseValue<::std::vec::Vec<types::TraceProfileSummary>>,
+            Error<types::ApiError>,
+        > {
+            let Self { client, trace_id } = self;
+            let trace_id = trace_id.map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/api/profiles/trace/{}",
+                client.baseurl,
+                encode_path(&trace_id.to_string()),
+            );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "list_profiles_for_trace",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
     /**Builder for [`Client::list_profile_label_names`]
 
     [`Client::list_profile_label_names`]: super::Client::list_profile_label_names*/

--- a/src/tempo-api/src/lib.rs
+++ b/src/tempo-api/src/lib.rs
@@ -35,6 +35,9 @@ pub mod v2;
 pub struct TraceQueryParams {
     pub start: Option<i64>,
     pub end: Option<i64>,
+    /// When true, attach summaries of profiles linked to this trace.
+    #[serde(default)]
+    pub include_profiles: Option<bool>,
 }
 
 /// Parameters for TraceQL metrics queries
@@ -154,6 +157,30 @@ pub struct Trace {
     pub duration_ms: u64,
     #[serde(rename = "spanSets")]
     pub span_sets: Vec<SpanSet>,
+    /// Summaries of profiles linked to this trace; present only when the
+    /// client asked for them via `include_profiles`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profiles: Option<Vec<ProfileSummary>>,
+}
+
+/// Summary of a stored profile linked to a trace, without the bulky
+/// stack/sample payloads.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ProfileSummary {
+    #[serde(rename = "profileID")]
+    pub profile_id: String,
+    #[serde(rename = "timeUnixNano")]
+    pub time_unix_nano: String,
+    #[serde(rename = "durationNano")]
+    pub duration_nano: String,
+    #[serde(rename = "sampleType")]
+    pub sample_type: String,
+    #[serde(rename = "sampleUnit")]
+    pub sample_unit: String,
+    #[serde(rename = "serviceName")]
+    pub service_name: String,
+    #[serde(rename = "spanID", default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -261,6 +288,7 @@ mod tests {
                 }],
                 matched: 1,
             }],
+            profiles: None,
         }];
 
         let metrics = vec![("error".to_string(), 1)].into_iter().collect();
@@ -294,6 +322,7 @@ mod tests {
                 }],
                 matched: 1,
             }],
+            profiles: None,
         };
 
         assert_eq!(trace.trace_id, "2f3e0cee77ae5dc9c17ade3689eb2e54");


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–5 | merged | ✅ |
| 6–13 | #636 #637 #638 #639 #641 #642 #643 #644 | 🔁 in flight |
| 15 | profile ↔ trace correlation | 👀 **← this PR** |
| 16–17 | Grafana plugin, docs | 🔲 upcoming |

> Diff this PR against its base (`feat/profiles-13-pyroscope-api`), not main. (#360 needed no code — the acceptor HTTP endpoint from #636 covers it; #636's description now closes it.)

## This PR only
- **Querier**: `profiles_by_trace:{t}:{d}:{trace_id}[:{span_id}]` ticket — hex-validated, summary columns, newest first, capped by the search limit.
- **Router**: `GET /api/profiles/trace/{trace_id}` returns linked profile summaries; `include_profiles=true` on the Tempo single-trace endpoint attaches them to the trace response (best-effort — profile lookup failures degrade to the plain trace, never a 5xx).
- **tempo-api**: `Trace.profiles: Option<Vec<ProfileSummary>>` (omitted when absent, so existing clients see byte-identical responses) and the `ProfileSummary` type.
- **OpenAPI**: new path + `TraceProfileSummary` schema; spec JSON, api types, and SDK regenerated.

Closes #362
Closes #363