### PR TITLE
feat(logql): parse metric queries with a real-world corpus

### DIFF
--- a/src/logql/src/ast.rs
+++ b/src/logql/src/ast.rs
@@ -128,6 +128,16 @@ pub enum LabelFormatValue {
     Template(String),
 }
 
+/// A `by`/`without` grouping clause, shared by vector aggregations and
+/// unwrapped range aggregations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Grouping {
+    /// `true` for `without (...)`, `false` for `by (...)`.
+    pub without: bool,
+    /// The labels listed in the clause (may be empty: `by ()`).
+    pub labels: Vec<String>,
+}
+
 /// An `unwrap` stage: the label to unwrap plus an optional conversion.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Unwrap {

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -10,19 +10,25 @@
 //!
 //! - [`token`]: token type produced by the lexer
 //! - [`lexer`]: hand-rolled tokenizer with line/column error reporting
-//! - [`ast`]: abstract syntax tree for parsed queries
+//! - [`ast`]: abstract syntax tree for log queries
+//! - [`metric`]: abstract syntax tree for metric queries
 //! - [`parser`]: recursive-descent parser over the token stream
 
 pub mod ast;
 pub mod lexer;
+pub mod metric;
 pub mod parser;
 pub mod token;
 
 pub use ast::{
-    FilterOp, FilterValue, LabelExtraction, LabelFilterExpr, LabelFilterPred, LabelFormat,
-    LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp, PipelineStage,
-    StreamSelector, Unwrap,
+    FilterOp, FilterValue, Grouping, LabelExtraction, LabelFilterExpr, LabelFilterPred,
+    LabelFormat, LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp,
+    PipelineStage, StreamSelector, Unwrap,
 };
 pub use lexer::{LexError, tokenize};
-pub use parser::{ParseError, parse_query, parse_selector};
+pub use metric::{
+    AggregationFunction, BinOp, BinaryExpr, MetricQuery, RangeAggregation, RangeFunction,
+    VectorAggregation,
+};
+pub use parser::{Expr, ParseError, parse, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/metric.rs
+++ b/src/logql/src/metric.rs
@@ -1,0 +1,184 @@
+//! # LogQL Metric Query AST
+//!
+//! Metric queries turn log streams into numeric time series. They wrap a
+//! [`LogQuery`](crate::ast::LogQuery) in a range aggregation (`rate`,
+//! `count_over_time`, ...), optionally nest it in a vector aggregation
+//! (`sum by (...)`, `topk`, ...), and combine results with binary
+//! operators.
+
+use crate::ast::{Grouping, LogQuery, Unwrap};
+use std::time::Duration;
+
+/// A parsed LogQL metric query.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricQuery {
+    /// A range aggregation over a log selector, e.g. `rate({a="b"}[5m])`.
+    Range(Box<RangeAggregation>),
+    /// A vector aggregation over an inner metric query, e.g.
+    /// `sum by (level) (rate(...))`.
+    Vector(Box<VectorAggregation>),
+    /// A binary operation between two metric queries or scalars.
+    Binary(Box<BinaryExpr>),
+    /// A scalar literal (e.g. the `2` in `rate(...) * 2`).
+    Literal(f64),
+}
+
+/// A range aggregation: a range function applied to a ranged log query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeAggregation {
+    pub function: RangeFunction,
+    /// The log selector and pipeline being aggregated.
+    pub log_query: LogQuery,
+    /// The range window, e.g. `5m` in `[5m]`.
+    pub range: Duration,
+    /// Optional `offset <duration>` time shift.
+    pub offset: Option<Duration>,
+    /// Optional `| unwrap <label>` for value extraction (required by the
+    /// `*_over_time` functions that operate on extracted samples).
+    pub unwrap: Option<Unwrap>,
+    /// Scalar parameter for `quantile_over_time(<q>, ...)`.
+    pub param: Option<f64>,
+    /// Optional `by`/`without` grouping on unwrapped range aggregations.
+    pub grouping: Option<Grouping>,
+}
+
+/// Range aggregation functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeFunction {
+    Rate,
+    RateCounter,
+    CountOverTime,
+    BytesRate,
+    BytesOverTime,
+    AvgOverTime,
+    SumOverTime,
+    MinOverTime,
+    MaxOverTime,
+    StdvarOverTime,
+    StddevOverTime,
+    QuantileOverTime,
+    FirstOverTime,
+    LastOverTime,
+    AbsentOverTime,
+}
+
+impl RangeFunction {
+    /// Resolve a function name to its variant.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "rate" => RangeFunction::Rate,
+            "rate_counter" => RangeFunction::RateCounter,
+            "count_over_time" => RangeFunction::CountOverTime,
+            "bytes_rate" => RangeFunction::BytesRate,
+            "bytes_over_time" => RangeFunction::BytesOverTime,
+            "avg_over_time" => RangeFunction::AvgOverTime,
+            "sum_over_time" => RangeFunction::SumOverTime,
+            "min_over_time" => RangeFunction::MinOverTime,
+            "max_over_time" => RangeFunction::MaxOverTime,
+            "stdvar_over_time" => RangeFunction::StdvarOverTime,
+            "stddev_over_time" => RangeFunction::StddevOverTime,
+            "quantile_over_time" => RangeFunction::QuantileOverTime,
+            "first_over_time" => RangeFunction::FirstOverTime,
+            "last_over_time" => RangeFunction::LastOverTime,
+            "absent_over_time" => RangeFunction::AbsentOverTime,
+            _ => return None,
+        })
+    }
+
+    /// Whether this function requires a leading scalar parameter, as in
+    /// `quantile_over_time(0.99, ...)`.
+    pub fn takes_param(self) -> bool {
+        matches!(self, RangeFunction::QuantileOverTime)
+    }
+}
+
+/// A vector aggregation over an inner metric query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorAggregation {
+    pub function: AggregationFunction,
+    /// Scalar parameter for `topk`/`bottomk` (the `k`).
+    pub param: Option<f64>,
+    /// Optional `by`/`without` grouping.
+    pub grouping: Option<Grouping>,
+    /// The metric query being aggregated.
+    pub inner: MetricQuery,
+}
+
+/// Vector aggregation functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregationFunction {
+    Sum,
+    Avg,
+    Min,
+    Max,
+    Stddev,
+    Stdvar,
+    Count,
+    Topk,
+    Bottomk,
+    Sort,
+    SortDesc,
+}
+
+impl AggregationFunction {
+    /// Resolve an aggregation name to its variant.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "sum" => AggregationFunction::Sum,
+            "avg" => AggregationFunction::Avg,
+            "min" => AggregationFunction::Min,
+            "max" => AggregationFunction::Max,
+            "stddev" => AggregationFunction::Stddev,
+            "stdvar" => AggregationFunction::Stdvar,
+            "count" => AggregationFunction::Count,
+            "topk" => AggregationFunction::Topk,
+            "bottomk" => AggregationFunction::Bottomk,
+            "sort" => AggregationFunction::Sort,
+            "sort_desc" => AggregationFunction::SortDesc,
+            _ => return None,
+        })
+    }
+
+    /// Whether this aggregation requires a leading scalar parameter, as
+    /// in `topk(5, ...)`.
+    pub fn takes_param(self) -> bool {
+        matches!(
+            self,
+            AggregationFunction::Topk | AggregationFunction::Bottomk
+        )
+    }
+}
+
+/// A binary operation between two metric queries.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinaryExpr {
+    pub op: BinOp,
+    pub left: MetricQuery,
+    pub right: MetricQuery,
+    /// `true` when a comparison carries the `bool` modifier
+    /// (`> bool 5`), turning the filter into a 0/1 result.
+    pub bool_modifier: bool,
+}
+
+/// Binary operators, grouped by precedence tier (see the parser).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    // Arithmetic
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Pow,
+    // Comparison
+    Eq,
+    Neq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    // Logical / set
+    And,
+    Or,
+    Unless,
+}

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -6,12 +6,24 @@
 //! a later phase of the epic.
 
 use crate::ast::{
-    FilterOp, FilterValue, LabelExtraction, LabelFilterExpr, LabelFilterPred, LabelFormat,
-    LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp, PipelineStage,
-    StreamSelector, Unwrap,
+    FilterOp, FilterValue, Grouping, LabelExtraction, LabelFilterExpr, LabelFilterPred,
+    LabelFormat, LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp,
+    PipelineStage, StreamSelector, Unwrap,
 };
 use crate::lexer::{LexError, tokenize};
+use crate::metric::{
+    AggregationFunction, BinOp, BinaryExpr, MetricQuery, RangeAggregation, RangeFunction,
+    VectorAggregation,
+};
 use crate::token::{SpannedToken, Token};
+
+/// A top-level LogQL expression: either a log query (returns log lines)
+/// or a metric query (returns numeric samples).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Log(LogQuery),
+    Metric(MetricQuery),
+}
 
 /// Parse error with 1-based source position.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
@@ -49,6 +61,31 @@ pub fn parse_selector(input: &str) -> Result<StreamSelector, ParseError> {
     let selector = parser.parse_selector()?;
     parser.expect_eof()?;
     Ok(selector)
+}
+
+/// Parse a top-level LogQL expression, dispatching between a log query
+/// and a metric query. A query beginning with `{` is a log query; any
+/// other start (a range/vector function, a number, or a parenthesis) is
+/// a metric query.
+pub fn parse(input: &str) -> Result<Expr, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let expr = if matches!(parser.peek().map(|t| &t.token), Some(Token::LBrace)) {
+        let selector = parser.parse_selector()?;
+        let pipeline = parser.parse_pipeline()?;
+        Expr::Log(LogQuery { selector, pipeline })
+    } else {
+        Expr::Metric(parser.parse_metric_expr()?)
+    };
+    parser.expect_eof()?;
+    Ok(expr)
+}
+
+/// Parse a metric query (rejects a bare log query).
+pub fn parse_metric_query(input: &str) -> Result<MetricQuery, ParseError> {
+    let mut parser = Parser::new(input)?;
+    let query = parser.parse_metric_expr()?;
+    parser.expect_eof()?;
+    Ok(query)
 }
 
 pub(crate) struct Parser {
@@ -557,6 +594,317 @@ impl Parser {
 
         Ok(LabelMatcher { name, op, value })
     }
+
+    // ---- metric queries (#372) ----
+
+    /// Metric expression with full binary-operator precedence.
+    fn parse_metric_expr(&mut self) -> Result<MetricQuery, ParseError> {
+        self.parse_binary(0)
+    }
+
+    /// Precedence-climbing binary-operator parser. `min_prec` is the
+    /// lowest binding power this call will consume.
+    ///
+    /// Tiers, loosest to tightest: `or` (1); `and`/`unless` (2);
+    /// comparisons (3); `+`/`-` (4); `*`/`/`/`%` (5); `^` (6,
+    /// right-associative). Unary and atoms bind tighter still.
+    fn parse_binary(&mut self, min_prec: u8) -> Result<MetricQuery, ParseError> {
+        let mut left = self.parse_metric_unary()?;
+        while let Some((op, prec, right_assoc)) = self.peek_binary_op() {
+            if prec < min_prec {
+                break;
+            }
+            self.next(); // consume operator
+
+            // Optional `bool` modifier on comparison operators.
+            let bool_modifier = if is_comparison(op)
+                && matches!(self.peek().map(|t| &t.token), Some(Token::Bool))
+            {
+                self.next();
+                true
+            } else {
+                false
+            };
+
+            let next_min = if right_assoc { prec } else { prec + 1 };
+            let right = self.parse_binary(next_min)?;
+            left = MetricQuery::Binary(Box::new(BinaryExpr {
+                op,
+                left,
+                right,
+                bool_modifier,
+            }));
+        }
+        Ok(left)
+    }
+
+    /// Map the upcoming token to a binary operator and its precedence.
+    fn peek_binary_op(&self) -> Option<(BinOp, u8, bool)> {
+        let op = match self.peek().map(|t| &t.token)? {
+            Token::Or => (BinOp::Or, 1, false),
+            Token::And => (BinOp::And, 2, false),
+            Token::Unless => (BinOp::Unless, 2, false),
+            Token::CmpEq => (BinOp::Eq, 3, false),
+            Token::Neq => (BinOp::Neq, 3, false),
+            Token::Gt => (BinOp::Gt, 3, false),
+            Token::Gte => (BinOp::Gte, 3, false),
+            Token::Lt => (BinOp::Lt, 3, false),
+            Token::Lte => (BinOp::Lte, 3, false),
+            Token::Add => (BinOp::Add, 4, false),
+            Token::Sub => (BinOp::Sub, 4, false),
+            Token::Mul => (BinOp::Mul, 5, false),
+            Token::Div => (BinOp::Div, 5, false),
+            Token::Mod => (BinOp::Mod, 5, false),
+            Token::Pow => (BinOp::Pow, 6, true),
+            _ => return None,
+        };
+        Some(op)
+    }
+
+    /// A unary-prefixed metric atom (`-x` negates a scalar/vector).
+    fn parse_metric_unary(&mut self) -> Result<MetricQuery, ParseError> {
+        if matches!(self.peek().map(|t| &t.token), Some(Token::Sub)) {
+            self.next();
+            let inner = self.parse_metric_unary()?;
+            // Represent `-x` as `0 - x`.
+            return Ok(MetricQuery::Binary(Box::new(BinaryExpr {
+                op: BinOp::Sub,
+                left: MetricQuery::Literal(0.0),
+                right: inner,
+                bool_modifier: false,
+            })));
+        }
+        if matches!(self.peek().map(|t| &t.token), Some(Token::Add)) {
+            self.next();
+            return self.parse_metric_unary();
+        }
+        self.parse_metric_atom()
+    }
+
+    /// A metric atom: parenthesized expr, scalar literal, range
+    /// aggregation, or vector aggregation.
+    fn parse_metric_atom(&mut self) -> Result<MetricQuery, ParseError> {
+        match self.peek().map(|t| &t.token) {
+            Some(Token::LParen) => {
+                self.next();
+                let inner = self.parse_metric_expr()?;
+                self.expect(&Token::RParen, "')' to close a parenthesized expression")?;
+                Ok(inner)
+            }
+            Some(Token::Number(n)) => {
+                let n = *n;
+                self.next();
+                Ok(MetricQuery::Literal(n))
+            }
+            Some(Token::Ident(name)) => {
+                let name = name.clone();
+                if RangeFunction::from_name(&name).is_some() {
+                    self.parse_range_aggregation()
+                } else if AggregationFunction::from_name(&name).is_some() {
+                    self.parse_vector_aggregation()
+                } else {
+                    let t = self.peek().cloned();
+                    Err(self.error_at(format!("unknown metric function '{name}'"), t.as_ref()))
+                }
+            }
+            _ => {
+                let t = self.peek().cloned();
+                Err(self.error_at("expected a metric query", t.as_ref()))
+            }
+        }
+    }
+
+    /// `func ( [param,] logRangeExpr )` where `logRangeExpr` is a log
+    /// selector/pipeline carrying a `[range]`, plus optional `offset`
+    /// and `unwrap`; unwrapped forms may carry a trailing grouping.
+    fn parse_range_aggregation(&mut self) -> Result<MetricQuery, ParseError> {
+        let name = self.expect_ident("a range function")?;
+        let function = RangeFunction::from_name(&name).expect("checked by caller");
+        self.expect(&Token::LParen, "'(' after a range function")?;
+
+        let param = if function.takes_param() {
+            let p = self.parse_number("a scalar parameter")?;
+            self.expect(&Token::Comma, "',' after the range function parameter")?;
+            Some(p)
+        } else {
+            None
+        };
+
+        let (log_query, range, offset, unwrap) = self.parse_log_range_expr()?;
+        self.expect(&Token::RParen, "')' to close the range aggregation")?;
+
+        // A grouping may trail an unwrapped range aggregation.
+        let grouping = self.parse_optional_grouping()?;
+
+        Ok(MetricQuery::Range(Box::new(RangeAggregation {
+            function,
+            log_query,
+            range,
+            offset,
+            unwrap,
+            param,
+            grouping,
+        })))
+    }
+
+    /// Parse the `{selector} pipeline [range] [offset d] [| unwrap ...]`
+    /// core of a range aggregation. The `[range]` may appear before or
+    /// after the unwrap stage, matching Loki's grammar.
+    fn parse_log_range_expr(
+        &mut self,
+    ) -> Result<
+        (
+            LogQuery,
+            std::time::Duration,
+            Option<std::time::Duration>,
+            Option<Unwrap>,
+        ),
+        ParseError,
+    > {
+        let selector = self.parse_selector()?;
+        let mut pipeline = self.parse_pipeline()?;
+
+        // Range window `[Nd]`.
+        let range = self.parse_range_window()?;
+        let offset = self.parse_optional_offset()?;
+
+        // In `{..} | unwrap x [5m]`, the unwrap is the last pipeline
+        // stage and the range follows it; lift it into the aggregation.
+        let unwrap = match pipeline.last() {
+            Some(PipelineStage::Unwrap(_)) => {
+                let Some(PipelineStage::Unwrap(u)) = pipeline.pop() else {
+                    unreachable!()
+                };
+                Some(u)
+            }
+            _ => None,
+        };
+
+        Ok((
+            LogQuery {
+                selector: selector.clone(),
+                pipeline,
+            },
+            range,
+            offset,
+            unwrap,
+        ))
+    }
+
+    /// `[ <duration> ]`
+    fn parse_range_window(&mut self) -> Result<std::time::Duration, ParseError> {
+        self.expect(&Token::LBracket, "'[' to start a range window")?;
+        let range = match self.next() {
+            Some(t) => match t.token {
+                Token::Duration(d) => d,
+                ref other => {
+                    return Err(self.error_at(
+                        format!("expected a range duration, found '{other}'"),
+                        Some(&t),
+                    ));
+                }
+            },
+            None => return Err(self.error_at("expected a range duration", None)),
+        };
+        self.expect(&Token::RBracket, "']' to close a range window")?;
+        Ok(range)
+    }
+
+    /// Optional `offset <duration>`.
+    fn parse_optional_offset(&mut self) -> Result<Option<std::time::Duration>, ParseError> {
+        if !matches!(self.peek().map(|t| &t.token), Some(Token::Offset)) {
+            return Ok(None);
+        }
+        self.next();
+        match self.next() {
+            Some(t) => match t.token {
+                Token::Duration(d) => Ok(Some(d)),
+                ref other => Err(self.error_at(
+                    format!("expected a duration after 'offset', found '{other}'"),
+                    Some(&t),
+                )),
+            },
+            None => Err(self.error_at("expected a duration after 'offset'", None)),
+        }
+    }
+
+    /// `agg [by/without (labels)] ( [param,] inner )` — grouping may also
+    /// trail the parenthesized inner query.
+    fn parse_vector_aggregation(&mut self) -> Result<MetricQuery, ParseError> {
+        let name = self.expect_ident("an aggregation function")?;
+        let function = AggregationFunction::from_name(&name).expect("checked by caller");
+
+        // Grouping may precede the argument list.
+        let mut grouping = self.parse_optional_grouping()?;
+
+        self.expect(&Token::LParen, "'(' after an aggregation function")?;
+        let param = if function.takes_param() {
+            let p = self.parse_number("a scalar parameter")?;
+            self.expect(&Token::Comma, "',' after the aggregation parameter")?;
+            Some(p)
+        } else {
+            None
+        };
+        let inner = self.parse_metric_expr()?;
+        self.expect(&Token::RParen, "')' to close the aggregation")?;
+
+        // ...or after it (`sum(...) by (label)`).
+        if grouping.is_none() {
+            grouping = self.parse_optional_grouping()?;
+        }
+
+        Ok(MetricQuery::Vector(Box::new(VectorAggregation {
+            function,
+            param,
+            grouping,
+            inner,
+        })))
+    }
+
+    /// Optional `by (...)` / `without (...)` clause.
+    fn parse_optional_grouping(&mut self) -> Result<Option<Grouping>, ParseError> {
+        let without = match self.peek().map(|t| &t.token) {
+            Some(Token::By) => false,
+            Some(Token::Without) => true,
+            _ => return Ok(None),
+        };
+        self.next();
+        self.expect(&Token::LParen, "'(' after by/without")?;
+        let mut labels = Vec::new();
+        if !matches!(self.peek().map(|t| &t.token), Some(Token::RParen)) {
+            loop {
+                labels.push(self.expect_ident("a grouping label")?);
+                if matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+                    self.next();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect(&Token::RParen, "')' to close by/without")?;
+        Ok(Some(Grouping { without, labels }))
+    }
+
+    /// A bare numeric literal.
+    fn parse_number(&mut self, what: &str) -> Result<f64, ParseError> {
+        match self.next() {
+            Some(t) => match t.token {
+                Token::Number(n) => Ok(n),
+                ref other => {
+                    Err(self.error_at(format!("expected {what}, found '{other}'"), Some(&t)))
+                }
+            },
+            None => Err(self.error_at(format!("expected {what}, found end of input"), None)),
+        }
+    }
+}
+
+/// Whether an operator is a comparison (may carry a `bool` modifier).
+fn is_comparison(op: BinOp) -> bool {
+    matches!(
+        op,
+        BinOp::Eq | BinOp::Neq | BinOp::Gt | BinOp::Gte | BinOp::Lt | BinOp::Lte
+    )
 }
 
 #[cfg(test)]
@@ -889,5 +1237,260 @@ mod tests {
     fn rejects_dangling_pipe() {
         let err = parse_query(r#"{a="b"} |"#).unwrap_err();
         assert!(err.message.contains("pipeline stage after '|'"), "{err}");
+    }
+
+    // ---- metric queries (#372) ----
+
+    use std::time::Duration;
+
+    fn metric(input: &str) -> MetricQuery {
+        parse_metric_query(input).expect("parse metric")
+    }
+
+    fn as_range(q: &MetricQuery) -> &RangeAggregation {
+        match q {
+            MetricQuery::Range(r) => r,
+            other => panic!("expected range aggregation, got {other:?}"),
+        }
+    }
+
+    fn as_vector(q: &MetricQuery) -> &VectorAggregation {
+        match q {
+            MetricQuery::Vector(v) => v,
+            other => panic!("expected vector aggregation, got {other:?}"),
+        }
+    }
+
+    fn as_binary(q: &MetricQuery) -> &BinaryExpr {
+        match q {
+            MetricQuery::Binary(b) => b,
+            other => panic!("expected binary expression, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_bare_range_aggregation() {
+        let q = metric(r#"rate({job="api"}[5m])"#);
+        let r = as_range(&q);
+        assert_eq!(r.function, RangeFunction::Rate);
+        assert_eq!(r.range, Duration::from_secs(300));
+        assert_eq!(r.log_query.selector.matchers.len(), 1);
+        assert!(r.log_query.pipeline.is_empty());
+        assert!(r.offset.is_none() && r.unwrap.is_none() && r.param.is_none());
+    }
+
+    #[test]
+    fn parses_range_aggregation_over_a_pipeline() {
+        let q = metric(r#"count_over_time({job="api"} |= "error" [1h])"#);
+        let r = as_range(&q);
+        assert_eq!(r.function, RangeFunction::CountOverTime);
+        assert_eq!(r.range, Duration::from_secs(3600));
+        assert_eq!(r.log_query.pipeline.len(), 1);
+        assert!(matches!(
+            r.log_query.pipeline[0],
+            PipelineStage::LineFilter(_)
+        ));
+    }
+
+    #[test]
+    fn parses_every_range_function_name() {
+        for (name, func) in [
+            ("rate", RangeFunction::Rate),
+            ("rate_counter", RangeFunction::RateCounter),
+            ("count_over_time", RangeFunction::CountOverTime),
+            ("bytes_rate", RangeFunction::BytesRate),
+            ("bytes_over_time", RangeFunction::BytesOverTime),
+            ("first_over_time", RangeFunction::FirstOverTime),
+            ("last_over_time", RangeFunction::LastOverTime),
+            ("absent_over_time", RangeFunction::AbsentOverTime),
+        ] {
+            let q = metric(&format!(r#"{name}({{a="b"}}[5m])"#));
+            assert_eq!(as_range(&q).function, func, "{name}");
+        }
+    }
+
+    #[test]
+    fn parses_offset_modifier() {
+        let q = metric(r#"rate({a="b"}[5m] offset 1h)"#);
+        let r = as_range(&q);
+        assert_eq!(r.offset, Some(Duration::from_secs(3600)));
+    }
+
+    #[test]
+    fn parses_unwrap_range_aggregation() {
+        let q = metric(r#"avg_over_time({job="api"} | json | unwrap duration [5m])"#);
+        let r = as_range(&q);
+        assert_eq!(r.function, RangeFunction::AvgOverTime);
+        assert_eq!(
+            r.unwrap,
+            Some(Unwrap {
+                label: "duration".into(),
+                conversion: None,
+            })
+        );
+        // The unwrap stage is lifted out of the pipeline.
+        assert_eq!(r.log_query.pipeline.len(), 1);
+        assert!(matches!(r.log_query.pipeline[0], PipelineStage::Json(_)));
+    }
+
+    #[test]
+    fn parses_quantile_over_time_param() {
+        let q = metric(r#"quantile_over_time(0.99, {a="b"} | unwrap latency [5m])"#);
+        let r = as_range(&q);
+        assert_eq!(r.function, RangeFunction::QuantileOverTime);
+        assert_eq!(r.param, Some(0.99));
+        assert_eq!(r.unwrap.as_ref().unwrap().label, "latency");
+    }
+
+    #[test]
+    fn parses_vector_aggregation_with_grouping() {
+        let q = metric(r#"sum by (level) (rate({job="api"}[5m]))"#);
+        let v = as_vector(&q);
+        assert_eq!(v.function, AggregationFunction::Sum);
+        assert_eq!(
+            v.grouping,
+            Some(Grouping {
+                without: false,
+                labels: vec!["level".into()],
+            })
+        );
+        assert!(matches!(v.inner, MetricQuery::Range(_)));
+    }
+
+    #[test]
+    fn parses_trailing_grouping() {
+        let q = metric(r#"sum(rate({a="b"}[5m])) without (pod, ns)"#);
+        let v = as_vector(&q);
+        assert_eq!(
+            v.grouping,
+            Some(Grouping {
+                without: true,
+                labels: vec!["pod".into(), "ns".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn parses_topk_with_param_and_nested_aggregation() {
+        let q = metric(r#"topk(10, sum by (path) (rate({job="api"}[5m])))"#);
+        let v = as_vector(&q);
+        assert_eq!(v.function, AggregationFunction::Topk);
+        assert_eq!(v.param, Some(10.0));
+        let inner = as_vector(&v.inner);
+        assert_eq!(inner.function, AggregationFunction::Sum);
+    }
+
+    #[test]
+    fn parses_empty_grouping() {
+        let q = metric(r#"sum by () (rate({a="b"}[5m]))"#);
+        assert_eq!(
+            as_vector(&q).grouping.as_ref().unwrap().labels,
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn parses_binary_arithmetic_with_scalar() {
+        let q = metric(r#"rate({a="b"}[5m]) * 60"#);
+        let b = as_binary(&q);
+        assert_eq!(b.op, BinOp::Mul);
+        assert!(matches!(b.left, MetricQuery::Range(_)));
+        assert_eq!(b.right, MetricQuery::Literal(60.0));
+    }
+
+    #[test]
+    fn binary_operator_precedence() {
+        // `a + b * c` → `a + (b * c)`
+        let q = metric(r#"rate({a="b"}[1m]) + rate({a="c"}[1m]) * 2"#);
+        let b = as_binary(&q);
+        assert_eq!(b.op, BinOp::Add);
+        assert_eq!(as_binary(&b.right).op, BinOp::Mul);
+    }
+
+    #[test]
+    fn pow_is_right_associative() {
+        // `2 ^ 3 ^ 2` → `2 ^ (3 ^ 2)`
+        let q = metric("2 ^ 3 ^ 2");
+        let b = as_binary(&q);
+        assert_eq!(b.op, BinOp::Pow);
+        assert_eq!(b.left, MetricQuery::Literal(2.0));
+        assert_eq!(as_binary(&b.right).op, BinOp::Pow);
+    }
+
+    #[test]
+    fn logical_operators_bind_loosest() {
+        // `a > 1 and b > 2 or c > 3` → `((a>1) and (b>2)) or (c>3)`
+        let q =
+            metric(r#"rate({a="1"}[1m]) > 1 and rate({a="2"}[1m]) > 2 or rate({a="3"}[1m]) > 3"#);
+        let top = as_binary(&q);
+        assert_eq!(top.op, BinOp::Or);
+        assert_eq!(as_binary(&top.left).op, BinOp::And);
+    }
+
+    #[test]
+    fn parses_bool_modifier_on_comparison() {
+        let q = metric(r#"rate({a="b"}[5m]) > bool 5"#);
+        let b = as_binary(&q);
+        assert_eq!(b.op, BinOp::Gt);
+        assert!(b.bool_modifier);
+        assert_eq!(b.right, MetricQuery::Literal(5.0));
+    }
+
+    #[test]
+    fn parses_parenthesized_and_unary_minus() {
+        let q = metric(r#"(rate({a="b"}[5m]))"#);
+        assert!(matches!(q, MetricQuery::Range(_)));
+
+        let neg = metric(r#"- rate({a="b"}[5m])"#);
+        let b = as_binary(&neg);
+        assert_eq!(b.op, BinOp::Sub);
+        assert_eq!(b.left, MetricQuery::Literal(0.0));
+    }
+
+    #[test]
+    fn parse_dispatches_log_vs_metric() {
+        assert!(matches!(parse(r#"{job="api"}"#).unwrap(), Expr::Log(_)));
+        assert!(matches!(
+            parse(r#"{job="api"} |= "x""#).unwrap(),
+            Expr::Log(_)
+        ));
+        assert!(matches!(
+            parse(r#"rate({job="api"}[5m])"#).unwrap(),
+            Expr::Metric(_)
+        ));
+        assert!(matches!(
+            parse(r#"sum(rate({a="b"}[1m]))"#).unwrap(),
+            Expr::Metric(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_range_window() {
+        let err = parse_metric_query(r#"rate({a="b"})"#).unwrap_err();
+        assert!(
+            err.message.contains("range window") || err.message.contains("'['"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_metric_function() {
+        let err = parse_metric_query(r#"frobnicate({a="b"}[5m])"#).unwrap_err();
+        assert!(err.message.contains("unknown metric function"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_quantile_param() {
+        let err = parse_metric_query(r#"quantile_over_time({a="b"} | unwrap x [5m])"#).unwrap_err();
+        assert!(
+            err.message.contains("scalar parameter") || err.message.contains("','"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unclosed_aggregation_paren() {
+        let err = parse_metric_query(r#"sum(rate({a="b"}[5m])"#).unwrap_err();
+        assert!(err.message.contains("')'"), "{err}");
     }
 }

--- a/src/logql/tests/corpus.rs
+++ b/src/logql/tests/corpus.rs
@@ -1,0 +1,167 @@
+//! Real-world LogQL corpus.
+//!
+//! Queries harvested verbatim from the official Grafana Loki
+//! documentation (query/log_queries, metric_queries, query_examples, ip,
+//! template_functions) and well-known community cheat sheets. They serve
+//! two purposes: prove the parser accepts the breadth of syntax users
+//! actually write, and pin down — honestly — the features it does not
+//! support yet, so those gaps are visible and regression-guarded.
+
+use logql::parse;
+
+/// Queries that MUST parse with the current grammar. Grouped by feature
+/// for readability; the assertion treats them as one flat set.
+const SUPPORTED: &[&str] = &[
+    // --- stream selectors: all operators, single/multiple matchers ---
+    r#"{app="mysql",name="mysql-backup"}"#,
+    r#"{name =~ "mysql.+"}"#,
+    r#"{name !~ "mysql.+"}"#,
+    r#"{name !~ `mysql-\d+`}"#,
+    r#"{name =~ ".*mysql.*"}"#,
+    r#"{name =~ "(?s).*mysql.*"}"#,
+    r#"{service_name="nginx", status="500"}"#,
+    r#"{job="mysql"}"#,
+    r#"{instance=~"kafka-[23]",name="kafka"}"#,
+    r#"{cluster="ops-tools1", namespace="loki-dev", job="loki-dev/query-frontend"}"#,
+    // --- line filters: |=, !=, |~, !~, chained ---
+    r#"{job="mysql"} |= "error""#,
+    r#"{job="mysql"} |= "error" != "timeout""#,
+    r#"{name="kafka"} |~ "tsdb-ops.*io:2003""#,
+    r#"{name="cassandra"} |~ `error=\w+`"#,
+    r#"{instance=~"kafka-[23]",name="kafka"} != "kafka.server:type=ReplicaManager""#,
+    r#"{job="containerlogs"} |~ "(?i)(error|fail|lost|closed|panic|fatal|crash|password|authentication|denied)""#,
+    r#"{job="containerlogs", container_name!~"^promtail.+"} |~ "(?i)(error|fail|lost)" != "ForgotPassword""#,
+    r#"{job="containerlogs"} |~ "(too many requests|rate.limit)""#,
+    r#"{job="security"} != "grafana_com" |= "session opened" != "sudo: ""#,
+    r#"{job_name="myapp"} |= "3.180.71.3""#,
+    // --- parser stages: json, logfmt, regexp, pattern, unpack ---
+    r#"{job="mysql"} | json"#,
+    r#"{job="varlogs"} | logfmt"#,
+    r#"{job="mysql"} | pattern "<ip> - - <_> \"<method> <uri> <_>\" <status> <size> <_> \"<agent>\" <_>""#,
+    r#"{job="mysql"} | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)""#,
+    r#"{job="mysql"} | unpack"#,
+    r#"{job="security"} != "grafana_com" |= "session opened" != "sudo: " | regexp "(^(?P<user>\\S+ {1,2}){11})" | line_format "USER = {{.user}}""#,
+    // --- json/logfmt with extraction expressions ---
+    r#"{job="mysql"} | json first_server="servers[0]", ua="request.headers[\"User-Agent\"]""#,
+    r#"{job="mysql"} | json server_list="servers", headers="request.headers""#,
+    // --- label filter expressions: string/numeric/duration, and/or/comma ---
+    r#"{container="query-frontend",namespace="loki-dev"} |= "metrics.go" | logfmt | duration > 10s and throughput_mb < 500"#,
+    r#"{app="foo"} | logfmt | duration >= 20ms or method="GET""#,
+    r#"{app="foo"} | logfmt | duration >= 20ms , method!~"2..""#,
+    r#"{app="foo"} | logfmt | duration >= 20ms | method!~"2..""#,
+    r#"{cluster="ops-tools1", namespace="loki-dev"} |= "metrics.go" != "out of order" | logfmt | duration > 30s or status_code != "200""#,
+    // --- formatters: line_format, label_format (rename + template) ---
+    r#"{job="mysql"} |= "error" | json | line_format "{{.err}}""#,
+    r#"{job="mysql"} | json | line_format "{{.message}}" |= "error""#,
+    r#"{container="frontend"} | logfmt | line_format "{{.query}} {{.duration}}""#,
+    r#"{container="frontend"} | logfmt | line_format "{{.ip}} {{.status}} {{div .duration 1000}}""#,
+    r#"{job="access_log"} | json | line_format `{{.http_request_headers_x_forwarded_for | default "-"}}`"#,
+    r#"{job="loki/querier"} |= "finish in prometheus" | logfmt | line_format `{{ range $q := fromJson .queries }} {{ $q.query }} {{ end }}`"#,
+    r#"{job="xyzlog"} | line_format `{{ __line__ | count "XYZ"}}`"#,
+    r#"{job="loki/querier"} | label_format nowEpoch=`{{(unixEpoch now)}}`,createDateEpoch=`{{unixEpoch (toDate "2006-01-02" .createDate)}}` | label_format dateTimeDiff=`{{sub .nowEpoch .createDateEpoch}}` | dateTimeDiff > 86400"#,
+    // --- drop with bare labels / __error__ ---
+    r#"{job="varlogs"}|json|drop __error__"#,
+    r#"{job="varlogs"}|json|drop level, source"#,
+    // --- range aggregations ---
+    r#"count_over_time({job="mysql"}[5m])"#,
+    r#"count_over_time({job="mysql"}[5m] offset 5m)"#,
+    r#"rate({job="mysql"} |= "error" != "timeout" [5m])"#,
+    r#"bytes_over_time({job="mysql"}[5m])"#,
+    r#"bytes_rate({job="mysql"}[5m])"#,
+    r#"absent_over_time({job="mysql"}[5m])"#,
+    // --- unwrap range aggregations, incl. conversions ---
+    r#"sum_over_time({cluster="ops-tools1",container="loki-dev"} |= "metrics.go" | logfmt | unwrap bytes_processed [1m])"#,
+    r#"avg_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"min_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"max_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"stddev_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"stdvar_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"first_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"last_over_time({app="api"} | json | unwrap duration_ms [5m])"#,
+    r#"quantile_over_time(0.99, {container="ingress-nginx"} | json | __error__ = "" | unwrap request_time [1m]) by (path)"#,
+    r#"quantile_over_time(0.99, {container="ingress-nginx"} | json | unwrap duration(request_time) [1m]) by (path)"#,
+    r#"sum_over_time({container="loki"} | logfmt | unwrap bytes(bytes_processed) [1m])"#,
+    r#"avg_over_time({app="api"} | logfmt | unwrap duration_seconds(latency) [5m])"#,
+    // --- vector aggregations with by/without, topk/bottomk ---
+    r#"sum(count_over_time({job="mysql"}[5m])) by (level)"#,
+    r#"sum by (host) (rate({job="mysql"} |= "error" != "timeout" | json | duration > 10s [1m]))"#,
+    r#"sum by (org_id) (sum_over_time({cluster="ops-tools1",container="loki-dev"} |= "metrics.go" | logfmt | unwrap bytes_processed [1m]))"#,
+    r#"topk(10,sum(rate({region="us-east1"}[5m])) by (name))"#,
+    r#"topk(10, sum by (app) (rate({namespace="production"}[5m])))"#,
+    r#"bottomk(5, sum by (app) (rate({namespace="production"} |= "error" [5m])))"#,
+    r#"sum by (job) (bytes_rate({job=~".+"}[5m]))"#,
+    r#"sum without(app) (count_over_time({app="foo"}[1m]))"#,
+    // --- binary / arithmetic operations and scalars ---
+    r#"sum(rate({app="foo"}[5m])) * 2"#,
+    r#"sum(rate({app="foo", level="warn"}[1m])) / sum(rate({app="foo", level="error"}[1m]))"#,
+    // --- comparison operators, with & without bool ---
+    r#"count_over_time({foo="bar"}[1m]) > 10"#,
+    r#"count_over_time({foo="bar"}[1m]) > bool 10"#,
+    r#"sum without(app) (count_over_time({app="foo"}[1m])) > sum without(app) (count_over_time({app="bar"}[1m]))"#,
+    r#"sum without(app) (count_over_time({app="foo"}[1m])) > bool sum without(app) (count_over_time({app="bar"}[1m]))"#,
+];
+
+/// Documented LogQL features the parser does NOT support yet. Each MUST
+/// currently fail to parse; when support lands, move the entry into
+/// `SUPPORTED` and the failing assertion here will flag it. The trailing
+/// comment names the missing feature.
+const KNOWN_UNSUPPORTED: &[&str] = &[
+    r#"{app="foo"} | logfmt | duration > 1m and bytes_consumed > 20MB"#, // bytes literal (20MB)
+    r#"{app="foo"} | logfmt | size == 20KB"#,                            // bytes literal (20KB)
+    r#"{app="foo"} | logfmt | ((duration >= 20ms or method="GET") and size <= 20KB)"#, // parenthesized label filter + bytes
+    r#"{job="example"} | decolorize"#, // decolorize stage
+    r#"{job="varlogs"}|json|drop level, method="GET""#, // drop with matcher expression
+    r#"{job="varlogs"}|json|keep level, app=~"some-api.*""#, // keep with matcher expression
+    r#"{job="varlogs"} | logfmt --strict"#, // logfmt flags
+    r#"{job="varlogs"} | logfmt --keep-empty --strict host"#, // logfmt flags
+    r#"count_over_time({job="mysql"}[5m]) offset 5m"#, // offset after aggregation
+    r#"rate(({job="mysql"} |= "error" != "timeout")[10s])"#, // parenthesized selector in range
+    r#"avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)"#, // parenthesized selector in range
+    r#"sum(count_over_time({namespace="traefik"}[5m])) or vector(0)"#, // vector() function
+    r#"label_replace(sum(rate({job="api"}[5m])) by (instance), "host", "$1", "instance", "(.*):.*")"#, // label_replace()
+    r#"{job_name="myapp"} |= ip("192.168.4.5/16")"#, // ip() line filter
+    r#"{job_name="myapp"} | logfmt | addr = ip("192.168.4.0/24") or addr = ip("10.10.15.0/24")"#, // ip() label filter
+    r#"{$label_name=~"$label_value"}"#, // Grafana template variables
+];
+
+#[test]
+fn supported_corpus_parses() {
+    let mut failures = Vec::new();
+    for q in SUPPORTED {
+        if let Err(e) = parse(q) {
+            failures.push(format!("  {q}\n    -> {e}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} corpus queries failed to parse:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn known_unsupported_corpus_is_rejected() {
+    let mut unexpectedly_ok = Vec::new();
+    for q in KNOWN_UNSUPPORTED {
+        if parse(q).is_ok() {
+            unexpectedly_ok.push(*q);
+        }
+    }
+    assert!(
+        unexpectedly_ok.is_empty(),
+        "queries now parse and should move to SUPPORTED:\n  {}",
+        unexpectedly_ok.join("\n  ")
+    );
+}
+
+#[test]
+fn corpus_is_non_trivial() {
+    // Guard against accidental truncation of the corpus.
+    assert!(
+        SUPPORTED.len() >= 70,
+        "supported corpus shrank: {}",
+        SUPPORTED.len()
+    );
+    assert!(KNOWN_UNSUPPORTED.len() >= 10);
+}

--- a/src/logql/tests/queries.rs
+++ b/src/logql/tests/queries.rs
@@ -1,0 +1,128 @@
+//! End-to-end LogQL parsing tests over realistic queries.
+//!
+//! These exercise the public [`logql::parse`] entry point the router and
+//! querier use, asserting the top-level shape (log vs metric) and key
+//! structural details rather than the full AST — the crate's unit tests
+//! already pin the field-level behaviour.
+
+use logql::{
+    AggregationFunction, BinOp, Expr, LineFilterOp, MetricQuery, PipelineStage, RangeFunction,
+    parse, parse_query, parse_selector,
+};
+use std::time::Duration;
+
+/// Every query the Grafana Loki datasource commonly emits should parse.
+#[test]
+fn representative_queries_parse() {
+    let queries = [
+        r#"{job="api"}"#,
+        r#"{service_name="frontend", level="error"}"#,
+        r#"{namespace=~"prod-.*"}"#,
+        r#"{job!="test", env!~"dev.*"}"#,
+        r#"{job="api"} |= "error""#,
+        r#"{job="api"} |= "error" != "timeout""#,
+        r#"{job="api"} |~ "error|warning""#,
+        r#"{job="api"} | json | level="error""#,
+        r#"{job="api"} | logfmt | duration > 1s"#,
+        r#"{job="api"} | pattern "<method> <path> <status>""#,
+        r#"{job="api"} | json status="response.status" | status >= 500"#,
+        r#"{app="x"} | line_format "{{.msg}}""#,
+        r#"{app="x"} | label_format out="{{.a}}", renamed=orig"#,
+        r#"{app="x"} | drop level, source"#,
+        r#"rate({job="api"}[5m])"#,
+        r#"count_over_time({job="api"} |= "error" [1h])"#,
+        r#"sum by (level) (rate({job="api"}[5m]))"#,
+        r#"topk(10, sum by (path) (rate({job="api"}[5m])))"#,
+        r#"avg_over_time({job="api"} | json | unwrap duration [5m])"#,
+        r#"quantile_over_time(0.99, {app="x"} | unwrap latency [5m])"#,
+        r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#,
+        r#"rate({a="b"}[5m]) > bool 5"#,
+    ];
+    for q in queries {
+        assert!(parse(q).is_ok(), "should parse: {q}");
+    }
+}
+
+#[test]
+fn dispatches_log_and_metric_queries() {
+    assert!(matches!(parse(r#"{job="api"}"#).unwrap(), Expr::Log(_)));
+    assert!(matches!(
+        parse(r#"{job="api"} | json"#).unwrap(),
+        Expr::Log(_)
+    ));
+    assert!(matches!(
+        parse(r#"rate({job="api"}[5m])"#).unwrap(),
+        Expr::Metric(_)
+    ));
+}
+
+#[test]
+fn full_log_pipeline_round_trips_structurally() {
+    let query = parse_query(
+        r#"{app="api", env="prod"} |= "error" != "healthcheck" | json | status >= 500 | line_format "{{.message}}""#,
+    )
+    .expect("parse");
+
+    assert_eq!(query.selector.matchers.len(), 2);
+    assert_eq!(query.pipeline.len(), 5);
+    assert!(matches!(
+        query.pipeline[0],
+        PipelineStage::LineFilter(ref f) if f.op == LineFilterOp::Contains
+    ));
+    assert!(matches!(
+        query.pipeline[1],
+        PipelineStage::LineFilter(ref f) if f.op == LineFilterOp::NotContains
+    ));
+    assert!(matches!(query.pipeline[2], PipelineStage::Json(_)));
+    assert!(matches!(query.pipeline[3], PipelineStage::LabelFilter(_)));
+    assert!(matches!(query.pipeline[4], PipelineStage::LineFormat(_)));
+}
+
+#[test]
+fn binary_metric_query_shape() {
+    let Expr::Metric(MetricQuery::Binary(bin)) =
+        parse(r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#).unwrap()
+    else {
+        panic!("expected a binary metric query");
+    };
+    assert_eq!(bin.op, BinOp::Div);
+    assert!(matches!(bin.left, MetricQuery::Vector(_)));
+    assert!(matches!(bin.right, MetricQuery::Vector(_)));
+}
+
+#[test]
+fn range_and_aggregation_functions_resolve() {
+    let Expr::Metric(MetricQuery::Vector(v)) =
+        parse(r#"sum by (level) (count_over_time({a="b"}[10m]))"#).unwrap()
+    else {
+        panic!("expected a vector aggregation");
+    };
+    assert_eq!(v.function, AggregationFunction::Sum);
+    let MetricQuery::Range(r) = &v.inner else {
+        panic!("expected range inner");
+    };
+    assert_eq!(r.function, RangeFunction::CountOverTime);
+    assert_eq!(r.range, Duration::from_secs(600));
+}
+
+#[test]
+fn selector_only_parse_matches_query_selector() {
+    let selector = parse_selector(r#"{job="api", level="error"}"#).expect("parse selector");
+    let query = parse_query(r#"{job="api", level="error"}"#).expect("parse query");
+    assert_eq!(selector, query.selector);
+}
+
+#[test]
+fn malformed_queries_are_rejected() {
+    let bad = [
+        r#"{job="api""#,            // unclosed selector
+        r#"{job=}"#,                // missing value
+        r#"rate({a="b"})"#,         // missing range window
+        r#"sum(rate({a="b"}[5m])"#, // unclosed aggregation
+        r#"{a="b"} | status =~ 5"#, // regex op against number
+        r#"nonsense({a="b"}[5m])"#, // unknown function
+    ];
+    for q in bad {
+        assert!(parse(q).is_err(), "should be rejected: {q}");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the LogQL epic, final parser piece. Adds metric-query parsing and a top-level `parse()` that dispatches log vs metric queries.

- **Range aggregations** — `rate`, `count_over_time`, `bytes_rate/over_time`, `*_over_time`, `quantile_over_time` (leading scalar param), `first/last/absent_over_time`, with `[duration]`, `offset`, lifted `unwrap` (incl. `duration()`/`bytes()` conversions), and trailing `by/without`
- **Vector aggregations** — `sum/avg/min/max/count/stddev/stdvar/topk/bottomk/sort/sort_desc`, grouping before or after the argument, `topk/bottomk` scalar param
- **Binary operators** — precedence-climbing: `or` < `and`/`unless` < comparison < `+`/`-` < `*`/`/`/`%` < `^` (right-assoc); `bool` comparison modifier; unary minus; parentheses

## Real-world corpus

~90 **real LogQL queries** harvested verbatim from the Grafana Loki docs and community cheat sheets: **75 asserted to parse**, plus a ledger of **16 not-yet-supported** features asserted to error. A follow-up PR implements those gaps and promotes them.

## Testing

70 tests: 60 unit + 7 structural integration + 3 corpus.

Refs #372 (part of #366)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing LogQL metric queries, including aggregations, range functions, arithmetic, comparisons, offsets, and unwrap expressions.
  - Added `by (...)` and `without (...)` grouping clauses for metric queries.
  - Added a unified parser that automatically recognizes log and metric queries.
  - Added support for scalar values, parentheses, unary operators, and function parameters in metric expressions.

- **Tests**
  - Added broad coverage for real-world LogQL queries, supported syntax, and expected parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->