### PR TITLE
feat(logql): add LogQL lexer crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "logql"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "loki-api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "src/acceptor",
     "src/common",
     "src/compactor",
+    "src/logql",
     "src/loki-api",
     "src/pyroscope-api",
     "src/querier",
@@ -29,6 +30,7 @@ default-members = [
     "src/acceptor",
     "src/common",
     "src/compactor",
+    "src/logql",
     "src/loki-api",
     "src/pyroscope-api",
     "src/querier",
@@ -54,6 +56,7 @@ common = { path = "src/common" }
 compactor = { path = "src/compactor" }
 signaldb-api = { path = "src/signaldb-api" }
 signaldb-sdk = { path = "src/signaldb-sdk" }
+logql = { path = "src/logql" }
 loki-api = { path = "src/loki-api" }
 pyroscope-api = { path = "src/pyroscope-api" }
 tempo-api = { path = "src/tempo-api" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY src/writer/Cargo.toml src/writer/
 COPY src/querier/Cargo.toml src/querier/
 COPY src/compactor/Cargo.toml src/compactor/
 COPY src/common/Cargo.toml src/common/
+COPY src/logql/Cargo.toml src/logql/
 COPY src/loki-api/Cargo.toml src/loki-api/
 COPY src/pyroscope-api/Cargo.toml src/pyroscope-api/
 COPY src/tempo-api/Cargo.toml src/tempo-api/
@@ -48,6 +49,7 @@ RUN mkdir -p src/acceptor/src && echo "fn main() {}" > src/acceptor/src/main.rs 
     mkdir -p src/compactor/src && echo "fn main() {}" > src/compactor/src/main.rs && \
     echo "pub fn dummy() {}" > src/compactor/src/lib.rs && \
     mkdir -p src/common/src && echo "pub fn dummy() {}" > src/common/src/lib.rs && \
+    mkdir -p src/logql/src && echo "pub fn dummy() {}" > src/logql/src/lib.rs && \
     mkdir -p src/loki-api/src && echo "pub fn dummy() {}" > src/loki-api/src/lib.rs && \
     mkdir -p src/pyroscope-api/src && echo "pub fn dummy() {}" > src/pyroscope-api/src/lib.rs && \
     mkdir -p src/tempo-api/src && echo "pub fn dummy() {}" > src/tempo-api/src/lib.rs && \

--- a/src/logql/Cargo.toml
+++ b/src/logql/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "logql"
+version = "0.1.0"
+edition = "2024"
+description = "LogQL lexer and parser for SignalDB's Loki-compatible query interface"
+license = "AGPL-3.0"
+
+[dependencies]
+thiserror.workspace = true

--- a/src/logql/src/ast.rs
+++ b/src/logql/src/ast.rs
@@ -50,9 +50,137 @@ impl std::fmt::Display for MatchOp {
     }
 }
 
-/// One stage of a log pipeline (`|= "err"`, `| json`, ...).
-///
-/// Variants land with the pipeline-stage parser (#371); the enum exists
-/// so [`LogQuery`] carries a stable shape from the start.
+/// One stage of a log pipeline (`|= "err"`, `| json`, `| level="error"`).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PipelineStage {}
+pub enum PipelineStage {
+    /// Line filter: `|= "err"`, `!= "noise"`, `|~ "re"`, `!~ "re"`.
+    LineFilter(LineFilter),
+    /// `| json` with optional label-extraction expressions.
+    Json(Vec<LabelExtraction>),
+    /// `| logfmt` with optional label-extraction expressions.
+    Logfmt(Vec<LabelExtraction>),
+    /// `| regexp "(?P<name>re)"` — named-capture extraction.
+    Regexp(String),
+    /// `| pattern "<method> <path>"` — pattern extraction.
+    Pattern(String),
+    /// `| unpack` — promote a packed JSON entry's labels.
+    Unpack,
+    /// `| level="error"`, `| status >= 500 and duration > 1s`.
+    LabelFilter(LabelFilterExpr),
+    /// `| line_format "{{.msg}}"`.
+    LineFormat(String),
+    /// `| label_format dst="src", pretty=`{{.x}}``.
+    LabelFormat(Vec<LabelFormat>),
+    /// `| drop label1, label2`.
+    Drop(Vec<String>),
+    /// `| keep label1, label2`.
+    Keep(Vec<String>),
+    /// `| unwrap duration_ms` or `| unwrap duration(latency)`.
+    Unwrap(Unwrap),
+}
+
+/// A line filter operator and its match string.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LineFilter {
+    pub op: LineFilterOp,
+    pub value: String,
+}
+
+/// Line filter operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineFilterOp {
+    /// `|=`
+    Contains,
+    /// `!=`
+    NotContains,
+    /// `|~`
+    Regex,
+    /// `!~`
+    NotRegex,
+}
+
+/// One label extraction expression for `json`/`logfmt`, e.g.
+/// `status="response.status"` or a bare `level`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelExtraction {
+    /// Destination label name.
+    pub name: String,
+    /// Source expression (JSON path / logfmt key). `None` extracts the
+    /// field whose name equals `name`.
+    pub expr: Option<String>,
+}
+
+/// One `label_format` assignment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelFormat {
+    /// Destination label.
+    pub dst: String,
+    /// Either a rename from another label or a Go-template string.
+    pub value: LabelFormatValue,
+}
+
+/// The right-hand side of a `label_format` assignment.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LabelFormatValue {
+    /// `dst=src_label` — rename/copy from another label.
+    Rename(String),
+    /// `dst="template"` — render a Go template.
+    Template(String),
+}
+
+/// An `unwrap` stage: the label to unwrap plus an optional conversion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Unwrap {
+    /// Label whose value is unwrapped into a sample value.
+    pub label: String,
+    /// Conversion function wrapping the label, e.g. `duration` or
+    /// `bytes` in `unwrap duration(latency)`.
+    pub conversion: Option<String>,
+}
+
+/// A label-filter expression: comparisons combined with `and`/`or`.
+///
+/// A comma between predicates is sugar for `and`. `and` binds tighter
+/// than `or`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LabelFilterExpr {
+    Pred(LabelFilterPred),
+    And(Box<LabelFilterExpr>, Box<LabelFilterExpr>),
+    Or(Box<LabelFilterExpr>, Box<LabelFilterExpr>),
+}
+
+/// A single label-filter comparison, e.g. `status >= 500`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelFilterPred {
+    pub name: String,
+    pub op: FilterOp,
+    pub value: FilterValue,
+}
+
+/// Label-filter comparison operators. String matchers (`=`, `!=`, `=~`,
+/// `!~`) and ordered comparisons (`==`, `>`, `>=`, `<`, `<=`) share this
+/// enum; the parser rejects operator/value combinations that don't fit
+/// (e.g. `=~` against a number).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterOp {
+    Eq,
+    Neq,
+    Re,
+    Nre,
+    CmpEq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+/// The right-hand side value of a label filter.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterValue {
+    /// A quoted string (used with `=`, `!=`, `=~`, `!~`, and `==`).
+    String(String),
+    /// A numeric literal.
+    Number(f64),
+    /// A duration literal such as `1s` or `500ms`.
+    Duration(std::time::Duration),
+}

--- a/src/logql/src/ast.rs
+++ b/src/logql/src/ast.rs
@@ -1,0 +1,58 @@
+//! # LogQL AST
+//!
+//! Abstract syntax tree for parsed LogQL queries. The tree mirrors the
+//! shape of the language: a log query is a stream selector followed by
+//! an optional pipeline; metric queries (added with the metric-query
+//! parser) wrap log queries in range and vector aggregations.
+
+/// A parsed log query: stream selector plus pipeline stages.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogQuery {
+    pub selector: StreamSelector,
+    pub pipeline: Vec<PipelineStage>,
+}
+
+/// The `{...}` stream selector: a conjunction of label matchers.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct StreamSelector {
+    pub matchers: Vec<LabelMatcher>,
+}
+
+/// One label matcher, e.g. `service_name=~"web-.*"`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelMatcher {
+    pub name: String,
+    pub op: MatchOp,
+    pub value: String,
+}
+
+/// Label matching operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchOp {
+    /// `=`
+    Eq,
+    /// `!=`
+    Neq,
+    /// `=~`
+    Re,
+    /// `!~`
+    Nre,
+}
+
+impl std::fmt::Display for MatchOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            MatchOp::Eq => "=",
+            MatchOp::Neq => "!=",
+            MatchOp::Re => "=~",
+            MatchOp::Nre => "!~",
+        })
+    }
+}
+
+/// One stage of a log pipeline (`|= "err"`, `| json`, ...).
+///
+/// Variants land with the pipeline-stage parser (#371); the enum exists
+/// so [`LogQuery`] carries a stable shape from the start.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PipelineStage {}

--- a/src/logql/src/lexer.rs
+++ b/src/logql/src/lexer.rs
@@ -1,0 +1,637 @@
+//! # LogQL Lexer
+//!
+//! Hand-rolled tokenizer for LogQL. Produces [`SpannedToken`]s with
+//! 1-based line/column positions; every error carries the position it
+//! occurred at.
+//!
+//! Notable rules:
+//!
+//! - A number immediately followed by a letter is a duration literal
+//!   (`5m`, `1h30m`, `1.5h`); an invalid unit is an error rather than
+//!   two adjacent tokens.
+//! - Double-quoted strings process escapes; backtick strings are raw
+//!   (the form used for regex patterns).
+//! - `#` starts a comment running to end of line.
+
+use crate::token::{SpannedToken, Token};
+use std::time::Duration;
+
+/// Lexing error with 1-based source position.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("{message} at line {line}, column {col}")]
+pub struct LexError {
+    pub message: String,
+    pub line: u32,
+    pub col: u32,
+}
+
+/// Tokenize a LogQL query.
+pub fn tokenize(input: &str) -> Result<Vec<SpannedToken>, LexError> {
+    Lexer::new(input).run()
+}
+
+struct Lexer<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    line: u32,
+    col: u32,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            chars: input.chars().peekable(),
+            line: 1,
+            col: 1,
+        }
+    }
+
+    fn error(&self, message: impl Into<String>, line: u32, col: u32) -> LexError {
+        LexError {
+            message: message.into(),
+            line,
+            col,
+        }
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let c = self.chars.next()?;
+        if c == '\n' {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
+        Some(c)
+    }
+
+    /// Consume the next char when it equals `expected`.
+    fn eat(&mut self, expected: char) -> bool {
+        if self.chars.peek() == Some(&expected) {
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn run(mut self) -> Result<Vec<SpannedToken>, LexError> {
+        let mut tokens = Vec::new();
+        loop {
+            // Skip whitespace and comments.
+            match self.chars.peek() {
+                Some(c) if c.is_whitespace() => {
+                    self.bump();
+                    continue;
+                }
+                Some('#') => {
+                    while let Some(&c) = self.chars.peek() {
+                        if c == '\n' {
+                            break;
+                        }
+                        self.bump();
+                    }
+                    continue;
+                }
+                None => break,
+                _ => {}
+            }
+
+            let (line, col) = (self.line, self.col);
+            let c = self.bump().expect("peeked above");
+            let token = match c {
+                '{' => Token::LBrace,
+                '}' => Token::RBrace,
+                '(' => Token::LParen,
+                ')' => Token::RParen,
+                '[' => Token::LBracket,
+                ']' => Token::RBracket,
+                ',' => Token::Comma,
+                '+' => Token::Add,
+                '-' => Token::Sub,
+                '*' => Token::Mul,
+                '/' => Token::Div,
+                '%' => Token::Mod,
+                '^' => Token::Pow,
+                '|' => {
+                    if self.eat('=') {
+                        Token::PipeExact
+                    } else if self.eat('~') {
+                        Token::PipeRegex
+                    } else {
+                        Token::Pipe
+                    }
+                }
+                '=' => {
+                    if self.eat('=') {
+                        Token::CmpEq
+                    } else if self.eat('~') {
+                        Token::Re
+                    } else {
+                        Token::Eq
+                    }
+                }
+                '!' => {
+                    if self.eat('=') {
+                        Token::Neq
+                    } else if self.eat('~') {
+                        Token::Nre
+                    } else {
+                        return Err(self.error(
+                            "unexpected '!' (expected '!=' or '!~')",
+                            line,
+                            col,
+                        ));
+                    }
+                }
+                '>' => {
+                    if self.eat('=') {
+                        Token::Gte
+                    } else {
+                        Token::Gt
+                    }
+                }
+                '<' => {
+                    if self.eat('=') {
+                        Token::Lte
+                    } else {
+                        Token::Lt
+                    }
+                }
+                '"' => self.lex_string(line, col)?,
+                '`' => self.lex_raw_string(line, col)?,
+                c if c.is_ascii_digit() => self.lex_number_or_duration(c, line, col)?,
+                c if c.is_alphabetic() || c == '_' => {
+                    let mut word = String::from(c);
+                    while let Some(&next) = self.chars.peek() {
+                        if next.is_alphanumeric() || next == '_' {
+                            word.push(next);
+                            self.bump();
+                        } else {
+                            break;
+                        }
+                    }
+                    Token::keyword(&word).unwrap_or(Token::Ident(word))
+                }
+                other => {
+                    return Err(self.error(format!("unexpected character {other:?}"), line, col));
+                }
+            };
+            tokens.push(SpannedToken { token, line, col });
+        }
+        Ok(tokens)
+    }
+
+    /// Double-quoted string; the opening quote is already consumed.
+    fn lex_string(&mut self, line: u32, col: u32) -> Result<Token, LexError> {
+        let mut value = String::new();
+        loop {
+            let (c_line, c_col) = (self.line, self.col);
+            let Some(c) = self.bump() else {
+                return Err(self.error("unterminated string literal", line, col));
+            };
+            match c {
+                '"' => return Ok(Token::String(value)),
+                '\\' => {
+                    let Some(esc) = self.bump() else {
+                        return Err(self.error("unterminated string literal", line, col));
+                    };
+                    match esc {
+                        '"' => value.push('"'),
+                        '\\' => value.push('\\'),
+                        '/' => value.push('/'),
+                        'n' => value.push('\n'),
+                        't' => value.push('\t'),
+                        'r' => value.push('\r'),
+                        'u' => {
+                            let mut code = String::new();
+                            for _ in 0..4 {
+                                match self.bump() {
+                                    Some(h) if h.is_ascii_hexdigit() => code.push(h),
+                                    _ => {
+                                        return Err(self.error(
+                                            "invalid \\u escape (expected 4 hex digits)",
+                                            c_line,
+                                            c_col,
+                                        ));
+                                    }
+                                }
+                            }
+                            let cp = u32::from_str_radix(&code, 16).expect("hex digits");
+                            match char::from_u32(cp) {
+                                Some(ch) => value.push(ch),
+                                None => {
+                                    return Err(self.error(
+                                        format!("invalid unicode code point \\u{code}"),
+                                        c_line,
+                                        c_col,
+                                    ));
+                                }
+                            }
+                        }
+                        other => {
+                            return Err(self.error(
+                                format!("invalid escape sequence '\\{other}'"),
+                                c_line,
+                                c_col,
+                            ));
+                        }
+                    }
+                }
+                other => value.push(other),
+            }
+        }
+    }
+
+    /// Backtick raw string (no escape processing); the opening backtick
+    /// is already consumed.
+    fn lex_raw_string(&mut self, line: u32, col: u32) -> Result<Token, LexError> {
+        let mut value = String::new();
+        loop {
+            let Some(c) = self.bump() else {
+                return Err(self.error("unterminated raw string literal", line, col));
+            };
+            if c == '`' {
+                return Ok(Token::String(value));
+            }
+            value.push(c);
+        }
+    }
+
+    /// Read the digits (with optional fraction/exponent) of one number
+    /// starting with `first`.
+    fn read_number(&mut self, first: char, line: u32, col: u32) -> Result<f64, LexError> {
+        let mut text = String::from(first);
+        while let Some(&c) = self.chars.peek() {
+            if c.is_ascii_digit() {
+                text.push(c);
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        if self.chars.peek() == Some(&'.') {
+            text.push('.');
+            self.bump();
+            let mut has_fraction = false;
+            while let Some(&c) = self.chars.peek() {
+                if c.is_ascii_digit() {
+                    text.push(c);
+                    self.bump();
+                    has_fraction = true;
+                } else {
+                    break;
+                }
+            }
+            if !has_fraction {
+                return Err(self.error("expected digits after decimal point", line, col));
+            }
+        }
+        // Exponent: only when followed by digits (or sign + digits), so
+        // `5e` in a duration position is not misread. Peek-ahead here is
+        // single-char, so clone the iterator to look past the 'e'.
+        if matches!(self.chars.peek(), Some('e' | 'E')) {
+            let mut lookahead = self.chars.clone();
+            lookahead.next();
+            let next = lookahead.peek().copied();
+            let is_exponent = match next {
+                Some(d) if d.is_ascii_digit() => true,
+                Some('+') | Some('-') => {
+                    lookahead.next();
+                    matches!(lookahead.peek(), Some(d) if d.is_ascii_digit())
+                }
+                _ => false,
+            };
+            if is_exponent {
+                text.push(self.bump().expect("peeked 'e'"));
+                if matches!(self.chars.peek(), Some('+') | Some('-')) {
+                    text.push(self.bump().expect("peeked sign"));
+                }
+                while let Some(&c) = self.chars.peek() {
+                    if c.is_ascii_digit() {
+                        text.push(c);
+                        self.bump();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        text.parse::<f64>()
+            .map_err(|_| self.error(format!("invalid number '{text}'"), line, col))
+    }
+
+    /// A number, or a duration when a unit letter follows the number.
+    fn lex_number_or_duration(
+        &mut self,
+        first: char,
+        line: u32,
+        col: u32,
+    ) -> Result<Token, LexError> {
+        let value = self.read_number(first, line, col)?;
+
+        // 'µ' (as in µs) is alphabetic, so this also covers it.
+        if !matches!(self.chars.peek(), Some(c) if c.is_alphabetic()) {
+            return Ok(Token::Number(value));
+        }
+
+        // Duration: one or more (number, unit) pairs, e.g. `1h30m`.
+        let mut total_secs = 0.0_f64;
+        let mut pending = value;
+        loop {
+            let (u_line, u_col) = (self.line, self.col);
+            let mut unit = String::new();
+            while let Some(&c) = self.chars.peek() {
+                if c.is_alphabetic() || c == 'µ' {
+                    unit.push(c);
+                    self.bump();
+                } else {
+                    break;
+                }
+            }
+            let factor = match unit.as_str() {
+                "ns" => 1e-9,
+                "us" | "µs" => 1e-6,
+                "ms" => 1e-3,
+                "s" => 1.0,
+                "m" => 60.0,
+                "h" => 3600.0,
+                "d" => 86400.0,
+                "w" => 604800.0,
+                "y" => 31536000.0,
+                _ => {
+                    return Err(self.error(
+                        format!("invalid duration unit '{unit}'"),
+                        u_line,
+                        u_col,
+                    ));
+                }
+            };
+            total_secs += pending * factor;
+
+            // Another number directly attached continues the duration.
+            match self.chars.peek() {
+                Some(&c) if c.is_ascii_digit() => {
+                    let first = self.bump().expect("peeked digit");
+                    pending = self.read_number(first, self.line, self.col)?;
+                }
+                _ => break,
+            }
+        }
+        if total_secs < 0.0 {
+            return Err(self.error("negative duration", line, col));
+        }
+        Ok(Token::Duration(Duration::from_secs_f64(total_secs)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(input: &str) -> Vec<Token> {
+        tokenize(input)
+            .expect("tokenize")
+            .into_iter()
+            .map(|t| t.token)
+            .collect()
+    }
+
+    #[test]
+    fn lexes_stream_selector() {
+        assert_eq!(
+            tokens(r#"{job="api", env!="prod", pod=~"web-.*", ns!~"kube.*"}"#),
+            vec![
+                Token::LBrace,
+                Token::Ident("job".into()),
+                Token::Eq,
+                Token::String("api".into()),
+                Token::Comma,
+                Token::Ident("env".into()),
+                Token::Neq,
+                Token::String("prod".into()),
+                Token::Comma,
+                Token::Ident("pod".into()),
+                Token::Re,
+                Token::String("web-.*".into()),
+                Token::Comma,
+                Token::Ident("ns".into()),
+                Token::Nre,
+                Token::String("kube.*".into()),
+                Token::RBrace,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_line_filters_and_pipeline() {
+        assert_eq!(
+            tokens(
+                r#"{app="foo"} |= "error" != "timeout" |~ `exc.*` | json | line_format "{{.msg}}""#
+            ),
+            vec![
+                Token::LBrace,
+                Token::Ident("app".into()),
+                Token::Eq,
+                Token::String("foo".into()),
+                Token::RBrace,
+                Token::PipeExact,
+                Token::String("error".into()),
+                Token::Neq,
+                Token::String("timeout".into()),
+                Token::PipeRegex,
+                Token::String("exc.*".into()),
+                Token::Pipe,
+                Token::Ident("json".into()),
+                Token::Pipe,
+                Token::Ident("line_format".into()),
+                Token::String("{{.msg}}".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_metric_query() {
+        assert_eq!(
+            tokens(r#"sum by (level) (rate({app="foo"}[5m]))"#),
+            vec![
+                Token::Ident("sum".into()),
+                Token::By,
+                Token::LParen,
+                Token::Ident("level".into()),
+                Token::RParen,
+                Token::LParen,
+                Token::Ident("rate".into()),
+                Token::LParen,
+                Token::LBrace,
+                Token::Ident("app".into()),
+                Token::Eq,
+                Token::String("foo".into()),
+                Token::RBrace,
+                Token::LBracket,
+                Token::Duration(Duration::from_secs(300)),
+                Token::RBracket,
+                Token::RParen,
+                Token::RParen,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_unwrap_and_comparison() {
+        assert_eq!(
+            tokens(
+                r#"{app="foo"} | logfmt | unwrap duration_ms | __error__ = "" and latency > 1.5"#
+            ),
+            vec![
+                Token::LBrace,
+                Token::Ident("app".into()),
+                Token::Eq,
+                Token::String("foo".into()),
+                Token::RBrace,
+                Token::Pipe,
+                Token::Ident("logfmt".into()),
+                Token::Pipe,
+                Token::Unwrap,
+                Token::Ident("duration_ms".into()),
+                Token::Pipe,
+                Token::Ident("__error__".into()),
+                Token::Eq,
+                Token::String("".into()),
+                Token::And,
+                Token::Ident("latency".into()),
+                Token::Gt,
+                Token::Number(1.5),
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_compound_and_fractional_durations() {
+        assert_eq!(
+            tokens("[1h30m]"),
+            vec![
+                Token::LBracket,
+                Token::Duration(Duration::from_secs(5400)),
+                Token::RBracket,
+            ]
+        );
+        assert_eq!(
+            tokens("[1.5h]"),
+            vec![
+                Token::LBracket,
+                Token::Duration(Duration::from_secs(5400)),
+                Token::RBracket,
+            ]
+        );
+        assert_eq!(
+            tokens("[250ms]"),
+            vec![
+                Token::LBracket,
+                Token::Duration(Duration::from_millis(250)),
+                Token::RBracket,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_numbers_including_scientific_notation() {
+        assert_eq!(tokens("42"), vec![Token::Number(42.0)]);
+        assert_eq!(tokens("0.25"), vec![Token::Number(0.25)]);
+        assert_eq!(tokens("1e3"), vec![Token::Number(1000.0)]);
+        assert_eq!(tokens("2.5e-2"), vec![Token::Number(0.025)]);
+    }
+
+    #[test]
+    fn lexes_arithmetic_and_comparison_operators() {
+        assert_eq!(
+            tokens("+ - * / % ^ == >= <= > < = != =~ !~ |= |~ |"),
+            vec![
+                Token::Add,
+                Token::Sub,
+                Token::Mul,
+                Token::Div,
+                Token::Mod,
+                Token::Pow,
+                Token::CmpEq,
+                Token::Gte,
+                Token::Lte,
+                Token::Gt,
+                Token::Lt,
+                Token::Eq,
+                Token::Neq,
+                Token::Re,
+                Token::Nre,
+                Token::PipeExact,
+                Token::PipeRegex,
+                Token::Pipe,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_string_escapes() {
+        assert_eq!(
+            tokens(r#""a\"b\\c\n\tA""#),
+            vec![Token::String("a\"b\\c\n\tA".into())]
+        );
+    }
+
+    #[test]
+    fn raw_strings_keep_backslashes() {
+        assert_eq!(
+            tokens(r"`\d+(\.\d+)?`"),
+            vec![Token::String(r"\d+(\.\d+)?".into())]
+        );
+    }
+
+    #[test]
+    fn skips_comments_and_whitespace() {
+        assert_eq!(
+            tokens("{a=\"b\"} # trailing comment\n | json"),
+            vec![
+                Token::LBrace,
+                Token::Ident("a".into()),
+                Token::Eq,
+                Token::String("b".into()),
+                Token::RBrace,
+                Token::Pipe,
+                Token::Ident("json".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_position_of_tokens_and_errors() {
+        let spanned = tokenize("{job=\"a\"}\n  |= @").unwrap_err();
+        assert_eq!(spanned.line, 2);
+        assert_eq!(spanned.col, 6);
+        assert!(spanned.to_string().contains("line 2, column 6"));
+
+        let ok = tokenize("{job=\"a\"}\n  |= \"x\"").unwrap();
+        let pipe = ok.iter().find(|t| t.token == Token::PipeExact).unwrap();
+        assert_eq!((pipe.line, pipe.col), (2, 3));
+    }
+
+    #[test]
+    fn rejects_malformed_input() {
+        assert!(tokenize(r#"{job="unterminated"#).is_err());
+        assert!(tokenize(r"`unterminated").is_err());
+        assert!(tokenize(r#""bad \q escape""#).is_err());
+        assert!(tokenize("!x").is_err());
+        assert!(tokenize("5x").is_err());
+        assert!(tokenize("1.").is_err());
+        assert!(tokenize("@").is_err());
+    }
+
+    #[test]
+    fn keywords_are_case_sensitive() {
+        assert_eq!(
+            tokens("by BY By"),
+            vec![
+                Token::By,
+                Token::Ident("BY".into()),
+                Token::Ident("By".into()),
+            ]
+        );
+    }
+}

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -1,0 +1,18 @@
+//! # LogQL Front-End
+//!
+//! Lexing (and, in later phases, parsing and SQL transpilation) for
+//! Loki's LogQL query language. LogQL queries start from a stream
+//! selector (`{service_name="api"}`), optionally followed by a pipeline
+//! of line filters and parser stages, or wrapped in range/vector
+//! aggregations for metric queries.
+//!
+//! ## Modules
+//!
+//! - [`token`]: token type produced by the lexer
+//! - [`lexer`]: hand-rolled tokenizer with line/column error reporting
+
+pub mod lexer;
+pub mod token;
+
+pub use lexer::{LexError, tokenize};
+pub use token::{SpannedToken, Token};

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -18,7 +18,11 @@ pub mod lexer;
 pub mod parser;
 pub mod token;
 
-pub use ast::{LabelMatcher, LogQuery, MatchOp, PipelineStage, StreamSelector};
+pub use ast::{
+    FilterOp, FilterValue, LabelExtraction, LabelFilterExpr, LabelFilterPred, LabelFormat,
+    LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp, PipelineStage,
+    StreamSelector, Unwrap,
+};
 pub use lexer::{LexError, tokenize};
 pub use parser::{ParseError, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -10,9 +10,15 @@
 //!
 //! - [`token`]: token type produced by the lexer
 //! - [`lexer`]: hand-rolled tokenizer with line/column error reporting
+//! - [`ast`]: abstract syntax tree for parsed queries
+//! - [`parser`]: recursive-descent parser over the token stream
 
+pub mod ast;
 pub mod lexer;
+pub mod parser;
 pub mod token;
 
+pub use ast::{LabelMatcher, LogQuery, MatchOp, PipelineStage, StreamSelector};
 pub use lexer::{LexError, tokenize};
+pub use parser::{ParseError, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -1,10 +1,15 @@
 //! # LogQL Parser
 //!
 //! Recursive-descent parser over the [`crate::lexer`] token stream.
-//! This module currently covers stream selectors; pipeline stages and
-//! metric queries follow in later phases of the epic.
+//! Covers stream selectors and log pipelines (line filters, parser
+//! stages, label filters, formatters, unwrap); metric queries follow in
+//! a later phase of the epic.
 
-use crate::ast::{LabelMatcher, LogQuery, MatchOp, StreamSelector};
+use crate::ast::{
+    FilterOp, FilterValue, LabelExtraction, LabelFilterExpr, LabelFilterPred, LabelFormat,
+    LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp, PipelineStage,
+    StreamSelector, Unwrap,
+};
 use crate::lexer::{LexError, tokenize};
 use crate::token::{SpannedToken, Token};
 
@@ -27,16 +32,14 @@ impl From<LexError> for ParseError {
     }
 }
 
-/// Parse a full log query. Pipelines are not parsed yet, so any input
-/// beyond the stream selector is rejected (#371).
+/// Parse a full log query: a stream selector followed by an optional
+/// pipeline. Metric-query wrappers are not parsed here.
 pub fn parse_query(input: &str) -> Result<LogQuery, ParseError> {
     let mut parser = Parser::new(input)?;
     let selector = parser.parse_selector()?;
+    let pipeline = parser.parse_pipeline()?;
     parser.expect_eof()?;
-    Ok(LogQuery {
-        selector,
-        pipeline: Vec::new(),
-    })
+    Ok(LogQuery { selector, pipeline })
 }
 
 /// Parse a bare stream selector, as sent by the metadata endpoints'
@@ -106,10 +109,358 @@ impl Parser {
         match self.peek() {
             None => Ok(()),
             Some(t) => Err(ParseError {
-                message: format!("unexpected '{}' after stream selector", t.token),
+                message: format!("unexpected trailing token '{}'", t.token),
                 line: t.line,
                 col: t.col,
             }),
+        }
+    }
+
+    /// Parse zero or more pipeline stages following a stream selector.
+    ///
+    /// `|=`, `!=`, `|~`, `!~` introduce line filters; `|` introduces a
+    /// parser stage, formatter, `unwrap`, or label filter, resolved by
+    /// the token that follows.
+    pub(crate) fn parse_pipeline(&mut self) -> Result<Vec<PipelineStage>, ParseError> {
+        let mut stages = Vec::new();
+        loop {
+            match self.peek().map(|t| &t.token) {
+                Some(Token::PipeExact) => {
+                    self.next();
+                    stages.push(PipelineStage::LineFilter(
+                        self.parse_line_filter_value(LineFilterOp::Contains)?,
+                    ));
+                }
+                Some(Token::PipeRegex) => {
+                    self.next();
+                    stages.push(PipelineStage::LineFilter(
+                        self.parse_line_filter_value(LineFilterOp::Regex)?,
+                    ));
+                }
+                Some(Token::Neq) => {
+                    self.next();
+                    stages.push(PipelineStage::LineFilter(
+                        self.parse_line_filter_value(LineFilterOp::NotContains)?,
+                    ));
+                }
+                Some(Token::Nre) => {
+                    self.next();
+                    stages.push(PipelineStage::LineFilter(
+                        self.parse_line_filter_value(LineFilterOp::NotRegex)?,
+                    ));
+                }
+                Some(Token::Pipe) => {
+                    self.next();
+                    stages.push(self.parse_pipe_stage()?);
+                }
+                _ => break,
+            }
+        }
+        Ok(stages)
+    }
+
+    /// The string operand of a line filter.
+    fn parse_line_filter_value(&mut self, op: LineFilterOp) -> Result<LineFilter, ParseError> {
+        match self.next() {
+            Some(t) => match t.token {
+                Token::String(value) => Ok(LineFilter { op, value }),
+                ref other => Err(self.error_at(
+                    format!("expected quoted string after line filter, found '{other}'"),
+                    Some(&t),
+                )),
+            },
+            None => Err(self.error_at("expected quoted string after line filter", None)),
+        }
+    }
+
+    /// Parse the stage that follows a bare `|`.
+    fn parse_pipe_stage(&mut self) -> Result<PipelineStage, ParseError> {
+        // `unwrap` is a keyword; every other stage head is an identifier.
+        if let Some(t) = self.peek()
+            && t.token == Token::Unwrap
+        {
+            self.next();
+            return Ok(PipelineStage::Unwrap(self.parse_unwrap()?));
+        }
+
+        let head = match self.peek() {
+            Some(t) => match &t.token {
+                Token::Ident(name) => name.clone(),
+                other => {
+                    return Err(self.error_at(
+                        format!("expected a pipeline stage after '|', found '{other}'"),
+                        Some(t),
+                    ));
+                }
+            },
+            None => return Err(self.error_at("expected a pipeline stage after '|'", None)),
+        };
+
+        match head.as_str() {
+            "json" => {
+                self.next();
+                Ok(PipelineStage::Json(self.parse_label_extractions()?))
+            }
+            "logfmt" => {
+                self.next();
+                Ok(PipelineStage::Logfmt(self.parse_label_extractions()?))
+            }
+            "regexp" => {
+                self.next();
+                Ok(PipelineStage::Regexp(
+                    self.expect_string("a regexp pattern")?,
+                ))
+            }
+            "pattern" => {
+                self.next();
+                Ok(PipelineStage::Pattern(
+                    self.expect_string("a pattern string")?,
+                ))
+            }
+            "unpack" => {
+                self.next();
+                Ok(PipelineStage::Unpack)
+            }
+            "line_format" => {
+                self.next();
+                Ok(PipelineStage::LineFormat(
+                    self.expect_string("a line_format template")?,
+                ))
+            }
+            "label_format" => {
+                self.next();
+                Ok(PipelineStage::LabelFormat(self.parse_label_formats()?))
+            }
+            "drop" => {
+                self.next();
+                Ok(PipelineStage::Drop(self.parse_label_name_list()?))
+            }
+            "keep" => {
+                self.next();
+                Ok(PipelineStage::Keep(self.parse_label_name_list()?))
+            }
+            // Anything else is a label filter expression (it starts with
+            // a label name, which is an identifier).
+            _ => Ok(PipelineStage::LabelFilter(self.parse_label_filter_expr()?)),
+        }
+    }
+
+    fn expect_string(&mut self, what: &str) -> Result<String, ParseError> {
+        match self.next() {
+            Some(t) => match t.token {
+                Token::String(value) => Ok(value),
+                ref other => {
+                    Err(self.error_at(format!("expected {what}, found '{other}'"), Some(&t)))
+                }
+            },
+            None => Err(self.error_at(format!("expected {what}, found end of input"), None)),
+        }
+    }
+
+    /// An identifier or a keyword used as an identifier.
+    fn expect_ident(&mut self, what: &str) -> Result<String, ParseError> {
+        match self.next() {
+            Some(t) => match &t.token {
+                Token::Ident(name) => Ok(name.clone()),
+                other if Token::keyword_text(other).is_some() => {
+                    Ok(Token::keyword_text(other).expect("checked").to_string())
+                }
+                other => Err(self.error_at(format!("expected {what}, found '{other}'"), Some(&t))),
+            },
+            None => Err(self.error_at(format!("expected {what}, found end of input"), None)),
+        }
+    }
+
+    /// Optional comma-separated label extractions for `json`/`logfmt`.
+    /// Each is `name` or `name="expression"`. Stops at the next stage.
+    fn parse_label_extractions(&mut self) -> Result<Vec<LabelExtraction>, ParseError> {
+        let mut out = Vec::new();
+        // No extraction params when the next token isn't an identifier.
+        if !matches!(self.peek().map(|t| &t.token), Some(Token::Ident(_))) {
+            return Ok(out);
+        }
+        loop {
+            let name = self.expect_ident("a label name")?;
+            let expr = if matches!(self.peek().map(|t| &t.token), Some(Token::Eq)) {
+                self.next();
+                Some(self.expect_string("an extraction expression")?)
+            } else {
+                None
+            };
+            out.push(LabelExtraction { name, expr });
+            if matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+                self.next();
+            } else {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Comma-separated `label_format` assignments: `dst=src` (rename) or
+    /// `dst="template"`.
+    fn parse_label_formats(&mut self) -> Result<Vec<LabelFormat>, ParseError> {
+        let mut out = Vec::new();
+        loop {
+            let dst = self.expect_ident("a destination label")?;
+            self.expect(&Token::Eq, "'=' in label_format assignment")?;
+            let value = match self.next() {
+                Some(t) => match t.token {
+                    Token::String(tmpl) => LabelFormatValue::Template(tmpl),
+                    Token::Ident(src) => LabelFormatValue::Rename(src),
+                    ref other => {
+                        return Err(self.error_at(
+                            format!("expected a source label or template string, found '{other}'"),
+                            Some(&t),
+                        ));
+                    }
+                },
+                None => {
+                    return Err(self.error_at("expected a source label or template string", None));
+                }
+            };
+            out.push(LabelFormat { dst, value });
+            if matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+                self.next();
+            } else {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Comma-separated bare label names for `drop`/`keep`.
+    fn parse_label_name_list(&mut self) -> Result<Vec<String>, ParseError> {
+        let mut out = vec![self.expect_ident("a label name")?];
+        while matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+            self.next();
+            out.push(self.expect_ident("a label name")?);
+        }
+        Ok(out)
+    }
+
+    /// `unwrap <label>` or `unwrap <conversion>(<label>)`.
+    fn parse_unwrap(&mut self) -> Result<Unwrap, ParseError> {
+        let first = self.expect_ident("a label to unwrap")?;
+        if matches!(self.peek().map(|t| &t.token), Some(Token::LParen)) {
+            self.next();
+            let label = self.expect_ident("a label inside the conversion")?;
+            self.expect(&Token::RParen, "')' to close the unwrap conversion")?;
+            Ok(Unwrap {
+                label,
+                conversion: Some(first),
+            })
+        } else {
+            Ok(Unwrap {
+                label: first,
+                conversion: None,
+            })
+        }
+    }
+
+    /// Label-filter expression with `or` (loosest), then `and` / `,`.
+    fn parse_label_filter_expr(&mut self) -> Result<LabelFilterExpr, ParseError> {
+        let mut left = self.parse_label_filter_and()?;
+        while matches!(self.peek().map(|t| &t.token), Some(Token::Or)) {
+            self.next();
+            let right = self.parse_label_filter_and()?;
+            left = LabelFilterExpr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_label_filter_and(&mut self) -> Result<LabelFilterExpr, ParseError> {
+        let mut left = self.parse_label_filter_pred()?;
+        // Both `and` and a bare comma mean conjunction.
+        while matches!(
+            self.peek().map(|t| &t.token),
+            Some(Token::And) | Some(Token::Comma)
+        ) {
+            self.next();
+            let right = self.parse_label_filter_pred()?;
+            left = LabelFilterExpr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_label_filter_pred(&mut self) -> Result<LabelFilterExpr, ParseError> {
+        let name = self.expect_ident("a label name")?;
+        let (op_token, op) = match self.next() {
+            Some(t) => {
+                let op = match t.token {
+                    Token::Eq => FilterOp::Eq,
+                    Token::Neq => FilterOp::Neq,
+                    Token::Re => FilterOp::Re,
+                    Token::Nre => FilterOp::Nre,
+                    Token::CmpEq => FilterOp::CmpEq,
+                    Token::Gt => FilterOp::Gt,
+                    Token::Gte => FilterOp::Gte,
+                    Token::Lt => FilterOp::Lt,
+                    Token::Lte => FilterOp::Lte,
+                    ref other => {
+                        return Err(self.error_at(
+                            format!(
+                                "expected a comparison operator in label filter, found '{other}'"
+                            ),
+                            Some(&t),
+                        ));
+                    }
+                };
+                (t, op)
+            }
+            None => {
+                return Err(self.error_at("expected a comparison operator in label filter", None));
+            }
+        };
+
+        let value = self.parse_filter_value()?;
+        self.check_op_value(op, &value, &op_token)?;
+        Ok(LabelFilterExpr::Pred(LabelFilterPred { name, op, value }))
+    }
+
+    fn parse_filter_value(&mut self) -> Result<FilterValue, ParseError> {
+        match self.next() {
+            Some(t) => match t.token {
+                Token::String(s) => Ok(FilterValue::String(s)),
+                Token::Number(n) => Ok(FilterValue::Number(n)),
+                Token::Duration(d) => Ok(FilterValue::Duration(d)),
+                ref other => Err(self.error_at(
+                    format!(
+                        "expected a string, number, or duration in label filter, found '{other}'"
+                    ),
+                    Some(&t),
+                )),
+            },
+            None => Err(self.error_at("expected a value in label filter", None)),
+        }
+    }
+
+    /// Reject operator/value combinations that don't type-check: regex
+    /// matchers require a string; ordered comparisons require a number
+    /// or duration.
+    fn check_op_value(
+        &self,
+        op: FilterOp,
+        value: &FilterValue,
+        op_token: &SpannedToken,
+    ) -> Result<(), ParseError> {
+        let ok = match op {
+            FilterOp::Re | FilterOp::Nre => matches!(value, FilterValue::String(_)),
+            FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte => {
+                matches!(value, FilterValue::Number(_) | FilterValue::Duration(_))
+            }
+            FilterOp::Eq | FilterOp::Neq | FilterOp::CmpEq => true,
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(self.error_at(
+                format!(
+                    "operator '{}' is not valid for this value type",
+                    op_token.token
+                ),
+                Some(op_token),
+            ))
         }
     }
 
@@ -270,10 +621,16 @@ mod tests {
     }
 
     #[test]
-    fn rejects_pipeline_input_for_now() {
-        let err = parse_query(r#"{job="api"} |= "error""#).unwrap_err();
-        assert!(err.message.contains("after stream selector"), "{err}");
-        assert_eq!((err.line, err.col), (1, 13));
+    fn parse_query_parses_a_line_filter_pipeline() {
+        let query = parse_query(r#"{job="api"} |= "error""#).unwrap();
+        assert_eq!(query.selector.matchers.len(), 1);
+        assert_eq!(
+            query.pipeline,
+            vec![PipelineStage::LineFilter(LineFilter {
+                op: LineFilterOp::Contains,
+                value: "error".to_string(),
+            })]
+        );
     }
 
     #[test]
@@ -310,5 +667,227 @@ mod tests {
     fn lex_errors_propagate_with_position() {
         let err = parse_selector(r#"{job="unterminated}"#).unwrap_err();
         assert!(err.message.contains("unterminated"), "{err}");
+    }
+
+    // ---- pipeline stages (#371) ----
+
+    fn pipeline(input: &str) -> Vec<PipelineStage> {
+        parse_query(input).expect("parse").pipeline
+    }
+
+    fn line(op: LineFilterOp, value: &str) -> PipelineStage {
+        PipelineStage::LineFilter(LineFilter {
+            op,
+            value: value.to_string(),
+        })
+    }
+
+    #[test]
+    fn parses_all_line_filter_operators() {
+        assert_eq!(
+            pipeline(r#"{a="b"} |= "keep" != "drop" |~ "re" !~ "nre""#),
+            vec![
+                line(LineFilterOp::Contains, "keep"),
+                line(LineFilterOp::NotContains, "drop"),
+                line(LineFilterOp::Regex, "re"),
+                line(LineFilterOp::NotRegex, "nre"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_json_and_logfmt_with_and_without_extractions() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | json"#),
+            vec![PipelineStage::Json(vec![])]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | json status="response.status", method"#),
+            vec![PipelineStage::Json(vec![
+                LabelExtraction {
+                    name: "status".into(),
+                    expr: Some("response.status".into()),
+                },
+                LabelExtraction {
+                    name: "method".into(),
+                    expr: None,
+                },
+            ])]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | logfmt"#),
+            vec![PipelineStage::Logfmt(vec![])]
+        );
+    }
+
+    #[test]
+    fn parses_regexp_pattern_unpack() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | regexp "(?P<method>\\w+)""#),
+            vec![PipelineStage::Regexp(r"(?P<method>\w+)".into())]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | pattern "<method> <path>""#),
+            vec![PipelineStage::Pattern("<method> <path>".into())]
+        );
+        assert_eq!(pipeline(r#"{a="b"} | unpack"#), vec![PipelineStage::Unpack]);
+    }
+
+    #[test]
+    fn parses_formatters() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | line_format "{{.msg}}""#),
+            vec![PipelineStage::LineFormat("{{.msg}}".into())]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | label_format dst="{{.src}}", renamed=original"#),
+            vec![PipelineStage::LabelFormat(vec![
+                LabelFormat {
+                    dst: "dst".into(),
+                    value: LabelFormatValue::Template("{{.src}}".into()),
+                },
+                LabelFormat {
+                    dst: "renamed".into(),
+                    value: LabelFormatValue::Rename("original".into()),
+                },
+            ])]
+        );
+    }
+
+    #[test]
+    fn parses_drop_and_keep() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | drop level, source"#),
+            vec![PipelineStage::Drop(vec!["level".into(), "source".into()])]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | keep pod"#),
+            vec![PipelineStage::Keep(vec!["pod".into()])]
+        );
+    }
+
+    #[test]
+    fn parses_unwrap_forms() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | unwrap duration_ms"#),
+            vec![PipelineStage::Unwrap(Unwrap {
+                label: "duration_ms".into(),
+                conversion: None,
+            })]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | unwrap duration(latency)"#),
+            vec![PipelineStage::Unwrap(Unwrap {
+                label: "latency".into(),
+                conversion: Some("duration".into()),
+            })]
+        );
+    }
+
+    #[test]
+    fn parses_label_filter_string_and_numeric() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | level="error""#),
+            vec![PipelineStage::LabelFilter(LabelFilterExpr::Pred(
+                LabelFilterPred {
+                    name: "level".into(),
+                    op: FilterOp::Eq,
+                    value: FilterValue::String("error".into()),
+                }
+            ))]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | status >= 500"#),
+            vec![PipelineStage::LabelFilter(LabelFilterExpr::Pred(
+                LabelFilterPred {
+                    name: "status".into(),
+                    op: FilterOp::Gte,
+                    value: FilterValue::Number(500.0),
+                }
+            ))]
+        );
+    }
+
+    #[test]
+    fn label_filter_and_or_precedence() {
+        // `a and b or c` parses as `(a and b) or c`.
+        let stages = pipeline(r#"{x="y"} | a="1" and b="2" or c="3""#);
+        let PipelineStage::LabelFilter(expr) = &stages[0] else {
+            panic!("expected label filter");
+        };
+        match expr {
+            LabelFilterExpr::Or(left, right) => {
+                assert!(matches!(**left, LabelFilterExpr::And(_, _)));
+                assert!(matches!(**right, LabelFilterExpr::Pred(_)));
+            }
+            other => panic!("expected top-level Or, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_filter_comma_is_conjunction() {
+        let stages = pipeline(r#"{x="y"} | a="1", b="2""#);
+        let PipelineStage::LabelFilter(expr) = &stages[0] else {
+            panic!("expected label filter");
+        };
+        assert!(matches!(expr, LabelFilterExpr::And(_, _)));
+    }
+
+    #[test]
+    fn parses_full_pipeline_end_to_end() {
+        let query = parse_query(
+            r#"{app="api"} |= "error" | json | status >= 500 | line_format "{{.msg}}""#,
+        )
+        .unwrap();
+        assert_eq!(query.pipeline.len(), 4);
+        assert!(matches!(query.pipeline[0], PipelineStage::LineFilter(_)));
+        assert!(matches!(query.pipeline[1], PipelineStage::Json(_)));
+        assert!(matches!(query.pipeline[2], PipelineStage::LabelFilter(_)));
+        assert!(matches!(query.pipeline[3], PipelineStage::LineFormat(_)));
+    }
+
+    #[test]
+    fn duration_label_filter() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | logfmt | latency > 1s"#),
+            vec![
+                PipelineStage::Logfmt(vec![]),
+                PipelineStage::LabelFilter(LabelFilterExpr::Pred(LabelFilterPred {
+                    name: "latency".into(),
+                    op: FilterOp::Gt,
+                    value: FilterValue::Duration(std::time::Duration::from_secs(1)),
+                })),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_regex_operator_against_number() {
+        let err = parse_query(r#"{a="b"} | status =~ 500"#).unwrap_err();
+        assert!(
+            err.message.contains("not valid for this value type"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_ordered_comparison_against_string() {
+        let err = parse_query(r#"{a="b"} | level > "error""#).unwrap_err();
+        assert!(
+            err.message.contains("not valid for this value type"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_line_filter_without_string() {
+        let err = parse_query(r#"{a="b"} |= 5"#).unwrap_err();
+        assert!(err.message.contains("quoted string"), "{err}");
+    }
+
+    #[test]
+    fn rejects_dangling_pipe() {
+        let err = parse_query(r#"{a="b"} |"#).unwrap_err();
+        assert!(err.message.contains("pipeline stage after '|'"), "{err}");
     }
 }

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -1,0 +1,314 @@
+//! # LogQL Parser
+//!
+//! Recursive-descent parser over the [`crate::lexer`] token stream.
+//! This module currently covers stream selectors; pipeline stages and
+//! metric queries follow in later phases of the epic.
+
+use crate::ast::{LabelMatcher, LogQuery, MatchOp, StreamSelector};
+use crate::lexer::{LexError, tokenize};
+use crate::token::{SpannedToken, Token};
+
+/// Parse error with 1-based source position.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("{message} at line {line}, column {col}")]
+pub struct ParseError {
+    pub message: String,
+    pub line: u32,
+    pub col: u32,
+}
+
+impl From<LexError> for ParseError {
+    fn from(e: LexError) -> Self {
+        Self {
+            message: e.message,
+            line: e.line,
+            col: e.col,
+        }
+    }
+}
+
+/// Parse a full log query. Pipelines are not parsed yet, so any input
+/// beyond the stream selector is rejected (#371).
+pub fn parse_query(input: &str) -> Result<LogQuery, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let selector = parser.parse_selector()?;
+    parser.expect_eof()?;
+    Ok(LogQuery {
+        selector,
+        pipeline: Vec::new(),
+    })
+}
+
+/// Parse a bare stream selector, as sent by the metadata endpoints'
+/// `match[]` parameter.
+pub fn parse_selector(input: &str) -> Result<StreamSelector, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let selector = parser.parse_selector()?;
+    parser.expect_eof()?;
+    Ok(selector)
+}
+
+pub(crate) struct Parser {
+    tokens: Vec<SpannedToken>,
+    pos: usize,
+    /// Position just past the last token, for end-of-input errors.
+    end: (u32, u32),
+}
+
+impl Parser {
+    pub(crate) fn new(input: &str) -> Result<Self, ParseError> {
+        let tokens = tokenize(input)?;
+        let end = tokens
+            .last()
+            .map(|t| (t.line, t.col + t.token.to_string().len() as u32))
+            .unwrap_or((1, 1));
+        Ok(Self {
+            tokens,
+            pos: 0,
+            end,
+        })
+    }
+
+    fn peek(&self) -> Option<&SpannedToken> {
+        self.tokens.get(self.pos)
+    }
+
+    fn next(&mut self) -> Option<SpannedToken> {
+        let t = self.tokens.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn error_at(&self, message: impl Into<String>, at: Option<&SpannedToken>) -> ParseError {
+        let (line, col) = at.map(|t| (t.line, t.col)).unwrap_or(self.end);
+        ParseError {
+            message: message.into(),
+            line,
+            col,
+        }
+    }
+
+    fn expect(&mut self, expected: &Token, what: &str) -> Result<SpannedToken, ParseError> {
+        match self.next() {
+            Some(t) if &t.token == expected => Ok(t),
+            Some(t) => Err(ParseError {
+                message: format!("expected {what}, found '{}'", t.token),
+                line: t.line,
+                col: t.col,
+            }),
+            None => Err(self.error_at(format!("expected {what}, found end of input"), None)),
+        }
+    }
+
+    pub(crate) fn expect_eof(&mut self) -> Result<(), ParseError> {
+        match self.peek() {
+            None => Ok(()),
+            Some(t) => Err(ParseError {
+                message: format!("unexpected '{}' after stream selector", t.token),
+                line: t.line,
+                col: t.col,
+            }),
+        }
+    }
+
+    /// `{` [matcher {`,` matcher} [`,`]] `}`
+    pub(crate) fn parse_selector(&mut self) -> Result<StreamSelector, ParseError> {
+        self.expect(&Token::LBrace, "'{' to start a stream selector")?;
+
+        let mut matchers = Vec::new();
+        loop {
+            match self.peek() {
+                Some(t) if t.token == Token::RBrace => {
+                    self.next();
+                    break;
+                }
+                Some(_) => {
+                    matchers.push(self.parse_matcher()?);
+                    match self.next() {
+                        Some(t) if t.token == Token::Comma => continue,
+                        Some(t) if t.token == Token::RBrace => break,
+                        Some(t) => {
+                            return Err(self.error_at(
+                                format!(
+                                    "expected ',' or '}}' in stream selector, found '{}'",
+                                    t.token
+                                ),
+                                Some(&t),
+                            ));
+                        }
+                        None => {
+                            return Err(
+                                self.error_at("unclosed stream selector (missing '}')", None)
+                            );
+                        }
+                    }
+                }
+                None => {
+                    return Err(self.error_at("unclosed stream selector (missing '}')", None));
+                }
+            }
+        }
+
+        Ok(StreamSelector { matchers })
+    }
+
+    /// `name (= | != | =~ | !~) "value"`
+    fn parse_matcher(&mut self) -> Result<LabelMatcher, ParseError> {
+        let name = match self.next() {
+            // Grammar keywords are valid label names inside a selector
+            // (`{by="x"}` selects the label "by").
+            Some(t) => match &t.token {
+                Token::Ident(name) => name.clone(),
+                other if Token::keyword_text(other).is_some() => {
+                    Token::keyword_text(other).expect("checked").to_string()
+                }
+                other => {
+                    return Err(
+                        self.error_at(format!("expected label name, found '{other}'"), Some(&t))
+                    );
+                }
+            },
+            None => return Err(self.error_at("expected label name, found end of input", None)),
+        };
+
+        let op = match self.next() {
+            Some(t) => match t.token {
+                Token::Eq => MatchOp::Eq,
+                Token::Neq => MatchOp::Neq,
+                Token::Re => MatchOp::Re,
+                Token::Nre => MatchOp::Nre,
+                ref other => {
+                    return Err(self.error_at(
+                        format!("expected matcher operator (=, !=, =~, !~), found '{other}'"),
+                        Some(&t),
+                    ));
+                }
+            },
+            None => {
+                return Err(self.error_at("expected matcher operator, found end of input", None));
+            }
+        };
+
+        let value = match self.next() {
+            Some(t) => match t.token {
+                Token::String(value) => value,
+                ref other => {
+                    return Err(self.error_at(
+                        format!("expected quoted label value, found '{other}'"),
+                        Some(&t),
+                    ));
+                }
+            },
+            None => return Err(self.error_at("expected label value, found end of input", None)),
+        };
+
+        Ok(LabelMatcher { name, op, value })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matcher(name: &str, op: MatchOp, value: &str) -> LabelMatcher {
+        LabelMatcher {
+            name: name.to_string(),
+            op,
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_single_matcher() {
+        assert_eq!(
+            parse_selector(r#"{job="api"}"#).unwrap().matchers,
+            vec![matcher("job", MatchOp::Eq, "api")]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_matchers_with_all_operators() {
+        assert_eq!(
+            parse_selector(
+                r#"{service_name="frontend", level!="debug", namespace=~"prod-.*", env!~"dev.*"}"#
+            )
+            .unwrap()
+            .matchers,
+            vec![
+                matcher("service_name", MatchOp::Eq, "frontend"),
+                matcher("level", MatchOp::Neq, "debug"),
+                matcher("namespace", MatchOp::Re, "prod-.*"),
+                matcher("env", MatchOp::Nre, "dev.*"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_empty_selector_and_trailing_comma() {
+        assert!(parse_selector("{}").unwrap().matchers.is_empty());
+        assert_eq!(parse_selector(r#"{job="api",}"#).unwrap().matchers.len(), 1);
+    }
+
+    #[test]
+    fn keywords_are_valid_label_names() {
+        assert_eq!(
+            parse_selector(r#"{by="x", offset!="y"}"#).unwrap().matchers,
+            vec![
+                matcher("by", MatchOp::Eq, "x"),
+                matcher("offset", MatchOp::Neq, "y"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_query_returns_empty_pipeline() {
+        let query = parse_query(r#"{job="api"}"#).unwrap();
+        assert_eq!(query.selector.matchers.len(), 1);
+        assert!(query.pipeline.is_empty());
+    }
+
+    #[test]
+    fn rejects_pipeline_input_for_now() {
+        let err = parse_query(r#"{job="api"} |= "error""#).unwrap_err();
+        assert!(err.message.contains("after stream selector"), "{err}");
+        assert_eq!((err.line, err.col), (1, 13));
+    }
+
+    #[test]
+    fn rejects_missing_brace() {
+        let err = parse_selector(r#"{job="api""#).unwrap_err();
+        assert!(err.message.contains("missing '}'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_operator_and_value() {
+        let err = parse_selector(r#"{job}"#).unwrap_err();
+        assert!(err.message.contains("matcher operator"), "{err}");
+
+        let err = parse_selector(r#"{job=}"#).unwrap_err();
+        assert!(err.message.contains("quoted label value"), "{err}");
+
+        let err = parse_selector(r#"{job=api}"#).unwrap_err();
+        assert!(err.message.contains("quoted label value"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_selector() {
+        let err = parse_selector(r#"job="api""#).unwrap_err();
+        assert!(err.message.contains("'{'"), "{err}");
+    }
+
+    #[test]
+    fn error_positions_point_at_offending_token() {
+        let err = parse_selector("{job =\n  5}").unwrap_err();
+        assert_eq!((err.line, err.col), (2, 3));
+    }
+
+    #[test]
+    fn lex_errors_propagate_with_position() {
+        let err = parse_selector(r#"{job="unterminated}"#).unwrap_err();
+        assert!(err.message.contains("unterminated"), "{err}");
+    }
+}

--- a/src/logql/src/token.rs
+++ b/src/logql/src/token.rs
@@ -1,0 +1,190 @@
+//! # LogQL Tokens
+//!
+//! Token type produced by the [`crate::lexer`]. Function names
+//! (`rate`, `count_over_time`, `sum`, `json`, `line_format`, ...) are
+//! deliberately lexed as [`Token::Ident`] — LogQL treats them as
+//! context-dependent identifiers, so the parser resolves them where the
+//! grammar expects a function or parser stage. Only words that are
+//! reserved in the grammar itself become keyword tokens.
+
+use std::time::Duration;
+
+/// A single LogQL token.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Token {
+    // Literals
+    /// Double-quoted (escaped) or backtick-quoted (raw) string.
+    String(String),
+    /// Numeric literal, including floats and scientific notation.
+    Number(f64),
+    /// Duration literal such as `5m`, `1h30m`, or `1.5h`.
+    Duration(Duration),
+    /// Identifier: label names, function names, parser stage names.
+    Ident(String),
+
+    // Label matchers / equality
+    /// `=`
+    Eq,
+    /// `!=` (label matcher or line filter, depending on position)
+    Neq,
+    /// `=~`
+    Re,
+    /// `!~` (label matcher or line filter, depending on position)
+    Nre,
+
+    // Pipeline
+    /// `|=`
+    PipeExact,
+    /// `|~`
+    PipeRegex,
+    /// `|`
+    Pipe,
+
+    // Comparison (metric queries and label filter expressions)
+    /// `==`
+    CmpEq,
+    /// `>`
+    Gt,
+    /// `>=`
+    Gte,
+    /// `<`
+    Lt,
+    /// `<=`
+    Lte,
+
+    // Arithmetic
+    /// `+`
+    Add,
+    /// `-`
+    Sub,
+    /// `*`
+    Mul,
+    /// `/`
+    Div,
+    /// `%`
+    Mod,
+    /// `^`
+    Pow,
+
+    // Brackets
+    /// `{`
+    LBrace,
+    /// `}`
+    RBrace,
+    /// `(`
+    LParen,
+    /// `)`
+    RParen,
+    /// `[`
+    LBracket,
+    /// `]`
+    RBracket,
+
+    // Punctuation
+    /// `,`
+    Comma,
+
+    // Keywords (reserved words in the LogQL grammar)
+    /// `by`
+    By,
+    /// `without`
+    Without,
+    /// `on`
+    On,
+    /// `ignoring`
+    Ignoring,
+    /// `group_left`
+    GroupLeft,
+    /// `group_right`
+    GroupRight,
+    /// `unwrap`
+    Unwrap,
+    /// `offset`
+    Offset,
+    /// `bool`
+    Bool,
+    /// `and`
+    And,
+    /// `or`
+    Or,
+    /// `unless`
+    Unless,
+}
+
+impl Token {
+    /// Map a lexed word to its keyword token, if it is one.
+    pub(crate) fn keyword(word: &str) -> Option<Token> {
+        Some(match word {
+            "by" => Token::By,
+            "without" => Token::Without,
+            "on" => Token::On,
+            "ignoring" => Token::Ignoring,
+            "group_left" => Token::GroupLeft,
+            "group_right" => Token::GroupRight,
+            "unwrap" => Token::Unwrap,
+            "offset" => Token::Offset,
+            "bool" => Token::Bool,
+            "and" => Token::And,
+            "or" => Token::Or,
+            "unless" => Token::Unless,
+            _ => return None,
+        })
+    }
+}
+
+impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::String(s) => write!(f, "{s:?}"),
+            Token::Number(n) => write!(f, "{n}"),
+            Token::Duration(d) => write!(f, "{d:?}"),
+            Token::Ident(i) => write!(f, "{i}"),
+            Token::Eq => f.write_str("="),
+            Token::Neq => f.write_str("!="),
+            Token::Re => f.write_str("=~"),
+            Token::Nre => f.write_str("!~"),
+            Token::PipeExact => f.write_str("|="),
+            Token::PipeRegex => f.write_str("|~"),
+            Token::Pipe => f.write_str("|"),
+            Token::CmpEq => f.write_str("=="),
+            Token::Gt => f.write_str(">"),
+            Token::Gte => f.write_str(">="),
+            Token::Lt => f.write_str("<"),
+            Token::Lte => f.write_str("<="),
+            Token::Add => f.write_str("+"),
+            Token::Sub => f.write_str("-"),
+            Token::Mul => f.write_str("*"),
+            Token::Div => f.write_str("/"),
+            Token::Mod => f.write_str("%"),
+            Token::Pow => f.write_str("^"),
+            Token::LBrace => f.write_str("{"),
+            Token::RBrace => f.write_str("}"),
+            Token::LParen => f.write_str("("),
+            Token::RParen => f.write_str(")"),
+            Token::LBracket => f.write_str("["),
+            Token::RBracket => f.write_str("]"),
+            Token::Comma => f.write_str(","),
+            Token::By => f.write_str("by"),
+            Token::Without => f.write_str("without"),
+            Token::On => f.write_str("on"),
+            Token::Ignoring => f.write_str("ignoring"),
+            Token::GroupLeft => f.write_str("group_left"),
+            Token::GroupRight => f.write_str("group_right"),
+            Token::Unwrap => f.write_str("unwrap"),
+            Token::Offset => f.write_str("offset"),
+            Token::Bool => f.write_str("bool"),
+            Token::And => f.write_str("and"),
+            Token::Or => f.write_str("or"),
+            Token::Unless => f.write_str("unless"),
+        }
+    }
+}
+
+/// A token with its 1-based source position (position of the token's
+/// first character).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpannedToken {
+    pub token: Token,
+    pub line: u32,
+    pub col: u32,
+}

--- a/src/logql/src/token.rs
+++ b/src/logql/src/token.rs
@@ -130,6 +130,27 @@ impl Token {
             _ => return None,
         })
     }
+
+    /// The source text of a keyword token, if the token is one. Inverse
+    /// of [`Token::keyword`], used where the grammar allows keywords as
+    /// plain identifiers (e.g. label names).
+    pub(crate) fn keyword_text(token: &Token) -> Option<&'static str> {
+        Some(match token {
+            Token::By => "by",
+            Token::Without => "without",
+            Token::On => "on",
+            Token::Ignoring => "ignoring",
+            Token::GroupLeft => "group_left",
+            Token::GroupRight => "group_right",
+            Token::Unwrap => "unwrap",
+            Token::Offset => "offset",
+            Token::Bool => "bool",
+            Token::And => "and",
+            Token::Or => "or",
+            Token::Unless => "unless",
+            _ => return None,
+        })
+    }
 }
 
 impl std::fmt::Display for Token {


### PR DESCRIPTION
## Summary

Phase 2 of the LogQL epic begins: a hand-rolled lexer for LogQL, shipped as a **standalone `logql` workspace crate** (deliberate deviation from #369's `src/common/src/logql/` layout — the LogQL front-end is self-contained and will be consumed by the router/querier, so it gets the same treatment as `tempo-api`/`loki-api` rather than growing `common`).

- `token.rs` — `Token` enum covering literals (escaped + raw strings, numbers with scientific notation, compound/fractional durations like `1h30m`/`1.5h`), all operators (label matchers, line filters, comparison, arithmetic), brackets, and grammar keywords (`by`, `without`, `on`, `ignoring`, `group_left/right`, `unwrap`, `offset`, `bool`, `and`, `or`, `unless`)
- `lexer.rs` — single-pass tokenizer with 1-based line/column tracking on every token and error
- Design choice: function and parser-stage names (`rate`, `count_over_time`, `json`, `line_format`, ...) lex as `Ident` and are resolved by the parser, mirroring Loki's own lexer — this keeps the token set stable as stages are added
- A number glued to letters must form a valid duration (`5x` is an error, not `5` + `x`)

## Testing

13 unit tests covering representative queries (selectors, pipelines, metric aggregations, unwrap + comparisons), duration forms, escapes, comments, position reporting, and malformed-input rejection.

Refs #369 (part of #366)