### PR TITLE
feat(quotas): extend per-tenant storage quotas and rate limits to the profiles signal

### DIFF
--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -96,11 +96,11 @@ fields mean unlimited; DB-provisioned tenants get the defaults.
 
 | Limit | Enforced at | On exceed |
 |-------|-------------|-----------|
-| `max_ingest_requests_per_sec` / `max_ingest_bytes_per_sec` | Acceptor (OTLP gRPC, remote_write) | 429 / RESOURCE_EXHAUSTED |
+| `max_ingest_requests_per_sec` / `max_ingest_bytes_per_sec` | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED |
 | `max_query_requests_per_sec` | Router HTTP query API (`/tempo`, `/api/v1`) | 429 |
 | `max_api_keys` (active keys only) | Admin API key creation | 429 `quota_exceeded` |
 | `max_datasets` | Admin API dataset creation | 429 `quota_exceeded` |
-| `max_storage_bytes` | Acceptor (OTLP gRPC, remote_write) | 429 / RESOURCE_EXHAUSTED `quota_exceeded` |
+| `max_storage_bytes` | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED `quota_exceeded` |
 | `[querier] max_concurrent_queries_per_tenant` | Querier | query rejected |
 
 Token buckets per dimension (`common::ratelimit::TenantRateLimiter`);

--- a/docs/users/profiles.md
+++ b/docs/users/profiles.md
@@ -48,6 +48,13 @@ service:
 An export is acknowledged only after it is durably written to the
 profiles write-ahead log; a rejected export is safe to retry.
 
+Per-tenant ingest rate limits and storage quotas cover profiles like
+every other signal: gRPC exports over the limit fail with
+`RESOURCE_EXHAUSTED` (retryable — back off), HTTP exports with `429 Too
+Many Requests`. An error mentioning `quota_exceeded` means the tenant is
+at or over its storage quota (`max_storage_bytes`); retrying will not
+help until data is deleted, retention shortens, or the quota is raised.
+
 ## How profiles are stored
 
 The OTLP profiles wire format shares one dictionary (strings, functions,

--- a/docs/users/sending-otlp.md
+++ b/docs/users/sending-otlp.md
@@ -122,4 +122,5 @@ appear to succeed but no data is stored.
 | `PERMISSION_DENIED` | Key does not belong to the tenant/dataset you named | Use a key issued for that tenant |
 | `RESOURCE_EXHAUSTED` | Per-tenant ingest rate limit hit | Back off and retry; ask your operator about tenant limits |
 | `RESOURCE_EXHAUSTED` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
+| `429 Too Many Requests` on `POST /v1development/profiles` | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | See [profiles](profiles.md) |
 | Exports return 200 but no data is queryable | Exporter uses OTLP/HTTP on :4318 | Switch the exporter to gRPC on :4317 |

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -285,8 +285,9 @@ pub async fn serve_otlp_grpc(
     });
 
     let profile_handler = ProfileHandler::new(flight_transport.clone(), wal_manager.clone());
-    let profile_service =
-        ProfileAcceptorService::new(profile_handler).with_rate_limiter(rate_limiter.clone());
+    let profile_service = ProfileAcceptorService::new(profile_handler)
+        .with_rate_limiter(rate_limiter.clone())
+        .with_storage_quota(storage_usage.clone());
     let auth_for_profiles = authenticator.clone();
     let profile_server = ProfilesServiceServer::with_interceptor(profile_service, move |req| {
         grpc_auth_interceptor(auth_for_profiles.clone(), req)
@@ -364,20 +365,28 @@ pub fn prometheus_router(
 #[derive(Clone)]
 pub struct ProfilesHandlerState {
     pub handler: Arc<ProfileHandler>,
+    pub rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    pub storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
 }
 
 /// Create a router for the OTLP/HTTP profiles ingestion endpoint with authentication
 ///
 /// Handles `POST /v1development/profiles` (the OTLP development endpoint for
-/// the profiles signal) with protobuf or JSON request bodies.
+/// the profiles signal) with protobuf or JSON request bodies. Per-tenant
+/// ingest rate limits and storage quotas are enforced with HTTP 429; both
+/// are unlimited unless configured.
 pub fn profiles_http_router(
     authenticator: Arc<Authenticator>,
     profile_handler: Arc<ProfileHandler>,
+    rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
 ) -> Router {
     use axum::middleware;
 
     let state = ProfilesHandlerState {
         handler: profile_handler,
+        rate_limiter,
+        storage_quota,
     };
 
     Router::new()
@@ -409,6 +418,20 @@ async fn handle_http_profiles(
 ) -> axum::response::Response<axum::body::Body> {
     use opentelemetry_proto::tonic::collector::profiles::v1development::ExportProfilesServiceRequest;
     use prost::Message;
+
+    // Per-tenant ingest rate limiting (HTTP 429 with the reason)
+    if let Err(e) = state
+        .rate_limiter
+        .check_ingest(&tenant_context.tenant_id, body.len())
+    {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
+
+    // Per-tenant storage quota: a tenant at or over max_storage_bytes
+    // must free space (or get a raised quota) before ingesting more.
+    if let Err(e) = state.storage_quota.check_ingest(&tenant_context.tenant_id) {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
 
     let content_type = headers
         .get(axum::http::header::CONTENT_TYPE)
@@ -550,6 +573,8 @@ pub async fn serve_otlp_http(
         .merge(profiles_http_router(
             config.authenticator.clone(),
             profile_handler,
+            config.rate_limiter.clone(),
+            config.storage_usage.clone(),
         ));
 
     tracing::info!("Prometheus remote_write endpoint enabled at POST /api/v1/write");

--- a/src/acceptor/src/services/otlp_profile_service.rs
+++ b/src/acceptor/src/services/otlp_profile_service.rs
@@ -8,6 +8,7 @@ use crate::handler::otlp_profiles_handler::ProfileHandler;
 use crate::middleware::get_tenant_context;
 use common::auth::TenantContext;
 use common::ratelimit::TenantRateLimiter;
+use common::storage_usage::StorageUsageTracker;
 use prost::Message;
 use std::sync::Arc;
 
@@ -35,6 +36,7 @@ impl ProfileHandlerTrait for ProfileHandler {
 pub struct ProfileAcceptorService<H: ProfileHandlerTrait> {
     handler: H,
     rate_limiter: Option<Arc<TenantRateLimiter>>,
+    storage_quota: Option<Arc<StorageUsageTracker>>,
 }
 
 impl<H: ProfileHandlerTrait> ProfileAcceptorService<H> {
@@ -42,12 +44,19 @@ impl<H: ProfileHandlerTrait> ProfileAcceptorService<H> {
         Self {
             handler,
             rate_limiter: None,
+            storage_quota: None,
         }
     }
 
     /// Enforce per-tenant ingest rate limits on this service.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<TenantRateLimiter>) -> Self {
         self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Enforce per-tenant storage quotas on this service.
+    pub fn with_storage_quota(mut self, storage_quota: Arc<StorageUsageTracker>) -> Self {
+        self.storage_quota = Some(storage_quota);
         self
     }
 }
@@ -68,6 +77,14 @@ impl<H: ProfileHandlerTrait + Send + Sync + 'static> ProfilesService for Profile
         if let Some(limiter) = &self.rate_limiter {
             limiter
                 .check_ingest(&tenant_context.tenant_id, request_inner.encoded_len())
+                .map_err(|e| Status::resource_exhausted(e.to_string()))?;
+        }
+
+        // Per-tenant storage quota: a tenant at or over max_storage_bytes
+        // must free space (or get a raised quota) before ingesting more.
+        if let Some(quota) = &self.storage_quota {
+            quota
+                .check_ingest(&tenant_context.tenant_id)
                 .map_err(|e| Status::resource_exhausted(e.to_string()))?;
         }
 
@@ -189,5 +206,43 @@ mod tests {
         let response = service.export(tonic_request).await;
 
         assert!(response.is_ok());
+    }
+
+    #[tokio::test]
+    async fn export_rejects_tenant_over_storage_quota() {
+        use common::config::{AuthConfig, TenantLimits};
+        use std::collections::HashMap;
+
+        // No expectation set: the handler must never run for a rejected export.
+        let mock_handler = MockProfileHandler::new();
+
+        let auth = AuthConfig {
+            default_limits: TenantLimits {
+                max_storage_bytes: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let tracker = Arc::new(StorageUsageTracker::from_auth_config(&auth));
+        tracker.replace_all(HashMap::from([("test-tenant".to_string(), 10u64)]));
+
+        let service = ProfileAcceptorService::new(mock_handler).with_storage_quota(tracker);
+
+        let mut tonic_request = Request::new(ExportProfilesServiceRequest::default());
+        tonic_request.extensions_mut().insert(TenantContext {
+            tenant_id: "test-tenant".to_string(),
+            dataset_id: "test-dataset".to_string(),
+            tenant_slug: "test-tenant".to_string(),
+            dataset_slug: "test-dataset".to_string(),
+            api_key_name: Some("test-key".to_string()),
+            source: common::auth::TenantSource::Config,
+        });
+
+        let status = service
+            .export(tonic_request)
+            .await
+            .expect_err("tenant over quota must be rejected");
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert!(status.message().contains("quota_exceeded"));
     }
 }

--- a/tests-integration/src/generators/data_generator.rs
+++ b/tests-integration/src/generators/data_generator.rs
@@ -134,6 +134,47 @@ pub async fn generate_metrics(
     Ok(partitions)
 }
 
+/// Generates time-partitioned profile data
+pub async fn generate_profiles(
+    writer: &mut IcebergTableWriter,
+    config: &DataGeneratorConfig,
+) -> Result<Vec<PartitionInfo>> {
+    let mut partitions = Vec::new();
+    let partition_duration = config.partition_granularity.to_millis();
+
+    for partition_idx in 0..config.partition_count {
+        let partition_start = config.base_timestamp + (partition_idx as i64 * partition_duration);
+        let partition_end = partition_start + partition_duration;
+
+        let mut total_rows = 0;
+
+        for file_idx in 0..config.files_per_partition {
+            let batch = create_profile_batch(
+                partition_start,
+                partition_end,
+                config.rows_per_file,
+                partition_idx,
+                file_idx,
+            )?;
+
+            writer
+                .append_batches_with_marker("seed", vec![(uuid::Uuid::new_v4(), batch)])
+                .await?;
+            total_rows += config.rows_per_file;
+        }
+
+        let partition_id = format_partition_id(partition_start, config.partition_granularity);
+        partitions.push(PartitionInfo {
+            partition_id,
+            timestamp_range: (partition_start, partition_end),
+            file_count: config.files_per_partition,
+            row_count: total_rows,
+        });
+    }
+
+    Ok(partitions)
+}
+
 /// Creates a trace batch with specified parameters (v1 schema format)
 fn create_trace_batch(
     start_ts: i64,
@@ -545,6 +586,104 @@ fn create_metric_batch(
     Ok(batch)
 }
 
+/// Creates a profile batch with specified parameters (Iceberg storage schema)
+fn create_profile_batch(
+    start_ts: i64,
+    end_ts: i64,
+    num_rows: usize,
+    partition_idx: usize,
+    file_idx: usize,
+) -> Result<RecordBatch> {
+    use chrono::{DateTime, Datelike, Timelike};
+    use datafusion::arrow::array::{Date32Array, Int32Array, Int64Array, TimestampNanosecondArray};
+
+    // Use the writer's storage schema directly; batches in this shape pass
+    // through the writer without a v1->iceberg transform.
+    let schema = writer::schema_transform::create_profiles_arrow_schema();
+
+    let time_step = if num_rows == 0 {
+        0
+    } else {
+        (end_ts - start_ts) / num_rows as i64
+    };
+
+    let mut profile_ids: Vec<String> = Vec::with_capacity(num_rows);
+    let mut timestamps: Vec<Option<i64>> = Vec::with_capacity(num_rows);
+    let mut duration_nanos: Vec<i64> = Vec::with_capacity(num_rows);
+    let mut sample_types: Vec<String> = Vec::with_capacity(num_rows);
+    let mut sample_units: Vec<String> = Vec::with_capacity(num_rows);
+    let mut period_types: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut period_units: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut periods: Vec<Option<i64>> = Vec::with_capacity(num_rows);
+    let mut service_names: Vec<String> = Vec::with_capacity(num_rows);
+    let mut stacktraces_jsons: Vec<String> = Vec::with_capacity(num_rows);
+    let mut samples_jsons: Vec<String> = Vec::with_capacity(num_rows);
+    let mut resource_attributes: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut scope_attributes: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut profile_attributes: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut trace_ids: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut span_ids: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    let mut date_days: Vec<Option<i32>> = Vec::with_capacity(num_rows);
+    let mut hours: Vec<Option<i32>> = Vec::with_capacity(num_rows);
+
+    for i in 0..num_rows {
+        let ts_millis = start_ts + (i as i64 * time_step);
+        let ts_nanos = ts_millis * 1_000_000;
+
+        profile_ids.push(format!("profile-p{partition_idx}-f{file_idx}-{i}"));
+        timestamps.push(Some(ts_nanos));
+        duration_nanos.push(10_000_000 + (i as i64 * 1_000));
+        sample_types.push("cpu".to_string());
+        sample_units.push("nanoseconds".to_string());
+        period_types.push(Some("cpu".to_string()));
+        period_units.push(Some("nanoseconds".to_string()));
+        periods.push(Some(10_000_000));
+        service_names.push(format!("test-service-{}", i % 3));
+        stacktraces_jsons.push(r#"[{"locations":["main","work"]}]"#.to_string());
+        samples_jsons.push(r#"[{"stacktrace_index":0,"values":[100]}]"#.to_string());
+        resource_attributes.push(Some(r#"{"service.name":"test-service"}"#.to_string()));
+        scope_attributes.push(Some("{}".to_string()));
+        profile_attributes.push(Some("{}".to_string()));
+        trace_ids.push(Some(format!("{:032x}", i)));
+        span_ids.push(Some(format!("{:016x}", i)));
+
+        let secs = ts_nanos / 1_000_000_000;
+        if let Some(dt) = DateTime::from_timestamp(secs, 0) {
+            date_days.push(Some(dt.naive_utc().date().num_days_from_ce() - 719163));
+            hours.push(Some(dt.hour() as i32));
+        } else {
+            date_days.push(None);
+            hours.push(None);
+        }
+    }
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(profile_ids)),
+            Arc::new(TimestampNanosecondArray::from(timestamps)),
+            Arc::new(Int64Array::from(duration_nanos)),
+            Arc::new(StringArray::from(sample_types)),
+            Arc::new(StringArray::from(sample_units)),
+            Arc::new(StringArray::from(period_types)),
+            Arc::new(StringArray::from(period_units)),
+            Arc::new(Int64Array::from(periods)),
+            Arc::new(StringArray::from(service_names)),
+            Arc::new(StringArray::from(stacktraces_jsons)),
+            Arc::new(StringArray::from(samples_jsons)),
+            Arc::new(StringArray::from(resource_attributes)),
+            Arc::new(StringArray::from(scope_attributes)),
+            Arc::new(StringArray::from(profile_attributes)),
+            Arc::new(StringArray::from(trace_ids)),
+            Arc::new(StringArray::from(span_ids)),
+            Arc::new(Date32Array::from(date_days)),
+            Arc::new(Int32Array::from(hours)),
+        ],
+    )?;
+
+    Ok(batch)
+}
+
 /// Formats a partition ID from a timestamp
 fn format_partition_id(
     timestamp: i64,
@@ -586,6 +725,14 @@ mod tests {
         let batch = create_metric_batch(1700000000000, 1700003600000, 75, 0, 0)?;
         assert_eq!(batch.num_rows(), 75);
         assert_eq!(batch.num_columns(), 19); // Updated for metrics gauge schema with 19 fields
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_profile_batch() -> Result<()> {
+        let batch = create_profile_batch(1700000000000, 1700003600000, 25, 0, 0)?;
+        assert_eq!(batch.num_rows(), 25);
+        assert_eq!(batch.num_columns(), 18); // Profiles Iceberg storage schema with 18 fields
         Ok(())
     }
 

--- a/tests-integration/src/generators/mod.rs
+++ b/tests-integration/src/generators/mod.rs
@@ -6,5 +6,5 @@
 mod data_generator;
 mod snapshot_generator;
 
-pub use data_generator::{generate_logs, generate_metrics, generate_traces};
+pub use data_generator::{generate_logs, generate_metrics, generate_profiles, generate_traces};
 pub use snapshot_generator::{SnapshotGenerator, SnapshotInfo};

--- a/tests-integration/tests/storage_quota.rs
+++ b/tests-integration/tests/storage_quota.rs
@@ -43,6 +43,55 @@ async fn write_traces(catalog_manager: &Arc<CatalogManager>, writes: usize) -> R
     Ok(())
 }
 
+async fn write_profiles(catalog_manager: &Arc<CatalogManager>, writes: usize) -> Result<()> {
+    let object_store = Arc::new(InMemory::new());
+    let mut writer = IcebergTableWriter::new(
+        catalog_manager,
+        object_store,
+        TENANT.to_string(),
+        DATASET.to_string(),
+        "profiles".to_string(),
+    )
+    .await
+    .expect("Failed to create Iceberg writer");
+
+    let config = DataGeneratorConfig {
+        partition_count: 1,
+        files_per_partition: 1,
+        rows_per_file: 100,
+        base_timestamp: chrono::Utc::now().timestamp_millis() - (60 * 60 * 1000),
+        partition_granularity: PartitionGranularity::Hour,
+    };
+    for _ in 0..writes {
+        generators::generate_profiles(&mut writer, &config).await?;
+    }
+    Ok(())
+}
+
+/// Sum of live data-file sizes in one table's current snapshot, per the
+/// manifest reader (the accounting ground truth).
+async fn manifest_live_bytes(
+    catalog_manager: &Arc<CatalogManager>,
+    table_name: &str,
+) -> Result<u64> {
+    let identifier = catalog_manager.build_table_identifier(TENANT, DATASET, table_name);
+    let table = match catalog_manager
+        .catalog()
+        .load_tabular(&identifier)
+        .await
+        .expect("Failed to load table")
+    {
+        iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
+        _ => panic!("Expected table"),
+    };
+    Ok(compactor::iceberg::ManifestReader::new()
+        .get_snapshot_files(&table)
+        .await?
+        .iter()
+        .map(|f| f.file_size_bytes)
+        .sum())
+}
+
 #[tokio::test]
 async fn storage_usage_is_accounted_from_live_files_and_enforced() -> Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -69,22 +118,7 @@ async fn storage_usage_is_accounted_from_live_files_and_enforced() -> Result<()>
     let counted = *usage
         .get(TENANT)
         .expect("tenant with data must appear in the usage map");
-    let table_identifier = catalog_manager.build_table_identifier(TENANT, DATASET, "traces");
-    let table = match catalog_manager
-        .catalog()
-        .load_tabular(&table_identifier)
-        .await
-        .expect("Failed to load table")
-    {
-        iceberg_rust::catalog::tabular::Tabular::Table(t) => t,
-        _ => panic!("Expected table"),
-    };
-    let manifest_bytes: u64 = compactor::iceberg::ManifestReader::new()
-        .get_snapshot_files(&table)
-        .await?
-        .iter()
-        .map(|f| f.file_size_bytes)
-        .sum();
+    let manifest_bytes = manifest_live_bytes(&catalog_manager, "traces").await?;
     assert!(counted > 0, "real data files must produce non-zero usage");
     assert_eq!(
         counted, manifest_bytes,
@@ -110,6 +144,22 @@ async fn storage_usage_is_accounted_from_live_files_and_enforced() -> Result<()>
     assert!(
         usage_after[TENANT] > counted,
         "additional writes must increase accounted usage"
+    );
+
+    // The profiles signal (issue #635) must count toward the same tenant
+    // quota: accounting walks every table in the tenant namespace, so a
+    // profiles table's live files show up byte-for-byte in the total.
+    write_profiles(&catalog_manager, 2).await?;
+    let usage_with_profiles = compute_usage(&catalog_manager).await?;
+    let profile_bytes = manifest_live_bytes(&catalog_manager, "profiles").await?;
+    assert!(
+        profile_bytes > 0,
+        "profile writes must produce live data files"
+    );
+    assert_eq!(
+        usage_with_profiles[TENANT],
+        usage_after[TENANT] + profile_bytes,
+        "profiles tables must count toward tenant storage usage"
     );
     Ok(())
 }


### PR DESCRIPTION
Closes #635. Follow-up to #634, closing out the profiles epic: profiles were the one signal whose ingest paths bypassed tenant limits.

## Changes

**Enforcement (acceptor)**
- OTLP gRPC `ProfilesService/Export`: adds the missing storage-quota gate next to the existing rate limiter — `RESOURCE_EXHAUSTED` with the `quota_exceeded` wording, matching traces/logs/metrics.
- OTLP/HTTP `POST /v1development/profiles`: previously enforced nothing; now checks both the ingest rate limit and the storage quota before decoding the body, answering HTTP 429.
- Both follow the #634 pattern: quota check after the rate limiter, and unknown usage passes — accounting lag must not block ingest.

**Accounting verification (tests-integration)**
- `compute_usage` walks every table in each tenant namespace, so profiles tables are covered automatically. The extended `storage_quota` test proves it: after writing real profile Parquet files, accounted tenant usage grows by exactly the profiles table's live manifest bytes. Includes a new `generate_profiles` fixture generator using the writer's storage schema.

**Docs**
- Multi-tenancy skill limits table lists the profiles enforcement points.
- `docs/users/profiles.md` documents the rate-limit/quota behavior (`RESOURCE_EXHAUSTED` on gRPC, 429 on HTTP, `quota_exceeded` is not retryable); `sending-otlp.md` troubleshooting links to it.

## Scope note

The issue also listed the Pyroscope-compatible router API as an enforcement point, but that API shipped query-only (`/render`, `/label-names`, `/profile-types` — no ingest route), so the two OTLP surfaces are the complete set.

## Testing

- New unit test: over-quota tenant is rejected with `RESOURCE_EXHAUSTED` before the handler runs.
- `cargo test -p acceptor` (52 passed), `cargo test -p tests-integration --test storage_quota` (passed).
- fmt, clippy, machete, deny all green via pre-commit hooks.