### PR TITLE
docs(architecture): add pyroscope-api crate to workspace maps

### DIFF
--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -18,6 +18,7 @@ sources:
 | **router** | `src/router/` | Binary + Library | HTTP API gateway + Flight routing layer |
 | **querier** | `src/querier/` | Binary + Library | DataFusion query execution engine |
 | **compactor** | `src/compactor/` | Binary + Library | Complete data lifecycle: compaction planning/execution (Phase 1-2), retention enforcement, snapshot expiration, orphan cleanup (Phase 3); binary is `signaldb-compactor` |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -76,6 +76,7 @@ Parquet storage with DataFusion query processing:
 | **querier** | `src/querier/` | Binary + Library | Query execution engine via DataFusion |
 | **compactor** | `src/compactor/` | Binary + Library | Storage maintenance: compaction, retention (bin `signaldb-compactor`) |
 | **common** | `src/common/` | Library | Shared config, auth, WAL, Flight, catalog, schema |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |


### PR DESCRIPTION
Doc-freshness follow-up to the profiles epic (#343): the workspace gained the `src/pyroscope-api` library crate, so the crate tables in `docs/architecture/overview.md` and the `crate-map` skill now list it.

The `architecture` skill was also flagged (it declares `Cargo.toml` as a source) but contains no workspace-member listing — its content (FDAP stack, data flow, deployment models) is unaffected by adding a types-only library crate, so no change there.