### PR TITLE
feat(router): add LogQL endpoint skeleton under /loki

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -49,7 +49,7 @@ Key details:
 ## Query Path
 
 ```
-HTTP Client (Tempo API)
+HTTP Client (Tempo / Pyroscope / Loki APIs)
     -> Router (:3000 HTTP, :50053 Flight)
     -> Querier via Flight do_get (:50054)
     -> DataFusion SQL against Iceberg tables
@@ -63,6 +63,7 @@ Key details:
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
 4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
+6. Router also nests a Pyroscope-compatible profile API at `/pyroscope` and a Loki-compatible logs API at `/loki` (the latter returns wire-format stubs until LogQL execution lands, epic #366)
 
 ## Service Components
 

--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -19,6 +19,8 @@ sources:
 | **querier** | `src/querier/` | Binary + Library | DataFusion query execution engine |
 | **compactor** | `src/compactor/` | Binary + Library | Complete data lifecycle: compaction planning/execution (Phase 1-2), retention enforcement, snapshot expiration, orphan cleanup (Phase 3); binary is `signaldb-compactor` |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
+| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, dataset management |
@@ -88,6 +90,8 @@ This is the shared foundation. Key modules:
 | `main.rs` | `src/router/src/main.rs` | Standalone router binary |
 | `discovery.rs` | `src/router/src/discovery.rs` | Cached service discovery for the router |
 | `endpoints/tempo.rs` | `src/router/src/endpoints/tempo.rs` | Tempo-compatible API handlers |
+| `endpoints/logql.rs` | `src/router/src/endpoints/logql.rs` | Loki-compatible API handlers under `/loki` (stubs until LogQL execution lands) |
+| `endpoints/pyroscope.rs` | `src/router/src/endpoints/pyroscope.rs` | Pyroscope-compatible profile query handlers |
 | `endpoints/admin.rs` | `src/router/src/endpoints/admin.rs` | Admin API for tenant/key/dataset CRUD |
 | `endpoints/tenant.rs` | `src/router/src/endpoints/tenant.rs` | Tenant self-service API |
 | `endpoints/flight.rs` | `src/router/src/endpoints/flight.rs` | Router Flight service |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,6 +6029,7 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
+ "loki-api",
  "pyroscope-api",
  "serde",
  "serde_json",

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -77,6 +77,8 @@ Parquet storage with DataFusion query processing:
 | **compactor** | `src/compactor/` | Binary + Library | Storage maintenance: compaction, retention (bin `signaldb-compactor`) |
 | **common** | `src/common/` | Library | Shared config, auth, WAL, Flight, catalog, schema |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
+| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI and TUI for tenant, API key, and dataset management |
@@ -182,7 +184,7 @@ flowchart LR
 |----------|-------|
 | **Ports** | HTTP: 3000, Flight: 50053 |
 | **Capability** | `Routing` |
-| **APIs** | Tempo-compatible, Admin API, OpenAPI |
+| **APIs** | Tempo-compatible, Pyroscope-compatible, Loki-compatible (stubs), Admin API, OpenAPI |
 
 **Tempo API Endpoints**:
 
@@ -198,6 +200,27 @@ flowchart LR
 | `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented -- same lookup, v2 response shape |
 | `GET /tempo/api/metrics/query` | 501 Not Implemented (TraceQL metrics) |
 | `GET /tempo/api/metrics/query_range` | 501 Not Implemented (TraceQL metrics) |
+
+**Pyroscope API Endpoints** (profiles, nested at `/pyroscope` plus `/api/profiles`):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /pyroscope/render` | Implemented -- flamegraph via Querier |
+| `GET /pyroscope/render-diff` | Implemented -- differential flamegraph |
+| `GET /pyroscope/label-names`, `/label-values`, `/profile-types` | Implemented -- discovery via Querier |
+| `GET /api/profiles/trace/{trace_id}` | Implemented -- profiles linked to a trace |
+
+**Loki API Endpoints** (logs, nested at `/loki`; wire-format stubs until LogQL
+execution lands, see epic #366):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /loki/api/v1/query` | Stub -- validates params, returns empty streams |
+| `GET /loki/api/v1/query_range` | Stub -- validates params, returns empty streams |
+| `GET /loki/api/v1/labels` | Stub -- returns empty label list |
+| `GET /loki/api/v1/label/{name}/values` | Stub -- returns empty value list |
+| `GET /loki/api/v1/series` | Stub -- returns empty series list |
+| `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 common.workspace = true
 signaldb-api.workspace = true
+loki-api.workspace = true
 pyroscope-api.workspace = true
 tempo-api.workspace = true
 arrow-flight.workspace = true

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -1,0 +1,355 @@
+//! # Loki-Compatible HTTP API (LogQL)
+//!
+//! Query endpoints for the logs signal in the format Grafana's Loki
+//! datasource expects, nested under `/loki`:
+//!
+//! - `GET /api/v1/query` — instant query
+//! - `GET /api/v1/query_range` — range query
+//! - `GET /api/v1/labels` — label name discovery
+//! - `GET /api/v1/label/{name}/values` — label value discovery
+//! - `GET /api/v1/series` — series discovery
+//!
+//! Handlers currently return empty stub responses in the correct wire
+//! format; query execution lands with the LogQL transpiler and querier
+//! log service (#373–#377). The `/api/v1/tail` WebSocket endpoint is
+//! tracked separately (#380).
+
+use crate::RouterState;
+use axum::{
+    Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use common::auth::TenantContextExtractor;
+use loki_api::{LabelsResponse, QueryResponse, QueryResult, SeriesResponse};
+use serde::Deserialize;
+
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new()
+        .route("/api/v1/query", get(query::<S>))
+        .route("/api/v1/query_range", get(query_range::<S>))
+        .route("/api/v1/labels", get(labels::<S>))
+        .route("/api/v1/label/{name}/values", get(label_values::<S>))
+        .route("/api/v1/series", get(series::<S>))
+}
+
+fn default_limit() -> u32 {
+    100
+}
+
+fn default_direction() -> String {
+    "backward".to_string()
+}
+
+/// Query parameters for `/api/v1/query` (instant queries).
+#[derive(Debug, Deserialize)]
+pub struct InstantQueryParams {
+    /// LogQL query string.
+    pub query: Option<String>,
+    /// Evaluation timestamp (unix epoch ns, s, or RFC3339).
+    pub time: Option<String>,
+    /// Maximum number of entries for log queries.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+    /// `forward` or `backward`.
+    #[serde(default = "default_direction")]
+    pub direction: String,
+}
+
+/// Query parameters for `/api/v1/query_range`.
+#[derive(Debug, Deserialize)]
+pub struct RangeQueryParams {
+    /// LogQL query string.
+    pub query: Option<String>,
+    /// Range start (unix epoch ns, s, or RFC3339).
+    pub start: Option<String>,
+    /// Range end (unix epoch ns, s, or RFC3339).
+    pub end: Option<String>,
+    /// Evaluation interval for metric queries (duration or seconds).
+    pub step: Option<String>,
+    /// Maximum number of entries for log queries.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+    /// `forward` or `backward`.
+    #[serde(default = "default_direction")]
+    pub direction: String,
+}
+
+/// Query parameters for the metadata endpoints (`/labels`,
+/// `/label/{name}/values`, `/series`).
+#[derive(Debug, Default, Deserialize)]
+pub struct MetadataParams {
+    /// Range start (unix epoch ns, s, or RFC3339).
+    pub start: Option<String>,
+    /// Range end (unix epoch ns, s, or RFC3339).
+    pub end: Option<String>,
+    /// Stream selector to restrict results, e.g. `{service_name="api"}`.
+    #[serde(rename = "match[]")]
+    pub matcher: Option<String>,
+    /// `query` is accepted as an alias for `match[]` (Grafana sends it
+    /// on the labels/values endpoints).
+    pub query: Option<String>,
+}
+
+/// Reject requests without a `query` parameter, mirroring Loki's
+/// "empty query" error status.
+fn require_query(query: &Option<String>) -> Result<String, StatusCode> {
+    query
+        .as_deref()
+        .map(str::trim)
+        .filter(|q| !q.is_empty())
+        .map(str::to_string)
+        .ok_or(StatusCode::BAD_REQUEST)
+}
+
+/// Validate the `direction` parameter.
+fn validate_direction(direction: &str) -> Result<(), StatusCode> {
+    match direction {
+        "forward" | "backward" => Ok(()),
+        _ => Err(StatusCode::BAD_REQUEST),
+    }
+}
+
+/// GET /loki/api/v1/query — instant query.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn query<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<InstantQueryParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let logql = require_query(&params.query)?;
+    validate_direction(&params.direction)?;
+    tracing::debug!(query = %logql, "LogQL instant query (stub)");
+
+    // Instant queries over log selectors return streams; execution is
+    // wired up in #376. Until then, answer with an empty stream set.
+    Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
+        vec![],
+    ))))
+}
+
+/// GET /loki/api/v1/query_range — range query.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn query_range<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RangeQueryParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let logql = require_query(&params.query)?;
+    validate_direction(&params.direction)?;
+    tracing::debug!(query = %logql, "LogQL range query (stub)");
+
+    Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
+        vec![],
+    ))))
+}
+
+/// GET /loki/api/v1/labels — list label names.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn labels<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    Ok(axum::Json(LabelsResponse::success(vec![])))
+}
+
+/// GET /loki/api/v1/label/{name}/values — list values of one label.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id,
+        label = %name
+    )
+)]
+pub async fn label_values<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Path(name): Path<String>,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    if name.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(axum::Json(LabelsResponse::success(vec![])))
+}
+
+/// GET /loki/api/v1/series — list series matching a selector.
+#[tracing::instrument(
+    skip(_state, tenant_ctx, _params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn series<S: RouterState>(
+    State(_state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> Result<axum::Json<SeriesResponse>, StatusCode> {
+    Ok(axum::Json(SeriesResponse::success(vec![])))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{InMemoryStateImpl, create_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use common::catalog::Catalog;
+    use common::config::{ApiKeyConfig, Configuration, TenantConfig};
+    use tower::ServiceExt;
+
+    fn test_config() -> Configuration {
+        let mut config = Configuration::default();
+        config.auth = common::config::AuthConfig {
+            tenants: vec![TenantConfig {
+                id: "acme".to_string(),
+                slug: "acme".to_string(),
+                name: "Acme".to_string(),
+                default_dataset: Some("default".to_string()),
+                datasets: vec![],
+                api_keys: vec![ApiKeyConfig {
+                    key: "sk-test-key".to_string(),
+                    name: Some("test".to_string()),
+                }],
+                schema_config: None,
+                limits: None,
+            }],
+            ..Default::default()
+        };
+        config
+    }
+
+    async fn test_app() -> axum::Router {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        create_router(InMemoryStateImpl::new(catalog, test_config()))
+    }
+
+    async fn get_json(app: &axum::Router, uri: &str) -> (StatusCode, Option<serde_json::Value>) {
+        let request = Request::builder()
+            .uri(uri)
+            .header("authorization", "Bearer sk-test-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&body).ok())
+    }
+
+    #[tokio::test]
+    async fn query_range_returns_empty_streams_stub() {
+        let app = test_app().await;
+        let (status, body) = get_json(
+            &app,
+            "/loki/api/v1/query_range?query=%7Bservice_name%3D%22api%22%7D&limit=50",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({
+                "status": "success",
+                "data": {"resultType": "streams", "result": []}
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn instant_query_returns_empty_streams_stub() {
+        let app = test_app().await;
+        let (status, body) = get_json(&app, "/loki/api/v1/query?query=%7Bjob%3D%22x%22%7D").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.unwrap()["data"]["resultType"], "streams");
+    }
+
+    #[tokio::test]
+    async fn query_without_query_param_is_bad_request() {
+        let app = test_app().await;
+        let (status, _) = get_json(&app, "/loki/api/v1/query").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let (status, _) = get_json(&app, "/loki/api/v1/query_range?query=").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn invalid_direction_is_bad_request() {
+        let app = test_app().await;
+        let (status, _) = get_json(
+            &app,
+            "/loki/api/v1/query_range?query=%7Bjob%3D%22x%22%7D&direction=sideways",
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn metadata_endpoints_return_empty_stubs() {
+        let app = test_app().await;
+
+        let (status, body) = get_json(&app, "/loki/api/v1/labels").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({"status": "success", "data": []})
+        );
+
+        let (status, body) = get_json(&app, "/loki/api/v1/label/service_name/values").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.unwrap()["status"], "success");
+
+        let (status, body) =
+            get_json(&app, "/loki/api/v1/series?match%5B%5D=%7Bjob%3D%22x%22%7D").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap(),
+            serde_json::json!({"status": "success", "data": []})
+        );
+    }
+
+    #[tokio::test]
+    async fn logql_endpoints_require_authentication() {
+        let app = test_app().await;
+
+        // Missing Authorization header is a 400 (middleware contract),
+        // a wrong key a 401.
+        let request = Request::builder()
+            .uri("/loki/api/v1/labels")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let request = Request::builder()
+            .uri("/loki/api/v1/labels")
+            .header("authorization", "Bearer sk-wrong-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod flight;
+pub mod logql;
 pub mod pyroscope;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -208,6 +208,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Loki-compatible log query API (LogQL)
+        .nest(
+            "/loki",
+            endpoints::logql::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Trace-to-profile correlation
         .nest(
             "/api/profiles",


### PR DESCRIPTION
## Summary

Stacked on #650. Phase 1 of the LogQL epic, part 2: registers the Loki-compatible HTTP surface in the router, nested at `/loki` behind the same tenant-auth and query rate-limit layers as the Tempo and Pyroscope APIs.

- `GET /loki/api/v1/query` and `/query_range` — validate `query` (400 when missing/empty) and `direction` (`forward`/`backward`), then return an empty `streams` result in the correct envelope
- `GET /loki/api/v1/labels`, `/label/{name}/values`, `/series` — empty metadata stubs
- Tenant context extraction via `TenantContextExtractor` with tenant/dataset tracing fields, matching the Pyroscope handlers
- `/loki/api/v1/tail` intentionally omitted — tracked in #380

Query execution lands with #373–#377; these handlers give Grafana a well-formed surface to point at in the meantime.

## Testing

6 router-level tests exercising the full middleware stack via `oneshot`: stub payload shape, missing/empty query → 400, invalid direction → 400, metadata stubs, and auth rejection (missing header → 400 per middleware contract, wrong key → 401).

Refs #368 (part of #366)