### PR TITLE
chore(hooks): split doc-freshness check into TaskCompleted gate + Stop backstop

### DIFF
--- a/.claude/hooks/doc-freshness-common.sh
+++ b/.claude/hooks/doc-freshness-common.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Shared logic for the doc-freshness hooks, sourced by both wrappers:
+#   doc-freshness-taskcompleted.sh — hard gate at milestone (task) completion
+#   doc-freshness-stop.sh          — soft reminder at turn end, for debt that
+#                                    never passed through a task completion
+#
+# Reads the hook JSON from stdin, locates the repo the session is working in,
+# runs the freshness checker, and populates:
+#   DF_REPORT     — the checker's findings (empty when docs are fresh)
+#   DF_DIGEST     — stable digest of the findings, for per-debt-set dedup
+#   DF_SESSION_ID — session id (or "unknown")
+#
+# df_collect returns 0 when there is doc debt to act on, non-zero when there is
+# nothing to do (docs fresh, or the checker is unavailable) — callers should
+# exit 0 in that case.
+set -uo pipefail
+
+df_collect() {
+    local input session_cwd repo_root checker
+    input=$(cat)
+
+    DF_SESSION_ID=$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    [[ -z "$DF_SESSION_ID" ]] && DF_SESSION_ID="unknown"
+
+    # Prefer the cwd from the hook input: in a linked worktree the session cwd is
+    # the worktree, while CLAUDE_PROJECT_DIR may point at the main checkout.
+    session_cwd=$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    if [[ -n "$session_cwd" && -d "$session_cwd" ]]; then
+        cd "$session_cwd" || return 1
+    elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+        cd "$CLAUDE_PROJECT_DIR" || return 1
+    fi
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+
+    # The checker cds to the toplevel of the repo it runs in, so invoking the
+    # worktree's own copy (when present) checks the worktree's diff and docs.
+    checker="$repo_root/scripts/check-doc-freshness.sh"
+    [[ -x "$checker" ]] || checker="${CLAUDE_PROJECT_DIR:-$repo_root}/scripts/check-doc-freshness.sh"
+    [[ -x "$checker" ]] || return 1
+
+    DF_REPORT=$("$checker" 2>/dev/null)
+    [[ -z "$DF_REPORT" ]] && return 1
+
+    DF_DIGEST=$(printf '%s' "$DF_REPORT" | cksum | tr -d ' \t')
+    return 0
+}
+
+# Marker path for a given kind (block | soft) and the current debt digest.
+# The block hook owns the "block" marker; the soft hook checks it too, so a debt
+# set already hard-blocked at a milestone is not softly re-reported at turn end.
+df_marker() {
+    printf '%s/claude-doc-freshness-%s-%s-%s' "${TMPDIR:-/tmp}" "$1" "$DF_SESSION_ID" "$DF_DIGEST"
+}

--- a/.claude/hooks/doc-freshness-stop.sh
+++ b/.claude/hooks/doc-freshness-stop.sh
@@ -1,51 +1,31 @@
 #!/usr/bin/env bash
-# Stop hook: block ending the turn when the session's diff touches source files
-# that living docs (per their `sources:` frontmatter) claim to describe, but the
-# docs were not updated. Blocks at most once per distinct debt set per session —
-# the agent may update the docs or consciously wave off, but not forget.
+# Stop hook: soft backstop for the doc-freshness check. Fires at every turn end,
+# but never blocks — it only injects a non-blocking reminder so long-running
+# goals are not interrupted mid-flight. The hard gate lives in the TaskCompleted
+# hook; this catches debt that never passed through a task completion (a taskless
+# session, or the un-tasked tail of a goal).
+#
+# Reminds at most once per distinct debt set per session, and stays silent for
+# any debt set the TaskCompleted hook already hard-blocked (shared "block"
+# marker), so the two hooks never nag about the same thing twice.
 set -uo pipefail
 
-input=$(cat)
+source "$(dirname "${BASH_SOURCE[0]}")/doc-freshness-common.sh"
 
-# Never re-block while the agent is already continuing because of this hook.
-if [[ "$input" == *'"stop_hook_active":true'* || "$input" == *'"stop_hook_active": true'* ]]; then
-    exit 0
-fi
+df_collect || exit 0
 
-session_id=$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-[[ -z "$session_id" ]] && session_id="unknown"
+# Already hard-blocked at a milestone this session — don't softly repeat it.
+[[ -f "$(df_marker block)" ]] && exit 0
 
-# Run against the repo the session is actually working in. In a linked worktree
-# the session cwd is the worktree, while CLAUDE_PROJECT_DIR may point at the
-# main checkout — prefer the cwd from the hook input.
-session_cwd=$(printf '%s' "$input" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-if [[ -n "$session_cwd" && -d "$session_cwd" ]]; then
-    cd "$session_cwd"
-elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-    cd "$CLAUDE_PROJECT_DIR"
-fi
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
-
-# The checker cds to the toplevel of the repo it runs in, so invoking the
-# worktree's own copy (when present) checks the worktree's diff and docs.
-checker="$repo_root/scripts/check-doc-freshness.sh"
-[[ -x "$checker" ]] || checker="${CLAUDE_PROJECT_DIR:-$repo_root}/scripts/check-doc-freshness.sh"
-[[ -x "$checker" ]] || exit 0
-
-report=$("$checker" 2>/dev/null)
-[[ -z "$report" ]] && exit 0
-
-# One nag per distinct debt set: key marker on session + report content.
-digest=$(printf '%s' "$report" | cksum | tr -d ' \t')
-marker="${TMPDIR:-/tmp}/claude-doc-freshness-${session_id}-${digest}"
+marker=$(df_marker soft)
 [[ -f "$marker" ]] && exit 0
 touch "$marker"
 
-reason="Doc-freshness check: this session's changes touch files that the following living docs declare as sources, but the docs were not updated:
+context="Doc-freshness reminder: this branch's changes touch files that the following living docs declare as sources, but the docs were not updated:
 
-$report
+$DF_REPORT
 
-Invoke the 'docs' skill for routing guidance, then either update the affected docs (and .claude/skills entries) or state explicitly in your final message why no documentation change is needed. This check will not repeat for the same set of findings."
+Before wrapping up, invoke the 'docs' skill for routing guidance, then either update the affected docs (and .claude/skills entries) or note why no documentation change is needed. This reminder will not repeat for the same set of findings."
 
-python3 -c 'import json,sys; print(json.dumps({"decision":"block","reason":sys.argv[1]}))' "$reason"
+python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":sys.argv[1]}}))' "$context"
 exit 0

--- a/.claude/hooks/doc-freshness-taskcompleted.sh
+++ b/.claude/hooks/doc-freshness-taskcompleted.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# TaskCompleted hook: block marking a task complete when the branch diff touches
+# source files that living docs (per their `sources:` frontmatter) claim to
+# describe, but the docs were not updated. This is the hard gate — it fires at
+# milestone boundaries rather than every turn, so long-running goals are not
+# interrupted at arbitrary points. Blocks at most once per distinct debt set per
+# session: the agent may update the docs or consciously wave off, then re-mark
+# the task complete.
+set -uo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/doc-freshness-common.sh"
+
+df_collect || exit 0
+
+marker=$(df_marker block)
+[[ -f "$marker" ]] && exit 0
+touch "$marker"
+
+reason="Doc-freshness check: this branch's changes touch files that the following living docs declare as sources, but the docs were not updated:
+
+$DF_REPORT
+
+Invoke the 'docs' skill for routing guidance, then either update the affected docs (and .claude/skills entries) or state explicitly why no documentation change is needed before completing this task. This check will not repeat for the same set of findings."
+
+python3 -c 'import json,sys; print(json.dumps({"decision":"block","reason":sys.argv[1]}))' "$reason"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/doc-freshness-taskcompleted.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Why

The doc-freshness check ran only as a `Stop` hook. `Stop` fires at **every turn end** and re-evaluates the whole branch-vs-`main` diff, so on long-running goals it kept re-surfacing the same accumulated doc debt and blocking at arbitrary mid-goal points.

## What

Split the single Stop hook into a hard gate + soft backstop, sharing one library:

- **`doc-freshness-common.sh`** *(new)* — shared collect/diff/dedup helpers (`df_collect`, `df_marker`). Worktree-aware repo resolution and the `check-doc-freshness.sh` invocation now live in one place.
- **`doc-freshness-taskcompleted.sh`** *(new)* — **hard gate**. On `TaskCompleted` it emits `decision: block` when the branch diff leaves doc debt, so the check lands at milestone boundaries instead of every turn. Long goals aren't interrupted mid-flight.
- **`doc-freshness-stop.sh`** *(rewritten)* — **soft backstop**. On `Stop` it now emits non-blocking `hookSpecificOutput.additionalContext` instead of blocking, catching debt that never passed through a task completion (taskless session, or the un-tasked tail of a goal).
- **`settings.json`** — registers the new `TaskCompleted` hook; `Stop` still points at its (now non-blocking) script.

The two hooks share a `block` marker, so a debt set hard-blocked at a milestone is never softly re-reported at turn end, and neither nags twice for the same debt set.

## Verification

Ran all wrappers end-to-end (introduced a real `Cargo.toml` change to trigger debt, then reverted):

- Clean branch → both hooks silent
- `TaskCompleted` with debt → `decision: block`; repeat → silent (dedup)
- `Stop` after a hard block → silent (shared marker)
- Fresh session, `Stop` first → `additionalContext` reminder; repeat → silent

## Tradeoffs

- The `Stop` reminder no longer forces a stop — it's injected context rather than a hard block.
- The hard gate only fires if the goal uses the task system; taskless goals get only the soft reminder.