### PR TITLE
docs(architecture): drop duplicated pyroscope-api workspace rows

### DIFF
--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -21,7 +21,6 @@ sources:
 | **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
-| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, dataset management |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -79,7 +79,6 @@ Parquet storage with DataFusion query processing:
 | **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
-| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope HTTP API response types (flamebearer format) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI and TUI for tenant, API key, and dataset management |


### PR DESCRIPTION
#651 and #650 landed concurrently and both added a `pyroscope-api` row to the workspace member tables in the architecture overview and the crate-map skill. Keep one (the #651 wording).