### PR TITLE
feat(grafana): profiles support in the datasource plugin

### DIFF
--- a/src/grafana-plugin/backend/Cargo.lock
+++ b/src/grafana-plugin/backend/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "futures",
  "grafana-plugin-sdk",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tonic",

--- a/src/grafana-plugin/backend/Cargo.toml
+++ b/src/grafana-plugin/backend/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3.31"
 
 # Serialization
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.145"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Error handling

--- a/src/grafana-plugin/backend/src/conversion.rs
+++ b/src/grafana-plugin/backend/src/conversion.rs
@@ -8,7 +8,7 @@ use arrow::array::{
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use grafana_plugin_sdk::data::{self, Field};
-use grafana_plugin_sdk::prelude::{IntoField, IntoOptField};
+use grafana_plugin_sdk::prelude::{IntoField, IntoFrame, IntoOptField};
 
 /// Error type for conversion operations.
 #[derive(Debug, thiserror::Error)]
@@ -691,5 +691,161 @@ mod tests {
         } else {
             panic!("Expected TypeMismatch error");
         }
+    }
+}
+
+/// One decoded flamebearer block with absolute offsets.
+#[derive(Debug, Clone)]
+struct FlameBlock {
+    start: i64,
+    total: i64,
+    self_value: i64,
+    name_index: usize,
+}
+
+/// Decode one flamebearer level (flat `[offset_delta, total, self,
+/// name_index]` quadruples with offsets delta-encoded against the previous
+/// block's end) into blocks with absolute start offsets.
+fn decode_level(level: &[i64]) -> Vec<FlameBlock> {
+    let mut blocks = Vec::with_capacity(level.len() / 4);
+    let mut cursor = 0i64;
+    for chunk in level.chunks_exact(4) {
+        let start = cursor + chunk[0];
+        blocks.push(FlameBlock {
+            start,
+            total: chunk[1],
+            self_value: chunk[2],
+            name_index: chunk[3] as usize,
+        });
+        cursor = start + chunk[1];
+    }
+    blocks
+}
+
+/// Convert a Pyroscope flamebearer (name table + delta-encoded levels)
+/// into the nested-set data frame Grafana's flamegraph panel expects:
+/// depth-first ordered rows with `level`, `value`, `self`, and `label`
+/// fields.
+pub fn flamebearer_to_nested_set_frame(
+    names: &[String],
+    levels: &[Vec<i64>],
+    frame_name: &str,
+) -> data::Frame {
+    let (out_levels, out_values, out_selfs, out_labels) = flamebearer_to_nested_set(names, levels);
+    [
+        out_levels.into_field("level"),
+        out_values.into_field("value"),
+        out_selfs.into_field("self"),
+        out_labels.into_field("label"),
+    ]
+    .into_frame(frame_name)
+}
+
+/// Depth-first traversal of the flamebearer levels producing parallel
+/// `(level, value, self, label)` columns.
+fn flamebearer_to_nested_set(
+    names: &[String],
+    levels: &[Vec<i64>],
+) -> (Vec<i64>, Vec<i64>, Vec<i64>, Vec<String>) {
+    let decoded: Vec<Vec<FlameBlock>> = levels.iter().map(|l| decode_level(l)).collect();
+
+    let mut out_levels: Vec<i64> = Vec::new();
+    let mut out_values: Vec<i64> = Vec::new();
+    let mut out_selfs: Vec<i64> = Vec::new();
+    let mut out_labels: Vec<String> = Vec::new();
+
+    // Depth-first traversal: children of a block at level N are the level
+    // N+1 blocks whose extent falls inside the parent's extent.
+    #[allow(clippy::too_many_arguments)]
+    fn visit(
+        decoded: &[Vec<FlameBlock>],
+        names: &[String],
+        depth: usize,
+        block: &FlameBlock,
+        out_levels: &mut Vec<i64>,
+        out_values: &mut Vec<i64>,
+        out_selfs: &mut Vec<i64>,
+        out_labels: &mut Vec<String>,
+    ) {
+        out_levels.push(depth as i64);
+        out_values.push(block.total);
+        out_selfs.push(block.self_value);
+        out_labels.push(
+            names
+                .get(block.name_index)
+                .cloned()
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        );
+
+        if let Some(children) = decoded.get(depth + 1) {
+            let end = block.start + block.total;
+            for child in children
+                .iter()
+                .filter(|c| c.start >= block.start && c.start + c.total <= end)
+            {
+                visit(
+                    decoded,
+                    names,
+                    depth + 1,
+                    child,
+                    out_levels,
+                    out_values,
+                    out_selfs,
+                    out_labels,
+                );
+            }
+        }
+    }
+
+    if let Some(roots) = decoded.first() {
+        for root in roots {
+            visit(
+                &decoded,
+                names,
+                0,
+                root,
+                &mut out_levels,
+                &mut out_values,
+                &mut out_selfs,
+                &mut out_labels,
+            );
+        }
+    }
+
+    (out_levels, out_values, out_selfs, out_labels)
+}
+
+#[cfg(test)]
+mod flamegraph_tests {
+    use super::*;
+
+    #[test]
+    fn converts_flamebearer_to_depth_first_nested_set() {
+        // total(175) -> main(150) -> [work(100), idle(50)]; other_root(25).
+        let names: Vec<String> = ["total", "main", "other_root", "work", "idle"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let levels = vec![
+            vec![0, 175, 0, 0],
+            vec![0, 150, 0, 1, 0, 25, 25, 2],
+            vec![0, 100, 100, 3, 0, 50, 50, 4],
+        ];
+
+        let (out_levels, out_values, out_selfs, out_labels) =
+            flamebearer_to_nested_set(&names, &levels);
+
+        // Depth-first: total, main, work, idle, other_root.
+        assert_eq!(
+            out_labels,
+            vec!["total", "main", "work", "idle", "other_root"]
+        );
+        assert_eq!(out_levels, vec![0, 1, 2, 2, 1]);
+        assert_eq!(out_values, vec![175, 150, 100, 50, 25]);
+        assert_eq!(out_selfs, vec![0, 0, 100, 50, 25]);
+
+        // Frame construction succeeds and validates.
+        let frame = flamebearer_to_nested_set_frame(&names, &levels, "profiles");
+        assert!(frame.check().is_ok());
     }
 }

--- a/src/grafana-plugin/backend/src/main.rs
+++ b/src/grafana-plugin/backend/src/main.rs
@@ -218,8 +218,9 @@ impl SignalDBDataSource {
             "traces" => self.query_traces(query, auth).await,
             "metrics" => self.query_metrics(query, auth).await,
             "logs" => self.query_logs(query, auth).await,
+            "profiles" => self.query_profiles(query, auth).await,
             _ => Err(anyhow::anyhow!(
-                "Unknown signal type '{}'. Supported types: traces, metrics, logs",
+                "Unknown signal type '{}'. Supported types: traces, metrics, logs, profiles",
                 query.signal_type
             )),
         }
@@ -322,6 +323,103 @@ impl SignalDBDataSource {
 
         Ok(frame)
     }
+}
+
+impl SignalDBDataSource {
+    /// Query profiles via Flight and render them as a flamegraph frame.
+    async fn query_profiles(
+        &self,
+        query: &SignalDBQuery,
+        auth: Option<&AuthContext>,
+    ) -> anyhow::Result<data::Frame> {
+        // Profile tickets are tenant-scoped; the querier verifies the
+        // ticket tenant against the authenticated caller.
+        let (tenant, dataset) = match auth {
+            Some(AuthContext {
+                tenant_id: Some(tenant),
+                dataset_id: Some(dataset),
+                ..
+            }) => (tenant.clone(), dataset.clone()),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Profile queries require tenant and dataset to be configured on the datasource"
+                ));
+            }
+        };
+
+        let (sample_type, service_name) = parse_profile_query(&query.query_text);
+        let params = serde_json::json!({
+            "sample_type": sample_type,
+            "service_name": service_name,
+        });
+        let ticket = format!("profile_flamegraph:{tenant}:{dataset}:{params}");
+
+        tracing::debug!("Executing Flight query with ticket: {ticket}");
+
+        let mut client = self.create_flight_client().await?;
+        let (batches, _schema) = client.query_with_auth(&ticket, auth).await?;
+
+        // The querier returns a single-row, single-column JSON document.
+        use arrow::array::Array;
+        let json = batches
+            .iter()
+            .find_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .filter(|column| column.len() > 0)
+                    .map(|column| column.value(0).to_string())
+            })
+            .ok_or_else(|| anyhow::anyhow!("Profile query returned no flamegraph document"))?;
+
+        #[derive(serde::Deserialize)]
+        struct FlamegraphDoc {
+            names: Vec<String>,
+            levels: Vec<Vec<i64>>,
+        }
+        let flamegraph: FlamegraphDoc = serde_json::from_str(&json)?;
+
+        Ok(conversion::flamebearer_to_nested_set_frame(
+            &flamegraph.names,
+            &flamegraph.levels,
+            "profiles",
+        ))
+    }
+}
+
+/// Parse a Pyroscope-style profile query (`type{service_name="x"}` or a
+/// bare type) into (sample_type, service_name) filters.
+fn parse_profile_query(query_text: &str) -> (Option<String>, Option<String>) {
+    let query_text = query_text.trim();
+    if query_text.is_empty() {
+        return (None, None);
+    }
+    let (id_part, selector_part) = match query_text.split_once('{') {
+        Some((id, rest)) => (id.trim(), rest.strip_suffix('}').unwrap_or(rest)),
+        None => (query_text, ""),
+    };
+    let sample_type = if id_part.is_empty() {
+        None
+    } else {
+        let segments: Vec<&str> = id_part.split(':').collect();
+        Some(
+            segments
+                .get(1)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&segments[0])
+                .to_string(),
+        )
+    };
+    let mut service_name = None;
+    for matcher in selector_part.split(',') {
+        if let Some((key, value)) = matcher.split_once('=')
+            && key.trim() == "service_name"
+        {
+            service_name = Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+    (sample_type, service_name)
 }
 
 /// Create an empty traces frame with expected columns.

--- a/src/grafana-plugin/src/components/QueryEditor.tsx
+++ b/src/grafana-plugin/src/components/QueryEditor.tsx
@@ -10,6 +10,7 @@ const SIGNAL_TYPE_OPTIONS: Array<SelectableValue<SignalType>> = [
   { label: 'Traces', value: SignalType.Traces, description: 'Query trace data using TraceQL' },
   { label: 'Metrics', value: SignalType.Metrics, description: 'Query metrics using PromQL' },
   { label: 'Logs', value: SignalType.Logs, description: 'Query logs using LogQL' },
+  { label: 'Profiles', value: SignalType.Profiles, description: 'Query profiles as a flamegraph' },
 ];
 
 export function QueryEditor({ query, onChange, onRunQuery }: Props) {
@@ -38,6 +39,8 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
         return 'up{job="my-job"}';
       case SignalType.Logs:
         return '{app="my-app"} |= "error"';
+      case SignalType.Profiles:
+        return 'cpu{service_name="my-service"}';
       default:
         return 'Enter your query';
     }
@@ -51,6 +54,8 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
         return 'PromQL Query';
       case SignalType.Logs:
         return 'LogQL Query';
+      case SignalType.Profiles:
+        return 'Profile Query';
       default:
         return 'Query';
     }

--- a/src/grafana-plugin/src/types.ts
+++ b/src/grafana-plugin/src/types.ts
@@ -8,6 +8,7 @@ export enum SignalType {
   Traces = 'traces',
   Metrics = 'metrics',
   Logs = 'logs',
+  Profiles = 'profiles',
 }
 
 /**
@@ -24,6 +25,7 @@ export interface SignalDBQuery extends DataQuery {
    * - For traces: TraceQL query
    * - For metrics: PromQL query or metric name
    * - For logs: LogQL query or search expression
+   * - For profiles: Pyroscope-style selector, e.g. cpu{service_name="checkout"}
    */
   queryText: string;
 


### PR DESCRIPTION
## Stack (Profiles epic #343)
| # | PR | Status |
|---|---|---|
| 1–6 | merged | ✅ |
| 7–15 | #637 #638 #639 #641 #642 #643 #644 #645 | 🔁 in flight |
| 16 | Grafana plugin | 👀 **← this PR** |
| 17 | docs | 🔲 last |

> Diff this PR against its base (`feat/profiles-15-correlation`), not main.

## This PR only
- **Frontend**: `SignalType.Profiles` with a query-editor option, placeholder, and label for Pyroscope-style selectors (`cpu{service_name="my-service"}`).
- **Backend**: `query_profiles` parses the selector, requires tenant/dataset from the datasource config, runs the `profile_flamegraph` Flight ticket, and converts the flamebearer into the depth-first nested-set frame (`level`/`value`/`self`/`label`) the Grafana flamegraph panel consumes. Conversion is unit-tested against a hand-computed flamebearer.

Closes #364