### PR TITLE
fix(docker): include loki-api in dependency-caching stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY src/writer/Cargo.toml src/writer/
 COPY src/querier/Cargo.toml src/querier/
 COPY src/compactor/Cargo.toml src/compactor/
 COPY src/common/Cargo.toml src/common/
+COPY src/loki-api/Cargo.toml src/loki-api/
 COPY src/pyroscope-api/Cargo.toml src/pyroscope-api/
 COPY src/tempo-api/Cargo.toml src/tempo-api/
 COPY src/signaldb-bin/Cargo.toml src/signaldb-bin/
@@ -47,6 +48,7 @@ RUN mkdir -p src/acceptor/src && echo "fn main() {}" > src/acceptor/src/main.rs 
     mkdir -p src/compactor/src && echo "fn main() {}" > src/compactor/src/main.rs && \
     echo "pub fn dummy() {}" > src/compactor/src/lib.rs && \
     mkdir -p src/common/src && echo "pub fn dummy() {}" > src/common/src/lib.rs && \
+    mkdir -p src/loki-api/src && echo "pub fn dummy() {}" > src/loki-api/src/lib.rs && \
     mkdir -p src/pyroscope-api/src && echo "pub fn dummy() {}" > src/pyroscope-api/src/lib.rs && \
     mkdir -p src/tempo-api/src && echo "pub fn dummy() {}" > src/tempo-api/src/lib.rs && \
     mkdir -p src/signaldb-bin/src && echo "fn main() {}" > src/signaldb-bin/src/main.rs && \


### PR DESCRIPTION
The Docker build's dependency-caching stage enumerates every workspace crate manifest; `loki-api` (added in #650) was missing, so `cargo build --release` failed in the builder stage — same failure mode de4eb57 fixed for `pyroscope-api`.

Adds the `COPY src/loki-api/Cargo.toml` line and the dummy `lib.rs` to the caching stage.