### PR TITLE
feat(loki): add Loki API types crate and router LogQL endpoint skeleton

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -49,7 +49,7 @@ Key details:
 ## Query Path
 
 ```
-HTTP Client (Tempo API)
+HTTP Client (Tempo / Pyroscope / Loki APIs)
     -> Router (:3000 HTTP, :50053 Flight)
     -> Querier via Flight do_get (:50054)
     -> DataFusion SQL against Iceberg tables
@@ -63,6 +63,7 @@ Key details:
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
 4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
+6. Router also nests a Pyroscope-compatible profile API at `/pyroscope` and a Loki-compatible logs API at `/loki` (the latter returns wire-format stubs until LogQL execution lands, epic #366)
 
 ## Service Components
 

--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -19,6 +19,8 @@ sources:
 | **querier** | `src/querier/` | Binary + Library | DataFusion query execution engine |
 | **compactor** | `src/compactor/` | Binary + Library | Complete data lifecycle: compaction planning/execution (Phase 1-2), retention enforcement, snapshot expiration, orphan cleanup (Phase 3); binary is `signaldb-compactor` |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
+| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, dataset management |
@@ -88,6 +90,8 @@ This is the shared foundation. Key modules:
 | `main.rs` | `src/router/src/main.rs` | Standalone router binary |
 | `discovery.rs` | `src/router/src/discovery.rs` | Cached service discovery for the router |
 | `endpoints/tempo.rs` | `src/router/src/endpoints/tempo.rs` | Tempo-compatible API handlers |
+| `endpoints/logql.rs` | `src/router/src/endpoints/logql.rs` | Loki-compatible API handlers under `/loki` (stubs until LogQL execution lands) |
+| `endpoints/pyroscope.rs` | `src/router/src/endpoints/pyroscope.rs` | Pyroscope-compatible profile query handlers |
 | `endpoints/admin.rs` | `src/router/src/endpoints/admin.rs` | Admin API for tenant/key/dataset CRUD |
 | `endpoints/tenant.rs` | `src/router/src/endpoints/tenant.rs` | Tenant self-service API |
 | `endpoints/flight.rs` | `src/router/src/endpoints/flight.rs` | Router Flight service |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loki-api"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,6 +6029,7 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
+ "loki-api",
  "pyroscope-api",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "src/acceptor",
     "src/common",
     "src/compactor",
+    "src/loki-api",
     "src/pyroscope-api",
     "src/querier",
     "src/router",
@@ -28,6 +29,7 @@ default-members = [
     "src/acceptor",
     "src/common",
     "src/compactor",
+    "src/loki-api",
     "src/pyroscope-api",
     "src/querier",
     "src/router",
@@ -52,6 +54,7 @@ common = { path = "src/common" }
 compactor = { path = "src/compactor" }
 signaldb-api = { path = "src/signaldb-api" }
 signaldb-sdk = { path = "src/signaldb-sdk" }
+loki-api = { path = "src/loki-api" }
 pyroscope-api = { path = "src/pyroscope-api" }
 tempo-api = { path = "src/tempo-api" }
 writer = { path = "src/writer" }

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -77,6 +77,8 @@ Parquet storage with DataFusion query processing:
 | **compactor** | `src/compactor/` | Binary + Library | Storage maintenance: compaction, retention (bin `signaldb-compactor`) |
 | **common** | `src/common/` | Library | Shared config, auth, WAL, Flight, catalog, schema |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
+| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI and TUI for tenant, API key, and dataset management |
@@ -182,7 +184,7 @@ flowchart LR
 |----------|-------|
 | **Ports** | HTTP: 3000, Flight: 50053 |
 | **Capability** | `Routing` |
-| **APIs** | Tempo-compatible, Admin API, OpenAPI |
+| **APIs** | Tempo-compatible, Pyroscope-compatible, Loki-compatible (stubs), Admin API, OpenAPI |
 
 **Tempo API Endpoints**:
 
@@ -198,6 +200,27 @@ flowchart LR
 | `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented -- same lookup, v2 response shape |
 | `GET /tempo/api/metrics/query` | 501 Not Implemented (TraceQL metrics) |
 | `GET /tempo/api/metrics/query_range` | 501 Not Implemented (TraceQL metrics) |
+
+**Pyroscope API Endpoints** (profiles, nested at `/pyroscope` plus `/api/profiles`):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /pyroscope/render` | Implemented -- flamegraph via Querier |
+| `GET /pyroscope/render-diff` | Implemented -- differential flamegraph |
+| `GET /pyroscope/label-names`, `/label-values`, `/profile-types` | Implemented -- discovery via Querier |
+| `GET /api/profiles/trace/{trace_id}` | Implemented -- profiles linked to a trace |
+
+**Loki API Endpoints** (logs, nested at `/loki`; wire-format stubs until LogQL
+execution lands, see epic #366):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /loki/api/v1/query` | Stub -- validates params, returns empty streams |
+| `GET /loki/api/v1/query_range` | Stub -- validates params, returns empty streams |
+| `GET /loki/api/v1/labels` | Stub -- returns empty label list |
+| `GET /loki/api/v1/label/{name}/values` | Stub -- returns empty value list |
+| `GET /loki/api/v1/series` | Stub -- returns empty series list |
+| `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/src/loki-api/Cargo.toml
+++ b/src/loki-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "loki-api"
+version = "0.1.0"
+edition = "2024"
+description = "Loki-compatible API types for SignalDB"
+license = "AGPL-3.0"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/src/loki-api/src/lib.rs
+++ b/src/loki-api/src/lib.rs
@@ -1,0 +1,380 @@
+//! # Loki API Types
+//!
+//! Response types for the Loki-compatible HTTP API, mirroring the wire
+//! format Grafana's Loki datasource consumes.
+//!
+//! Query responses wrap a [`QueryData`] whose `resultType` discriminates
+//! between log `streams` (raw log lines keyed by nanosecond timestamps)
+//! and Prometheus-style `matrix`/`vector` results for LogQL metric
+//! queries. Metadata endpoints (`/labels`, `/label/{name}/values`,
+//! `/series`) share the flat `{status, data}` envelope.
+
+use std::collections::HashMap;
+
+use serde::de::{self, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Envelope for `/loki/api/v1/query` and `/loki/api/v1/query_range`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryResponse {
+    /// `"success"` or `"error"`.
+    pub status: String,
+    pub data: QueryData,
+}
+
+impl QueryResponse {
+    /// Successful response carrying the given result payload.
+    pub fn success(result: QueryResult) -> Self {
+        Self {
+            status: "success".to_string(),
+            data: QueryData {
+                result,
+                stats: None,
+            },
+        }
+    }
+}
+
+/// The `data` object of a query response: a typed result plus optional
+/// execution statistics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryData {
+    #[serde(flatten)]
+    pub result: QueryResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats: Option<QueryStatistics>,
+}
+
+/// Query result payload, discriminated by the `resultType` field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "resultType", content = "result", rename_all = "lowercase")]
+pub enum QueryResult {
+    /// Log lines grouped by label set (log queries).
+    Streams(Vec<Stream>),
+    /// Range vectors (metric range queries).
+    Matrix(Vec<MetricSeries>),
+    /// Instant vectors (metric instant queries).
+    Vector(Vec<InstantValue>),
+}
+
+/// One log stream: a unique label set and its entries.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Stream {
+    /// Stream labels, e.g. `{"service_name": "api"}`.
+    pub stream: HashMap<String, String>,
+    /// Entries as `[timestamp, line]` pairs, timestamp in nanoseconds
+    /// rendered as a decimal string (Loki wire format).
+    pub values: Vec<LogEntry>,
+}
+
+/// A single log entry: `["<unix epoch ns>", "<log line>"]`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LogEntry(pub String, pub String);
+
+impl LogEntry {
+    /// Build an entry from a nanosecond timestamp and a log line.
+    pub fn new(timestamp_ns: i64, line: impl Into<String>) -> Self {
+        Self(timestamp_ns.to_string(), line.into())
+    }
+}
+
+/// One series of a `matrix` result.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct MetricSeries {
+    /// Series labels.
+    pub metric: HashMap<String, String>,
+    /// Samples ordered by timestamp.
+    pub values: Vec<Sample>,
+}
+
+/// One entry of a `vector` result.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct InstantValue {
+    /// Series labels.
+    pub metric: HashMap<String, String>,
+    /// The sample at the query's evaluation timestamp.
+    pub value: Sample,
+}
+
+/// A Prometheus-style sample: `[<unix epoch seconds>, "<value>"]`.
+///
+/// The timestamp is a JSON number (integral seconds serialize without a
+/// fractional part, matching Loki), the value a decimal string.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Sample {
+    /// Unix timestamp in seconds; may carry sub-second precision.
+    pub timestamp: f64,
+    /// Sample value rendered as a string, e.g. `"137"`.
+    pub value: String,
+}
+
+impl Sample {
+    pub fn new(timestamp: f64, value: impl Into<String>) -> Self {
+        Self {
+            timestamp,
+            value: value.into(),
+        }
+    }
+}
+
+impl Serialize for Sample {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        // Loki emits whole-second timestamps as integers; only emit a
+        // float when there is actual sub-second precision.
+        if self.timestamp.fract() == 0.0
+            && self.timestamp >= i64::MIN as f64
+            && self.timestamp <= i64::MAX as f64
+        {
+            seq.serialize_element(&(self.timestamp as i64))?;
+        } else {
+            seq.serialize_element(&self.timestamp)?;
+        }
+        seq.serialize_element(&self.value)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Sample {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SampleVisitor;
+
+        impl<'de> Visitor<'de> for SampleVisitor {
+            type Value = Sample;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a [timestamp, value] pair")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Sample, A::Error> {
+                let timestamp: f64 = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let value: String = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                Ok(Sample { timestamp, value })
+            }
+        }
+
+        deserializer.deserialize_seq(SampleVisitor)
+    }
+}
+
+/// Response of `/loki/api/v1/labels` and `/loki/api/v1/label/{name}/values`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LabelsResponse {
+    /// `"success"` or `"error"`.
+    pub status: String,
+    /// Label names (or values), sorted.
+    #[serde(default)]
+    pub data: Vec<String>,
+}
+
+impl LabelsResponse {
+    pub fn success(data: Vec<String>) -> Self {
+        Self {
+            status: "success".to_string(),
+            data,
+        }
+    }
+}
+
+/// Response of `/loki/api/v1/series`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SeriesResponse {
+    /// `"success"` or `"error"`.
+    pub status: String,
+    /// One label set per matching series.
+    #[serde(default)]
+    pub data: Vec<HashMap<String, String>>,
+}
+
+impl SeriesResponse {
+    pub fn success(data: Vec<HashMap<String, String>>) -> Self {
+        Self {
+            status: "success".to_string(),
+            data,
+        }
+    }
+}
+
+/// Query execution statistics (`data.stats`).
+///
+/// SignalDB populates the summary block only; Loki's full statistics
+/// tree (querier, ingester, cache breakdowns) is not modeled.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct QueryStatistics {
+    pub summary: SummaryStats,
+}
+
+/// The `stats.summary` block.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct SummaryStats {
+    pub bytes_processed_per_second: i64,
+    pub lines_processed_per_second: i64,
+    pub total_bytes_processed: i64,
+    pub total_lines_processed: i64,
+    /// Wall-clock execution time in seconds.
+    pub exec_time: f64,
+    /// Time spent queued before execution, in seconds.
+    pub queue_time: f64,
+    pub total_entries_returned: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn streams_response_matches_loki_wire_format() {
+        let response = QueryResponse::success(QueryResult::Streams(vec![Stream {
+            stream: HashMap::from([("service_name".to_string(), "api".to_string())]),
+            values: vec![
+                LogEntry::new(1_569_266_497_240_578_000, "foo"),
+                LogEntry::new(1_569_266_492_548_155_000, "bar"),
+            ],
+        }]));
+
+        let expected = json!({
+            "status": "success",
+            "data": {
+                "resultType": "streams",
+                "result": [
+                    {
+                        "stream": {"service_name": "api"},
+                        "values": [
+                            ["1569266497240578000", "foo"],
+                            ["1569266492548155000", "bar"]
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_eq!(serde_json::to_value(&response).unwrap(), expected);
+    }
+
+    #[test]
+    fn matrix_response_matches_loki_wire_format() {
+        let response = QueryResponse::success(QueryResult::Matrix(vec![MetricSeries {
+            metric: HashMap::from([("level".to_string(), "info".to_string())]),
+            values: vec![
+                Sample::new(1_588_889_221.0, "137"),
+                Sample::new(1_588_889_236.0, "467"),
+            ],
+        }]));
+
+        let expected = json!({
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {
+                        "metric": {"level": "info"},
+                        "values": [[1_588_889_221i64, "137"], [1_588_889_236i64, "467"]]
+                    }
+                ]
+            }
+        });
+        assert_eq!(serde_json::to_value(&response).unwrap(), expected);
+    }
+
+    #[test]
+    fn vector_response_matches_loki_wire_format() {
+        let response = QueryResponse::success(QueryResult::Vector(vec![InstantValue {
+            metric: HashMap::new(),
+            value: Sample::new(1_588_889_221.0, "1"),
+        }]));
+
+        let expected = json!({
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [{"metric": {}, "value": [1_588_889_221i64, "1"]}]
+            }
+        });
+        assert_eq!(serde_json::to_value(&response).unwrap(), expected);
+    }
+
+    #[test]
+    fn sample_preserves_subsecond_precision() {
+        let sample = Sample::new(1_588_889_221.5, "3");
+        assert_eq!(
+            serde_json::to_value(&sample).unwrap(),
+            json!([1_588_889_221.5, "3"])
+        );
+    }
+
+    #[test]
+    fn query_response_round_trips() {
+        let response = QueryResponse::success(QueryResult::Matrix(vec![MetricSeries {
+            metric: HashMap::from([("job".to_string(), "worker".to_string())]),
+            values: vec![Sample::new(1_588_889_221.0, "42")],
+        }]));
+
+        let json = serde_json::to_string(&response).unwrap();
+        let parsed: QueryResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, response);
+    }
+
+    #[test]
+    fn streams_response_round_trips_from_loki_json() {
+        let raw = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "streams",
+                "result": [
+                    {
+                        "stream": {"level": "error"},
+                        "values": [["1569266497240578000", "boom"]]
+                    }
+                ],
+                "stats": {
+                    "summary": {
+                        "bytesProcessedPerSecond": 2048,
+                        "execTime": 0.25,
+                        "totalEntriesReturned": 1
+                    }
+                }
+            }
+        }"#;
+
+        let parsed: QueryResponse = serde_json::from_str(raw).unwrap();
+        let QueryResult::Streams(streams) = &parsed.data.result else {
+            panic!("expected streams result");
+        };
+        assert_eq!(
+            streams[0].values[0],
+            LogEntry::new(1_569_266_497_240_578_000, "boom")
+        );
+        let stats = parsed.data.stats.as_ref().unwrap();
+        assert_eq!(stats.summary.bytes_processed_per_second, 2048);
+        assert_eq!(stats.summary.exec_time, 0.25);
+        assert_eq!(stats.summary.total_entries_returned, 1);
+    }
+
+    #[test]
+    fn labels_response_matches_loki_wire_format() {
+        let response =
+            LabelsResponse::success(vec!["level".to_string(), "service_name".to_string()]);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            json!({"status": "success", "data": ["level", "service_name"]})
+        );
+    }
+
+    #[test]
+    fn series_response_matches_loki_wire_format() {
+        let response = SeriesResponse::success(vec![HashMap::from([(
+            "service_name".to_string(),
+            "api".to_string(),
+        )])]);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            json!({"status": "success", "data": [{"service_name": "api"}]})
+        );
+    }
+}

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 common.workspace = true
 signaldb-api.workspace = true
+loki-api.workspace = true
 pyroscope-api.workspace = true
 tempo-api.workspace = true
 arrow-flight.workspace = true

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -1,0 +1,355 @@
+//! # Loki-Compatible HTTP API (LogQL)
+//!
+//! Query endpoints for the logs signal in the format Grafana's Loki
+//! datasource expects, nested under `/loki`:
+//!
+//! - `GET /api/v1/query` — instant query
+//! - `GET /api/v1/query_range` — range query
+//! - `GET /api/v1/labels` — label name discovery
+//! - `GET /api/v1/label/{name}/values` — label value discovery
+//! - `GET /api/v1/series` — series discovery
+//!
+//! Handlers currently return empty stub responses in the correct wire
+//! format; query execution lands with the LogQL transpiler and querier
+//! log service (#373–#377). The `/api/v1/tail` WebSocket endpoint is
+//! tracked separately (#380).
+
+use crate::RouterState;
+use axum::{
+    Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use common::auth::TenantContextExtractor;
+use loki_api::{LabelsResponse, QueryResponse, QueryResult, SeriesResponse};
+use serde::Deserialize;
+
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new()
+        .route("/api/v1/query", get(query::<S>))
+        .route("/api/v1/query_range", get(query_range::<S>))
+        .route("/api/v1/labels", get(labels::<S>))
+        .route("/api/v1/label/{name}/values", get(label_values::<S>))
+        .route("/api/v1/series", get(series::<S>))
+}
+
+fn default_limit() -> u32 {
+    100
+}
+
+fn default_direction() -> String {
+    "backward".to_string()
+}
+
+/// Query parameters for `/api/v1/query` (instant queries).
+#[derive(Debug, Deserialize)]
+pub struct InstantQueryParams {
+    /// LogQL query string.
+    pub query: Option<String>,
+    /// Evaluation timestamp (unix epoch ns, s, or RFC3339).
+    pub time: Option<String>,
+    /// Maximum number of entries for log queries.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+    /// `forward` or `backward`.
+    #[serde(default = "default_direction")]
+    pub direction: String,
+}
+
+/// Query parameters for `/api/v1/query_range`.
+#[derive(Debug, Deserialize)]
+pub struct RangeQueryParams {
+    /// LogQL query string.
+    pub query: Option<String>,
+    /// Range start (unix epoch ns, s, or RFC3339).
+    pub start: Option<String>,
+    /// Range end (unix epoch ns, s, or RFC3339).
+    pub end: Option<String>,
+    /// Evaluation interval for metric queries (duration or seconds).
+    pub step: Option<String>,
+    /// Maximum number of entries for log queries.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+    /// `forward` or `backward`.
+    #[serde(default = "default_direction")]
+    pub direction: String,
+}
+
+/// Query parameters for the metadata endpoints (`/labels`,
+/// `/label/{name}/values`, `/series`).
+#[derive(Debug, Default, Deserialize)]
+pub struct MetadataParams {
+    /// Range start (unix epoch ns, s, or RFC3339).
+    pub start: Option<String>,
+    /// Range end (unix epoch ns, s, or RFC3339).
+    pub end: Option<String>,
+    /// Stream selector to restrict results, e.g. `{service_name="api"}`.
+    #[serde(rename = "match[]")]
+    pub matcher: Option<String>,
+    /// `query` is accepted as an alias for `match[]` (Grafana sends it
+    /// on the labels/values endpoints).
+    pub query: Option<String>,
+}
+
+/// Reject requests without a `query` parameter, mirroring Loki's
+/// "empty query" error status.
+fn require_query(query: &Option<String>) -> Result<String, StatusCode> {
+    query
+        .as_deref()
+        .map(str::trim)
+        .filter(|q| !q.is_empty())
+        .map(str::to_string)
+        .ok_or(StatusCode::BAD_REQUEST)
+}
+
+/// Validate the `direction` parameter.
+fn validate_direction(direction: &str) -> Result<(), StatusCode> {
+    match direction {
+        "forward" | "backward" => Ok(()),
+        _ => Err(StatusCode::BAD_REQUEST),
+    }
+}
+
+/// GET /loki/api/v1/query — instant query.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn query<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<InstantQueryParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let logql = require_query(&params.query)?;
+    validate_direction(&params.direction)?;
+    tracing::debug!(query = %logql, "LogQL instant query (stub)");
+
+    // Instant queries over log selectors return streams; execution is
+    // wired up in #376. Until then, answer with an empty stream set.
+    Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
+        vec![],
+    ))))
+}
+
+/// GET /loki/api/v1/query_range — range query.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn query_range<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RangeQueryParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let logql = require_query(&params.query)?;
+    validate_direction(&params.direction)?;
+    tracing::debug!(query = %logql, "LogQL range query (stub)");
+
+    Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
+        vec![],
+    ))))
+}
+
+/// GET /loki/api/v1/labels — list label names.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn labels<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    Ok(axum::Json(LabelsResponse::success(vec![])))
+}
+
+/// GET /loki/api/v1/label/{name}/values — list values of one label.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id,
+        label = %name
+    )
+)]
+pub async fn label_values<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Path(name): Path<String>,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    if name.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(axum::Json(LabelsResponse::success(vec![])))
+}
+
+/// GET /loki/api/v1/series — list series matching a selector.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn series<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<SeriesResponse>, StatusCode> {
+    Ok(axum::Json(SeriesResponse::success(vec![])))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{InMemoryStateImpl, create_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use common::catalog::Catalog;
+    use common::config::{ApiKeyConfig, Configuration, TenantConfig};
+    use tower::ServiceExt;
+
+    fn test_config() -> Configuration {
+        let mut config = Configuration::default();
+        config.auth = common::config::AuthConfig {
+            tenants: vec![TenantConfig {
+                id: "acme".to_string(),
+                slug: "acme".to_string(),
+                name: "Acme".to_string(),
+                default_dataset: Some("default".to_string()),
+                datasets: vec![],
+                api_keys: vec![ApiKeyConfig {
+                    key: "sk-test-key".to_string(),
+                    name: Some("test".to_string()),
+                }],
+                schema_config: None,
+                limits: None,
+            }],
+            ..Default::default()
+        };
+        config
+    }
+
+    async fn test_app() -> axum::Router {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        create_router(InMemoryStateImpl::new(catalog, test_config()))
+    }
+
+    async fn get_json(app: &axum::Router, uri: &str) -> (StatusCode, Option<serde_json::Value>) {
+        let request = Request::builder()
+            .uri(uri)
+            .header("authorization", "Bearer sk-test-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&body).ok())
+    }
+
+    #[tokio::test]
+    async fn query_range_returns_empty_streams_stub() {
+        let app = test_app().await;
+        let (status, body) = get_json(
+            &app,
+            "/loki/api/v1/query_range?query=%7Bservice_name%3D%22api%22%7D&limit=50",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({
+                "status": "success",
+                "data": {"resultType": "streams", "result": []}
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn instant_query_returns_empty_streams_stub() {
+        let app = test_app().await;
+        let (status, body) = get_json(&app, "/loki/api/v1/query?query=%7Bjob%3D%22x%22%7D").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.unwrap()["data"]["resultType"], "streams");
+    }
+
+    #[tokio::test]
+    async fn query_without_query_param_is_bad_request() {
+        let app = test_app().await;
+        let (status, _) = get_json(&app, "/loki/api/v1/query").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let (status, _) = get_json(&app, "/loki/api/v1/query_range?query=").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn invalid_direction_is_bad_request() {
+        let app = test_app().await;
+        let (status, _) = get_json(
+            &app,
+            "/loki/api/v1/query_range?query=%7Bjob%3D%22x%22%7D&direction=sideways",
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn metadata_endpoints_return_empty_stubs() {
+        let app = test_app().await;
+
+        let (status, body) = get_json(&app, "/loki/api/v1/labels").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({"status": "success", "data": []})
+        );
+
+        let (status, body) = get_json(&app, "/loki/api/v1/label/service_name/values").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.unwrap()["status"], "success");
+
+        let (status, body) =
+            get_json(&app, "/loki/api/v1/series?match%5B%5D=%7Bjob%3D%22x%22%7D").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({"status": "success", "data": []})
+        );
+    }
+
+    #[tokio::test]
+    async fn logql_endpoints_require_authentication() {
+        let app = test_app().await;
+
+        // Missing Authorization header is a 400 (middleware contract),
+        // a wrong key a 401.
+        let request = Request::builder()
+            .uri("/loki/api/v1/labels")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let request = Request::builder()
+            .uri("/loki/api/v1/labels")
+            .header("authorization", "Bearer sk-wrong-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod flight;
+pub mod logql;
 pub mod pyroscope;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -208,6 +208,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Loki-compatible log query API (LogQL)
+        .nest(
+            "/loki",
+            endpoints::logql::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Trace-to-profile correlation
         .nest(
             "/api/profiles",


### PR DESCRIPTION
## Summary

Phase 1 (Foundation) of the LogQL epic #366, complete. (#652 — the router skeleton — auto-merged into this branch rather than stacking, so this PR carries both parts.)

### loki-api crate (#367)
- New workspace crate with serde types for the Loki HTTP API wire format: `QueryResponse` with `resultType`-tagged streams/matrix/vector payloads, `Stream`/`LogEntry` (nanosecond string timestamps), Prometheus-style `Sample` (integral seconds serialize as JSON integers), `LabelsResponse`, `SeriesResponse`, `stats.summary`
- 8 unit tests assert serialized JSON matches the Loki HTTP API docs

### Router endpoint skeleton (#368)
- `/loki/api/v1/{query,query_range,labels,label/{name}/values,series}` nested behind the tenant-auth and query rate-limit layers
- Param validation (missing/empty `query` → 400, invalid `direction` → 400), tenant-scoped tracing fields, wire-format empty stubs until execution lands (#373–#377); `/tail` tracked in #380
- 6 router-level tests through the full middleware stack

### Docs
- Architecture overview + crate-map/architecture skills record the new crate and endpoint surface

Closes #367
Closes #368