### PR TITLE
feat(logql): parse stream selectors into an AST

### DIFF
--- a/src/logql/src/ast.rs
+++ b/src/logql/src/ast.rs
@@ -1,0 +1,58 @@
+//! # LogQL AST
+//!
+//! Abstract syntax tree for parsed LogQL queries. The tree mirrors the
+//! shape of the language: a log query is a stream selector followed by
+//! an optional pipeline; metric queries (added with the metric-query
+//! parser) wrap log queries in range and vector aggregations.
+
+/// A parsed log query: stream selector plus pipeline stages.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogQuery {
+    pub selector: StreamSelector,
+    pub pipeline: Vec<PipelineStage>,
+}
+
+/// The `{...}` stream selector: a conjunction of label matchers.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct StreamSelector {
+    pub matchers: Vec<LabelMatcher>,
+}
+
+/// One label matcher, e.g. `service_name=~"web-.*"`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelMatcher {
+    pub name: String,
+    pub op: MatchOp,
+    pub value: String,
+}
+
+/// Label matching operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchOp {
+    /// `=`
+    Eq,
+    /// `!=`
+    Neq,
+    /// `=~`
+    Re,
+    /// `!~`
+    Nre,
+}
+
+impl std::fmt::Display for MatchOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            MatchOp::Eq => "=",
+            MatchOp::Neq => "!=",
+            MatchOp::Re => "=~",
+            MatchOp::Nre => "!~",
+        })
+    }
+}
+
+/// One stage of a log pipeline (`|= "err"`, `| json`, ...).
+///
+/// Variants land with the pipeline-stage parser (#371); the enum exists
+/// so [`LogQuery`] carries a stable shape from the start.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PipelineStage {}

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -10,9 +10,15 @@
 //!
 //! - [`token`]: token type produced by the lexer
 //! - [`lexer`]: hand-rolled tokenizer with line/column error reporting
+//! - [`ast`]: abstract syntax tree for parsed queries
+//! - [`parser`]: recursive-descent parser over the token stream
 
+pub mod ast;
 pub mod lexer;
+pub mod parser;
 pub mod token;
 
+pub use ast::{LabelMatcher, LogQuery, MatchOp, PipelineStage, StreamSelector};
 pub use lexer::{LexError, tokenize};
+pub use parser::{ParseError, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -1,0 +1,314 @@
+//! # LogQL Parser
+//!
+//! Recursive-descent parser over the [`crate::lexer`] token stream.
+//! This module currently covers stream selectors; pipeline stages and
+//! metric queries follow in later phases of the epic.
+
+use crate::ast::{LabelMatcher, LogQuery, MatchOp, StreamSelector};
+use crate::lexer::{LexError, tokenize};
+use crate::token::{SpannedToken, Token};
+
+/// Parse error with 1-based source position.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("{message} at line {line}, column {col}")]
+pub struct ParseError {
+    pub message: String,
+    pub line: u32,
+    pub col: u32,
+}
+
+impl From<LexError> for ParseError {
+    fn from(e: LexError) -> Self {
+        Self {
+            message: e.message,
+            line: e.line,
+            col: e.col,
+        }
+    }
+}
+
+/// Parse a full log query. Pipelines are not parsed yet, so any input
+/// beyond the stream selector is rejected (#371).
+pub fn parse_query(input: &str) -> Result<LogQuery, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let selector = parser.parse_selector()?;
+    parser.expect_eof()?;
+    Ok(LogQuery {
+        selector,
+        pipeline: Vec::new(),
+    })
+}
+
+/// Parse a bare stream selector, as sent by the metadata endpoints'
+/// `match[]` parameter.
+pub fn parse_selector(input: &str) -> Result<StreamSelector, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let selector = parser.parse_selector()?;
+    parser.expect_eof()?;
+    Ok(selector)
+}
+
+pub(crate) struct Parser {
+    tokens: Vec<SpannedToken>,
+    pos: usize,
+    /// Position just past the last token, for end-of-input errors.
+    end: (u32, u32),
+}
+
+impl Parser {
+    pub(crate) fn new(input: &str) -> Result<Self, ParseError> {
+        let tokens = tokenize(input)?;
+        let end = tokens
+            .last()
+            .map(|t| (t.line, t.col + t.token.to_string().len() as u32))
+            .unwrap_or((1, 1));
+        Ok(Self {
+            tokens,
+            pos: 0,
+            end,
+        })
+    }
+
+    fn peek(&self) -> Option<&SpannedToken> {
+        self.tokens.get(self.pos)
+    }
+
+    fn next(&mut self) -> Option<SpannedToken> {
+        let t = self.tokens.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn error_at(&self, message: impl Into<String>, at: Option<&SpannedToken>) -> ParseError {
+        let (line, col) = at.map(|t| (t.line, t.col)).unwrap_or(self.end);
+        ParseError {
+            message: message.into(),
+            line,
+            col,
+        }
+    }
+
+    fn expect(&mut self, expected: &Token, what: &str) -> Result<SpannedToken, ParseError> {
+        match self.next() {
+            Some(t) if &t.token == expected => Ok(t),
+            Some(t) => Err(ParseError {
+                message: format!("expected {what}, found '{}'", t.token),
+                line: t.line,
+                col: t.col,
+            }),
+            None => Err(self.error_at(format!("expected {what}, found end of input"), None)),
+        }
+    }
+
+    pub(crate) fn expect_eof(&mut self) -> Result<(), ParseError> {
+        match self.peek() {
+            None => Ok(()),
+            Some(t) => Err(ParseError {
+                message: format!("unexpected '{}' after stream selector", t.token),
+                line: t.line,
+                col: t.col,
+            }),
+        }
+    }
+
+    /// `{` [matcher {`,` matcher} [`,`]] `}`
+    pub(crate) fn parse_selector(&mut self) -> Result<StreamSelector, ParseError> {
+        self.expect(&Token::LBrace, "'{' to start a stream selector")?;
+
+        let mut matchers = Vec::new();
+        loop {
+            match self.peek() {
+                Some(t) if t.token == Token::RBrace => {
+                    self.next();
+                    break;
+                }
+                Some(_) => {
+                    matchers.push(self.parse_matcher()?);
+                    match self.next() {
+                        Some(t) if t.token == Token::Comma => continue,
+                        Some(t) if t.token == Token::RBrace => break,
+                        Some(t) => {
+                            return Err(self.error_at(
+                                format!(
+                                    "expected ',' or '}}' in stream selector, found '{}'",
+                                    t.token
+                                ),
+                                Some(&t),
+                            ));
+                        }
+                        None => {
+                            return Err(
+                                self.error_at("unclosed stream selector (missing '}')", None)
+                            );
+                        }
+                    }
+                }
+                None => {
+                    return Err(self.error_at("unclosed stream selector (missing '}')", None));
+                }
+            }
+        }
+
+        Ok(StreamSelector { matchers })
+    }
+
+    /// `name (= | != | =~ | !~) "value"`
+    fn parse_matcher(&mut self) -> Result<LabelMatcher, ParseError> {
+        let name = match self.next() {
+            // Grammar keywords are valid label names inside a selector
+            // (`{by="x"}` selects the label "by").
+            Some(t) => match &t.token {
+                Token::Ident(name) => name.clone(),
+                other if Token::keyword_text(other).is_some() => {
+                    Token::keyword_text(other).expect("checked").to_string()
+                }
+                other => {
+                    return Err(
+                        self.error_at(format!("expected label name, found '{other}'"), Some(&t))
+                    );
+                }
+            },
+            None => return Err(self.error_at("expected label name, found end of input", None)),
+        };
+
+        let op = match self.next() {
+            Some(t) => match t.token {
+                Token::Eq => MatchOp::Eq,
+                Token::Neq => MatchOp::Neq,
+                Token::Re => MatchOp::Re,
+                Token::Nre => MatchOp::Nre,
+                ref other => {
+                    return Err(self.error_at(
+                        format!("expected matcher operator (=, !=, =~, !~), found '{other}'"),
+                        Some(&t),
+                    ));
+                }
+            },
+            None => {
+                return Err(self.error_at("expected matcher operator, found end of input", None));
+            }
+        };
+
+        let value = match self.next() {
+            Some(t) => match t.token {
+                Token::String(value) => value,
+                ref other => {
+                    return Err(self.error_at(
+                        format!("expected quoted label value, found '{other}'"),
+                        Some(&t),
+                    ));
+                }
+            },
+            None => return Err(self.error_at("expected label value, found end of input", None)),
+        };
+
+        Ok(LabelMatcher { name, op, value })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matcher(name: &str, op: MatchOp, value: &str) -> LabelMatcher {
+        LabelMatcher {
+            name: name.to_string(),
+            op,
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_single_matcher() {
+        assert_eq!(
+            parse_selector(r#"{job="api"}"#).unwrap().matchers,
+            vec![matcher("job", MatchOp::Eq, "api")]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_matchers_with_all_operators() {
+        assert_eq!(
+            parse_selector(
+                r#"{service_name="frontend", level!="debug", namespace=~"prod-.*", env!~"dev.*"}"#
+            )
+            .unwrap()
+            .matchers,
+            vec![
+                matcher("service_name", MatchOp::Eq, "frontend"),
+                matcher("level", MatchOp::Neq, "debug"),
+                matcher("namespace", MatchOp::Re, "prod-.*"),
+                matcher("env", MatchOp::Nre, "dev.*"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_empty_selector_and_trailing_comma() {
+        assert!(parse_selector("{}").unwrap().matchers.is_empty());
+        assert_eq!(parse_selector(r#"{job="api",}"#).unwrap().matchers.len(), 1);
+    }
+
+    #[test]
+    fn keywords_are_valid_label_names() {
+        assert_eq!(
+            parse_selector(r#"{by="x", offset!="y"}"#).unwrap().matchers,
+            vec![
+                matcher("by", MatchOp::Eq, "x"),
+                matcher("offset", MatchOp::Neq, "y"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_query_returns_empty_pipeline() {
+        let query = parse_query(r#"{job="api"}"#).unwrap();
+        assert_eq!(query.selector.matchers.len(), 1);
+        assert!(query.pipeline.is_empty());
+    }
+
+    #[test]
+    fn rejects_pipeline_input_for_now() {
+        let err = parse_query(r#"{job="api"} |= "error""#).unwrap_err();
+        assert!(err.message.contains("after stream selector"), "{err}");
+        assert_eq!((err.line, err.col), (1, 13));
+    }
+
+    #[test]
+    fn rejects_missing_brace() {
+        let err = parse_selector(r#"{job="api""#).unwrap_err();
+        assert!(err.message.contains("missing '}'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_operator_and_value() {
+        let err = parse_selector(r#"{job}"#).unwrap_err();
+        assert!(err.message.contains("matcher operator"), "{err}");
+
+        let err = parse_selector(r#"{job=}"#).unwrap_err();
+        assert!(err.message.contains("quoted label value"), "{err}");
+
+        let err = parse_selector(r#"{job=api}"#).unwrap_err();
+        assert!(err.message.contains("quoted label value"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_selector() {
+        let err = parse_selector(r#"job="api""#).unwrap_err();
+        assert!(err.message.contains("'{'"), "{err}");
+    }
+
+    #[test]
+    fn error_positions_point_at_offending_token() {
+        let err = parse_selector("{job =\n  5}").unwrap_err();
+        assert_eq!((err.line, err.col), (2, 3));
+    }
+
+    #[test]
+    fn lex_errors_propagate_with_position() {
+        let err = parse_selector(r#"{job="unterminated}"#).unwrap_err();
+        assert!(err.message.contains("unterminated"), "{err}");
+    }
+}

--- a/src/logql/src/token.rs
+++ b/src/logql/src/token.rs
@@ -130,6 +130,27 @@ impl Token {
             _ => return None,
         })
     }
+
+    /// The source text of a keyword token, if the token is one. Inverse
+    /// of [`Token::keyword`], used where the grammar allows keywords as
+    /// plain identifiers (e.g. label names).
+    pub(crate) fn keyword_text(token: &Token) -> Option<&'static str> {
+        Some(match token {
+            Token::By => "by",
+            Token::Without => "without",
+            Token::On => "on",
+            Token::Ignoring => "ignoring",
+            Token::GroupLeft => "group_left",
+            Token::GroupRight => "group_right",
+            Token::Unwrap => "unwrap",
+            Token::Offset => "offset",
+            Token::Bool => "bool",
+            Token::And => "and",
+            Token::Or => "or",
+            Token::Unless => "unless",
+            _ => return None,
+        })
+    }
 }
 
 impl std::fmt::Display for Token {


### PR DESCRIPTION
## Summary

Phase 2 of the LogQL epic, part 2 (stacked on #654). Adds the AST and a recursive-descent parser covering LogQL **stream selectors** — the `{...}` head of every query.

- `ast.rs` — `LogQuery`, `StreamSelector`, `LabelMatcher`, `MatchOp` (`=`, `!=`, `=~`, `!~`), and a placeholder `PipelineStage` enum so `LogQuery` carries a stable shape from the start
- `parser.rs` — recursive descent over the lexer's token stream, `ParseError` with 1-based line/column (lexer errors propagate with position)
- `parse_selector` serves the metadata endpoints' `match[]` parameter; `parse_query` builds a `LogQuery` and (for now) rejects any pipeline input, so the error surface is honest until stage parsing lands (#371)
- Grammar keywords (`by`, `offset`, ...) are accepted as label names inside a selector, matching Loki

## Testing

10 parser tests: single/multiple matchers, all four operators, empty selector, trailing comma, keywords-as-labels, and error cases (missing brace/operator/value, unclosed selector, pipeline rejection, propagated lex errors) with asserted positions.

Refs #370 (part of #366)