### PR TITLE
feat(logql): support the remaining common LogQL surface

### DIFF
--- a/src/logql/src/ast.rs
+++ b/src/logql/src/ast.rs
@@ -57,33 +57,61 @@ pub enum PipelineStage {
     LineFilter(LineFilter),
     /// `| json` with optional label-extraction expressions.
     Json(Vec<LabelExtraction>),
-    /// `| logfmt` with optional label-extraction expressions.
-    Logfmt(Vec<LabelExtraction>),
+    /// `| logfmt` with optional flags (`--strict`, `--keep-empty`) and
+    /// label-extraction expressions.
+    Logfmt(LogfmtStage),
     /// `| regexp "(?P<name>re)"` — named-capture extraction.
     Regexp(String),
     /// `| pattern "<method> <path>"` — pattern extraction.
     Pattern(String),
     /// `| unpack` — promote a packed JSON entry's labels.
     Unpack,
+    /// `| decolorize` — strip ANSI color codes from the line.
+    Decolorize,
     /// `| level="error"`, `| status >= 500 and duration > 1s`.
     LabelFilter(LabelFilterExpr),
     /// `| line_format "{{.msg}}"`.
     LineFormat(String),
     /// `| label_format dst="src", pretty=`{{.x}}``.
     LabelFormat(Vec<LabelFormat>),
-    /// `| drop label1, label2`.
-    Drop(Vec<String>),
-    /// `| keep label1, label2`.
-    Keep(Vec<String>),
+    /// `| drop label1, method="GET"` — drop labels, optionally only when
+    /// a matcher holds.
+    Drop(Vec<LabelPredicate>),
+    /// `| keep label1, method="GET"` — keep only these labels.
+    Keep(Vec<LabelPredicate>),
+    /// `| distinct label1, label2` — drop consecutive duplicate lines by
+    /// the given labels.
+    Distinct(Vec<String>),
     /// `| unwrap duration_ms` or `| unwrap duration(latency)`.
     Unwrap(Unwrap),
 }
 
-/// A line filter operator and its match string.
+/// A line filter: an operator, a match value, and whether the value is
+/// an `ip("...")` matcher rather than a literal/regex.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LineFilter {
     pub op: LineFilterOp,
     pub value: String,
+    /// `true` for `|= ip("...")`, matching the line's IP addresses.
+    pub is_ip: bool,
+}
+
+/// A `logfmt` stage: optional flags plus label extractions.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LogfmtStage {
+    /// Flags such as `strict` and `keep-empty` (without the `--`).
+    pub flags: Vec<String>,
+    pub extractions: Vec<LabelExtraction>,
+}
+
+/// One `drop`/`keep` item: a label name, optionally gated by a matcher
+/// (`method="GET"`, `app=~"api.*"`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelPredicate {
+    pub name: String,
+    /// The matcher operator and value, when the item is `name op "value"`
+    /// rather than a bare label name.
+    pub matcher: Option<(MatchOp, String)>,
 }
 
 /// Line filter operators.
@@ -193,4 +221,8 @@ pub enum FilterValue {
     Number(f64),
     /// A duration literal such as `1s` or `500ms`.
     Duration(std::time::Duration),
+    /// A bytes literal such as `20KB` or `5MB`, in bytes.
+    Bytes(u64),
+    /// An `ip("...")` matcher (single address, CIDR, or range).
+    Ip(String),
 }

--- a/src/logql/src/lexer.rs
+++ b/src/logql/src/lexer.rs
@@ -107,7 +107,15 @@ impl<'a> Lexer<'a> {
                 ']' => Token::RBracket,
                 ',' => Token::Comma,
                 '+' => Token::Add,
-                '-' => Token::Sub,
+                '-' => {
+                    // `--flag` is a parser-stage flag; a single `-` is
+                    // subtraction / unary minus.
+                    if self.eat('-') {
+                        self.lex_flag(line, col)?
+                    } else {
+                        Token::Sub
+                    }
+                }
                 '*' => Token::Mul,
                 '/' => Token::Div,
                 '%' => Token::Mod,
@@ -334,20 +342,25 @@ impl<'a> Lexer<'a> {
             return Ok(Token::Number(value));
         }
 
-        // Duration: one or more (number, unit) pairs, e.g. `1h30m`.
+        // Read the first unit. A bytes unit (`KB`, `MiB`, ...) yields a
+        // bytes literal; otherwise fall through to duration parsing.
+        let (u_line, u_col) = (self.line, self.col);
+        let unit = self.read_unit();
+        if let Some(factor) = bytes_factor(&unit) {
+            if value < 0.0 {
+                return Err(self.error("negative bytes literal", line, col));
+            }
+            let bytes = (value * factor as f64).round() as u64;
+            return Ok(Token::Bytes(bytes));
+        }
+
+        // Duration: one or more (number, unit) pairs, e.g. `1h30m`. The
+        // first unit was already read above.
         let mut total_secs = 0.0_f64;
         let mut pending = value;
+        let mut unit = unit;
+        let (mut u_line, mut u_col) = (u_line, u_col);
         loop {
-            let (u_line, u_col) = (self.line, self.col);
-            let mut unit = String::new();
-            while let Some(&c) = self.chars.peek() {
-                if c.is_alphabetic() || c == 'µ' {
-                    unit.push(c);
-                    self.bump();
-                } else {
-                    break;
-                }
-            }
             let factor = match unit.as_str() {
                 "ns" => 1e-9,
                 "us" | "µs" => 1e-6,
@@ -373,6 +386,8 @@ impl<'a> Lexer<'a> {
                 Some(&c) if c.is_ascii_digit() => {
                     let first = self.bump().expect("peeked digit");
                     pending = self.read_number(first, self.line, self.col)?;
+                    (u_line, u_col) = (self.line, self.col);
+                    unit = self.read_unit();
                 }
                 _ => break,
             }
@@ -382,6 +397,60 @@ impl<'a> Lexer<'a> {
         }
         Ok(Token::Duration(Duration::from_secs_f64(total_secs)))
     }
+
+    /// Read a run of unit letters (`ms`, `KiB`, `µs`, ...).
+    fn read_unit(&mut self) -> String {
+        let mut unit = String::new();
+        while let Some(&c) = self.chars.peek() {
+            if c.is_alphabetic() || c == 'µ' {
+                unit.push(c);
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        unit
+    }
+
+    /// A parser-stage flag: `--<name>`. The two dashes are already
+    /// consumed.
+    fn lex_flag(&mut self, line: u32, col: u32) -> Result<Token, LexError> {
+        let mut name = String::new();
+        while let Some(&c) = self.chars.peek() {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                name.push(c);
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        if name.is_empty() {
+            return Err(self.error("expected a flag name after '--'", line, col));
+        }
+        Ok(Token::Flag(name))
+    }
+}
+
+/// Bytes-per-unit factor for a byte-size unit, or `None` if `unit` is
+/// not a bytes unit. Decimal units are powers of 1000; `*iB` units and
+/// bare `KB`/`MB`/... follow Loki's `humanize` convention of powers of
+/// 1024 for the `i` forms.
+fn bytes_factor(unit: &str) -> Option<u64> {
+    let f = match unit {
+        "B" => 1,
+        "kB" | "KB" => 1_000,
+        "MB" => 1_000_000,
+        "GB" => 1_000_000_000,
+        "TB" => 1_000_000_000_000,
+        "PB" => 1_000_000_000_000_000,
+        "KiB" => 1_024,
+        "MiB" => 1_024 * 1_024,
+        "GiB" => 1_024 * 1_024 * 1_024,
+        "TiB" => 1_024_u64.pow(4),
+        "PiB" => 1_024_u64.pow(5),
+        _ => return None,
+    };
+    Some(f)
 }
 
 #[cfg(test)]
@@ -539,6 +608,38 @@ mod tests {
         assert_eq!(tokens("0.25"), vec![Token::Number(0.25)]);
         assert_eq!(tokens("1e3"), vec![Token::Number(1000.0)]);
         assert_eq!(tokens("2.5e-2"), vec![Token::Number(0.025)]);
+    }
+
+    #[test]
+    fn lexes_bytes_literals() {
+        assert_eq!(tokens("20KB"), vec![Token::Bytes(20_000)]);
+        assert_eq!(tokens("5MB"), vec![Token::Bytes(5_000_000)]);
+        assert_eq!(tokens("1GB"), vec![Token::Bytes(1_000_000_000)]);
+        assert_eq!(tokens("1KiB"), vec![Token::Bytes(1_024)]);
+        assert_eq!(tokens("2MiB"), vec![Token::Bytes(2 * 1_024 * 1_024)]);
+        assert_eq!(tokens("512B"), vec![Token::Bytes(512)]);
+        // Bytes and durations are distinguished by unit.
+        assert_eq!(
+            tokens("20ms"),
+            vec![Token::Duration(Duration::from_millis(20))]
+        );
+    }
+
+    #[test]
+    fn lexes_parser_stage_flags() {
+        assert_eq!(
+            tokens("logfmt --strict --keep-empty"),
+            vec![
+                Token::Ident("logfmt".into()),
+                Token::Flag("strict".into()),
+                Token::Flag("keep-empty".into()),
+            ]
+        );
+        // A lone '-' is still subtraction.
+        assert_eq!(
+            tokens("5 - 2"),
+            vec![Token::Number(5.0), Token::Sub, Token::Number(2.0),]
+        );
     }
 
     #[test]

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -22,8 +22,8 @@ pub mod token;
 
 pub use ast::{
     FilterOp, FilterValue, Grouping, LabelExtraction, LabelFilterExpr, LabelFilterPred,
-    LabelFormat, LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp,
-    PipelineStage, StreamSelector, Unwrap,
+    LabelFormat, LabelFormatValue, LabelMatcher, LabelPredicate, LineFilter, LineFilterOp,
+    LogQuery, LogfmtStage, MatchOp, PipelineStage, StreamSelector, Unwrap,
 };
 pub use lexer::{LexError, tokenize};
 pub use metric::{

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -27,8 +27,8 @@ pub use ast::{
 };
 pub use lexer::{LexError, tokenize};
 pub use metric::{
-    AggregationFunction, BinOp, BinaryExpr, MetricQuery, RangeAggregation, RangeFunction,
-    VectorAggregation,
+    AggregationFunction, BinOp, BinaryExpr, LabelReplace, MetricQuery, RangeAggregation,
+    RangeFunction, VectorAggregation,
 };
 pub use parser::{Expr, ParseError, parse, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/metric.rs
+++ b/src/logql/src/metric.rs
@@ -21,6 +21,27 @@ pub enum MetricQuery {
     Binary(Box<BinaryExpr>),
     /// A scalar literal (e.g. the `2` in `rate(...) * 2`).
     Literal(f64),
+    /// `vector(<scalar>)` — a scalar promoted to an instant vector, used
+    /// for fallbacks like `... or vector(0)`.
+    VectorLiteral(f64),
+    /// `label_replace(v, dst, replacement, src, regex)` — rewrite a label
+    /// from a regex capture of another label.
+    LabelReplace(Box<LabelReplace>),
+}
+
+/// A `label_replace(v, dst, replacement, src, regex)` call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabelReplace {
+    /// The inner metric query whose labels are rewritten.
+    pub inner: MetricQuery,
+    /// Destination label name.
+    pub dst_label: String,
+    /// Replacement template referencing regex capture groups (`$1`).
+    pub replacement: String,
+    /// Source label the regex is matched against.
+    pub src_label: String,
+    /// Regex applied to the source label's value.
+    pub regex: String,
 }
 
 /// A range aggregation: a range function applied to a ranged log query.

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -7,8 +7,8 @@
 
 use crate::ast::{
     FilterOp, FilterValue, Grouping, LabelExtraction, LabelFilterExpr, LabelFilterPred,
-    LabelFormat, LabelFormatValue, LabelMatcher, LineFilter, LineFilterOp, LogQuery, MatchOp,
-    PipelineStage, StreamSelector, Unwrap,
+    LabelFormat, LabelFormatValue, LabelMatcher, LabelPredicate, LineFilter, LineFilterOp,
+    LogQuery, LogfmtStage, MatchOp, PipelineStage, StreamSelector, Unwrap,
 };
 use crate::lexer::{LexError, tokenize};
 use crate::metric::{
@@ -196,18 +196,42 @@ impl Parser {
         Ok(stages)
     }
 
-    /// The string operand of a line filter.
+    /// The operand of a line filter: a quoted string, or `ip("...")`.
     fn parse_line_filter_value(&mut self, op: LineFilterOp) -> Result<LineFilter, ParseError> {
+        // `ip("...")` matcher.
+        if let Some(t) = self.peek()
+            && matches!(&t.token, Token::Ident(name) if name == "ip")
+        {
+            self.next();
+            let value = self.parse_ip_call()?;
+            return Ok(LineFilter {
+                op,
+                value,
+                is_ip: true,
+            });
+        }
         match self.next() {
             Some(t) => match t.token {
-                Token::String(value) => Ok(LineFilter { op, value }),
+                Token::String(value) => Ok(LineFilter {
+                    op,
+                    value,
+                    is_ip: false,
+                }),
                 ref other => Err(self.error_at(
-                    format!("expected quoted string after line filter, found '{other}'"),
+                    format!("expected a quoted string or ip() after line filter, found '{other}'"),
                     Some(&t),
                 )),
             },
-            None => Err(self.error_at("expected quoted string after line filter", None)),
+            None => Err(self.error_at("expected a quoted string or ip() after line filter", None)),
         }
+    }
+
+    /// The `("...")` argument of an `ip(...)` matcher; `ip` is consumed.
+    fn parse_ip_call(&mut self) -> Result<String, ParseError> {
+        self.expect(&Token::LParen, "'(' after ip")?;
+        let value = self.expect_string("an IP pattern string")?;
+        self.expect(&Token::RParen, "')' to close ip(...)")?;
+        Ok(value)
     }
 
     /// Parse the stage that follows a bare `|`.
@@ -218,6 +242,11 @@ impl Parser {
         {
             self.next();
             return Ok(PipelineStage::Unwrap(self.parse_unwrap()?));
+        }
+
+        // A parenthesized label-filter group, e.g. `| (a="1" or b="2")`.
+        if matches!(self.peek().map(|t| &t.token), Some(Token::LParen)) {
+            return Ok(PipelineStage::LabelFilter(self.parse_label_filter_expr()?));
         }
 
         let head = match self.peek() {
@@ -240,7 +269,9 @@ impl Parser {
             }
             "logfmt" => {
                 self.next();
-                Ok(PipelineStage::Logfmt(self.parse_label_extractions()?))
+                let flags = self.parse_flags();
+                let extractions = self.parse_label_extractions()?;
+                Ok(PipelineStage::Logfmt(LogfmtStage { flags, extractions }))
             }
             "regexp" => {
                 self.next();
@@ -258,6 +289,14 @@ impl Parser {
                 self.next();
                 Ok(PipelineStage::Unpack)
             }
+            "decolorize" => {
+                self.next();
+                Ok(PipelineStage::Decolorize)
+            }
+            "distinct" => {
+                self.next();
+                Ok(PipelineStage::Distinct(self.parse_label_name_list()?))
+            }
             "line_format" => {
                 self.next();
                 Ok(PipelineStage::LineFormat(
@@ -270,11 +309,11 @@ impl Parser {
             }
             "drop" => {
                 self.next();
-                Ok(PipelineStage::Drop(self.parse_label_name_list()?))
+                Ok(PipelineStage::Drop(self.parse_label_predicate_list()?))
             }
             "keep" => {
                 self.next();
-                Ok(PipelineStage::Keep(self.parse_label_name_list()?))
+                Ok(PipelineStage::Keep(self.parse_label_predicate_list()?))
             }
             // Anything else is a label filter expression (it starts with
             // a label name, which is an identifier).
@@ -366,7 +405,7 @@ impl Parser {
         Ok(out)
     }
 
-    /// Comma-separated bare label names for `drop`/`keep`.
+    /// Comma-separated bare label names for `distinct`.
     fn parse_label_name_list(&mut self) -> Result<Vec<String>, ParseError> {
         let mut out = vec![self.expect_ident("a label name")?];
         while matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
@@ -374,6 +413,46 @@ impl Parser {
             out.push(self.expect_ident("a label name")?);
         }
         Ok(out)
+    }
+
+    /// Consume any leading `--flag` tokens (parser-stage options).
+    fn parse_flags(&mut self) -> Vec<String> {
+        let mut flags = Vec::new();
+        while let Some(Token::Flag(name)) = self.peek().map(|t| &t.token) {
+            flags.push(name.clone());
+            self.next();
+        }
+        flags
+    }
+
+    /// Comma-separated `drop`/`keep` items: a bare label name or a
+    /// `name op "value"` matcher.
+    fn parse_label_predicate_list(&mut self) -> Result<Vec<LabelPredicate>, ParseError> {
+        let mut out = vec![self.parse_label_predicate()?];
+        while matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+            self.next();
+            out.push(self.parse_label_predicate()?);
+        }
+        Ok(out)
+    }
+
+    fn parse_label_predicate(&mut self) -> Result<LabelPredicate, ParseError> {
+        let name = self.expect_ident("a label name")?;
+        let matcher = match self.peek().map(|t| &t.token) {
+            Some(Token::Eq | Token::Neq | Token::Re | Token::Nre) => {
+                let op = match self.next().expect("peeked").token {
+                    Token::Eq => MatchOp::Eq,
+                    Token::Neq => MatchOp::Neq,
+                    Token::Re => MatchOp::Re,
+                    Token::Nre => MatchOp::Nre,
+                    _ => unreachable!(),
+                };
+                let value = self.expect_string("a quoted matcher value")?;
+                Some((op, value))
+            }
+            _ => None,
+        };
+        Ok(LabelPredicate { name, matcher })
     }
 
     /// `unwrap <label>` or `unwrap <conversion>(<label>)`.
@@ -407,17 +486,28 @@ impl Parser {
     }
 
     fn parse_label_filter_and(&mut self) -> Result<LabelFilterExpr, ParseError> {
-        let mut left = self.parse_label_filter_pred()?;
+        let mut left = self.parse_label_filter_primary()?;
         // Both `and` and a bare comma mean conjunction.
         while matches!(
             self.peek().map(|t| &t.token),
             Some(Token::And) | Some(Token::Comma)
         ) {
             self.next();
-            let right = self.parse_label_filter_pred()?;
+            let right = self.parse_label_filter_primary()?;
             left = LabelFilterExpr::And(Box::new(left), Box::new(right));
         }
         Ok(left)
+    }
+
+    /// A parenthesized sub-expression or a single predicate.
+    fn parse_label_filter_primary(&mut self) -> Result<LabelFilterExpr, ParseError> {
+        if matches!(self.peek().map(|t| &t.token), Some(Token::LParen)) {
+            self.next();
+            let expr = self.parse_label_filter_expr()?;
+            self.expect(&Token::RParen, "')' to close a label filter group")?;
+            return Ok(expr);
+        }
+        self.parse_label_filter_pred()
     }
 
     fn parse_label_filter_pred(&mut self) -> Result<LabelFilterExpr, ParseError> {
@@ -456,14 +546,22 @@ impl Parser {
     }
 
     fn parse_filter_value(&mut self) -> Result<FilterValue, ParseError> {
+        // `ip("...")` matcher.
+        if let Some(t) = self.peek()
+            && matches!(&t.token, Token::Ident(name) if name == "ip")
+        {
+            self.next();
+            return Ok(FilterValue::Ip(self.parse_ip_call()?));
+        }
         match self.next() {
             Some(t) => match t.token {
                 Token::String(s) => Ok(FilterValue::String(s)),
                 Token::Number(n) => Ok(FilterValue::Number(n)),
                 Token::Duration(d) => Ok(FilterValue::Duration(d)),
+                Token::Bytes(b) => Ok(FilterValue::Bytes(b)),
                 ref other => Err(self.error_at(
                     format!(
-                        "expected a string, number, or duration in label filter, found '{other}'"
+                        "expected a string, number, duration, bytes, or ip() in label filter, found '{other}'"
                     ),
                     Some(&t),
                 )),
@@ -473,8 +571,8 @@ impl Parser {
     }
 
     /// Reject operator/value combinations that don't type-check: regex
-    /// matchers require a string; ordered comparisons require a number
-    /// or duration.
+    /// matchers require a string or ip; ordered comparisons require a
+    /// number, duration, or bytes.
     fn check_op_value(
         &self,
         op: FilterOp,
@@ -482,9 +580,14 @@ impl Parser {
         op_token: &SpannedToken,
     ) -> Result<(), ParseError> {
         let ok = match op {
-            FilterOp::Re | FilterOp::Nre => matches!(value, FilterValue::String(_)),
+            FilterOp::Re | FilterOp::Nre => {
+                matches!(value, FilterValue::String(_) | FilterValue::Ip(_))
+            }
             FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte => {
-                matches!(value, FilterValue::Number(_) | FilterValue::Duration(_))
+                matches!(
+                    value,
+                    FilterValue::Number(_) | FilterValue::Duration(_) | FilterValue::Bytes(_)
+                )
             }
             FilterOp::Eq | FilterOp::Neq | FilterOp::CmpEq => true,
         };
@@ -977,6 +1080,7 @@ mod tests {
             vec![PipelineStage::LineFilter(LineFilter {
                 op: LineFilterOp::Contains,
                 value: "error".to_string(),
+                is_ip: false,
             })]
         );
     }
@@ -1027,6 +1131,7 @@ mod tests {
         PipelineStage::LineFilter(LineFilter {
             op,
             value: value.to_string(),
+            is_ip: false,
         })
     }
 
@@ -1064,7 +1169,102 @@ mod tests {
         );
         assert_eq!(
             pipeline(r#"{a="b"} | logfmt"#),
-            vec![PipelineStage::Logfmt(vec![])]
+            vec![PipelineStage::Logfmt(LogfmtStage::default())]
+        );
+    }
+
+    #[test]
+    fn parses_logfmt_flags() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | logfmt --strict --keep-empty host"#),
+            vec![PipelineStage::Logfmt(LogfmtStage {
+                flags: vec!["strict".into(), "keep-empty".into()],
+                extractions: vec![LabelExtraction {
+                    name: "host".into(),
+                    expr: None,
+                }],
+            })]
+        );
+    }
+
+    #[test]
+    fn parses_decolorize_and_distinct() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | decolorize"#),
+            vec![PipelineStage::Decolorize]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | distinct host, path"#),
+            vec![PipelineStage::Distinct(vec!["host".into(), "path".into()])]
+        );
+    }
+
+    #[test]
+    fn parses_ip_line_and_label_filters() {
+        assert_eq!(
+            pipeline(r#"{a="b"} |= ip("192.168.4.5/16")"#),
+            vec![PipelineStage::LineFilter(LineFilter {
+                op: LineFilterOp::Contains,
+                value: "192.168.4.5/16".into(),
+                is_ip: true,
+            })]
+        );
+        assert_eq!(
+            pipeline(r#"{a="b"} | logfmt | addr = ip("10.0.0.0/8")"#),
+            vec![
+                PipelineStage::Logfmt(LogfmtStage::default()),
+                PipelineStage::LabelFilter(LabelFilterExpr::Pred(LabelFilterPred {
+                    name: "addr".into(),
+                    op: FilterOp::Eq,
+                    value: FilterValue::Ip("10.0.0.0/8".into()),
+                })),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_bytes_label_filter() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | logfmt | size > 20KB"#),
+            vec![
+                PipelineStage::Logfmt(LogfmtStage::default()),
+                PipelineStage::LabelFilter(LabelFilterExpr::Pred(LabelFilterPred {
+                    name: "size".into(),
+                    op: FilterOp::Gt,
+                    value: FilterValue::Bytes(20_000),
+                })),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_parenthesized_label_filter() {
+        // `(a or b) and c` groups the or under the and.
+        let stages = pipeline(r#"{x="y"} | (a="1" or b="2") and c="3""#);
+        let PipelineStage::LabelFilter(LabelFilterExpr::And(left, right)) = &stages[0] else {
+            panic!("expected top-level And, got {:?}", stages[0]);
+        };
+        assert!(matches!(**left, LabelFilterExpr::Or(_, _)));
+        assert!(matches!(**right, LabelFilterExpr::Pred(_)));
+    }
+
+    #[test]
+    fn parses_drop_keep_with_matchers() {
+        assert_eq!(
+            pipeline(r#"{a="b"} | json | drop __error__, method="GET""#),
+            vec![
+                PipelineStage::Json(vec![]),
+                PipelineStage::Drop(vec![
+                    LabelPredicate {
+                        name: "__error__".into(),
+                        matcher: None,
+                    },
+                    LabelPredicate {
+                        name: "method".into(),
+                        matcher: Some((MatchOp::Eq, "GET".into())),
+                    },
+                ]),
+            ]
         );
     }
 
@@ -1104,13 +1304,17 @@ mod tests {
 
     #[test]
     fn parses_drop_and_keep() {
+        let bare = |name: &str| LabelPredicate {
+            name: name.to_string(),
+            matcher: None,
+        };
         assert_eq!(
             pipeline(r#"{a="b"} | drop level, source"#),
-            vec![PipelineStage::Drop(vec!["level".into(), "source".into()])]
+            vec![PipelineStage::Drop(vec![bare("level"), bare("source")])]
         );
         assert_eq!(
             pipeline(r#"{a="b"} | keep pod"#),
-            vec![PipelineStage::Keep(vec!["pod".into()])]
+            vec![PipelineStage::Keep(vec![bare("pod")])]
         );
     }
 
@@ -1199,7 +1403,7 @@ mod tests {
         assert_eq!(
             pipeline(r#"{a="b"} | logfmt | latency > 1s"#),
             vec![
-                PipelineStage::Logfmt(vec![]),
+                PipelineStage::Logfmt(LogfmtStage::default()),
                 PipelineStage::LabelFilter(LabelFilterExpr::Pred(LabelFilterPred {
                     name: "latency".into(),
                     op: FilterOp::Gt,

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -805,6 +805,10 @@ impl Parser {
                     self.parse_range_aggregation()
                 } else if AggregationFunction::from_name(&name).is_some() {
                     self.parse_vector_aggregation()
+                } else if name == "vector" {
+                    self.parse_vector_literal()
+                } else if name == "label_replace" {
+                    self.parse_label_replace()
                 } else {
                     let t = self.peek().cloned();
                     Err(self.error_at(format!("unknown metric function '{name}'"), t.as_ref()))
@@ -833,8 +837,13 @@ impl Parser {
             None
         };
 
-        let (log_query, range, offset, unwrap) = self.parse_log_range_expr()?;
+        let (log_query, range, mut offset, unwrap) = self.parse_log_range_expr()?;
         self.expect(&Token::RParen, "')' to close the range aggregation")?;
+
+        // `offset` may also trail the aggregation: `count_over_time(...) offset 5m`.
+        if offset.is_none() {
+            offset = self.parse_optional_offset()?;
+        }
 
         // A grouping may trail an unwrapped range aggregation.
         let grouping = self.parse_optional_grouping()?;
@@ -848,6 +857,40 @@ impl Parser {
             param,
             grouping,
         })))
+    }
+
+    /// `vector ( <scalar> )`.
+    fn parse_vector_literal(&mut self) -> Result<MetricQuery, ParseError> {
+        self.expect_ident("vector")?;
+        self.expect(&Token::LParen, "'(' after vector")?;
+        let value = self.parse_number("a scalar value")?;
+        self.expect(&Token::RParen, "')' to close vector(...)")?;
+        Ok(MetricQuery::VectorLiteral(value))
+    }
+
+    /// `label_replace ( v, dst, replacement, src, regex )`.
+    fn parse_label_replace(&mut self) -> Result<MetricQuery, ParseError> {
+        self.expect_ident("label_replace")?;
+        self.expect(&Token::LParen, "'(' after label_replace")?;
+        let inner = self.parse_metric_expr()?;
+        self.expect(&Token::Comma, "',' after the label_replace vector")?;
+        let dst_label = self.expect_string("the destination label")?;
+        self.expect(&Token::Comma, "',' after the destination label")?;
+        let replacement = self.expect_string("the replacement template")?;
+        self.expect(&Token::Comma, "',' after the replacement")?;
+        let src_label = self.expect_string("the source label")?;
+        self.expect(&Token::Comma, "',' after the source label")?;
+        let regex = self.expect_string("the regex")?;
+        self.expect(&Token::RParen, "')' to close label_replace(...)")?;
+        Ok(MetricQuery::LabelReplace(Box::new(
+            crate::metric::LabelReplace {
+                inner,
+                dst_label,
+                replacement,
+                src_label,
+                regex,
+            },
+        )))
     }
 
     /// Parse the `{selector} pipeline [range] [offset d] [| unwrap ...]`
@@ -864,8 +907,20 @@ impl Parser {
         ),
         ParseError,
     > {
+        // The log expression may be wrapped in parentheses:
+        // `rate(({job="x"} |= "e")[5m])`.
+        let paren = matches!(self.peek().map(|t| &t.token), Some(Token::LParen));
+        if paren {
+            self.next();
+        }
         let selector = self.parse_selector()?;
         let mut pipeline = self.parse_pipeline()?;
+        if paren {
+            self.expect(
+                &Token::RParen,
+                "')' to close the parenthesized log expression",
+            )?;
+        }
 
         // Range window `[Nd]`.
         let range = self.parse_range_window()?;
@@ -1696,5 +1751,46 @@ mod tests {
     fn rejects_unclosed_aggregation_paren() {
         let err = parse_metric_query(r#"sum(rate({a="b"}[5m])"#).unwrap_err();
         assert!(err.message.contains("')'"), "{err}");
+    }
+
+    // ---- extended metric surface (#661) ----
+
+    #[test]
+    fn parses_offset_after_aggregation() {
+        let q = metric(r#"count_over_time({job="mysql"}[5m]) offset 5m"#);
+        assert_eq!(as_range(&q).offset, Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn parses_parenthesized_selector_in_range() {
+        let q = metric(r#"rate(({job="mysql"} |= "error" != "timeout")[10s])"#);
+        let r = as_range(&q);
+        assert_eq!(r.range, Duration::from_secs(10));
+        assert_eq!(r.log_query.pipeline.len(), 2);
+    }
+
+    #[test]
+    fn parses_vector_literal() {
+        assert_eq!(metric("vector(0)"), MetricQuery::VectorLiteral(0.0));
+        // `... or vector(0)` fallback.
+        let q = metric(r#"sum(count_over_time({a="b"}[5m])) or vector(0)"#);
+        let b = as_binary(&q);
+        assert_eq!(b.op, BinOp::Or);
+        assert_eq!(b.right, MetricQuery::VectorLiteral(0.0));
+    }
+
+    #[test]
+    fn parses_label_replace() {
+        let q = metric(
+            r#"label_replace(sum(rate({job="api"}[5m])) by (instance), "host", "$1", "instance", "(.*):.*")"#,
+        );
+        let MetricQuery::LabelReplace(lr) = &q else {
+            panic!("expected label_replace, got {q:?}");
+        };
+        assert_eq!(lr.dst_label, "host");
+        assert_eq!(lr.replacement, "$1");
+        assert_eq!(lr.src_label, "instance");
+        assert_eq!(lr.regex, "(.*):.*");
+        assert!(matches!(lr.inner, MetricQuery::Vector(_)));
     }
 }

--- a/src/logql/src/token.rs
+++ b/src/logql/src/token.rs
@@ -19,8 +19,13 @@ pub enum Token {
     Number(f64),
     /// Duration literal such as `5m`, `1h30m`, or `1.5h`.
     Duration(Duration),
+    /// Bytes literal such as `20KB`, `5MB`, or `1GiB`, in bytes.
+    Bytes(u64),
     /// Identifier: label names, function names, parser stage names.
     Ident(String),
+    /// A parser-stage flag such as `--strict` or `--keep-empty` (stored
+    /// without the leading dashes).
+    Flag(String),
 
     // Label matchers / equality
     /// `=`
@@ -159,7 +164,9 @@ impl std::fmt::Display for Token {
             Token::String(s) => write!(f, "{s:?}"),
             Token::Number(n) => write!(f, "{n}"),
             Token::Duration(d) => write!(f, "{d:?}"),
+            Token::Bytes(b) => write!(f, "{b}B"),
             Token::Ident(i) => write!(f, "{i}"),
+            Token::Flag(name) => write!(f, "--{name}"),
             Token::Eq => f.write_str("="),
             Token::Neq => f.write_str("!="),
             Token::Re => f.write_str("=~"),

--- a/src/logql/tests/ast.rs
+++ b/src/logql/tests/ast.rs
@@ -1,0 +1,376 @@
+//! Expected-AST tests for representative LogQL queries.
+//!
+//! The corpus test (`corpus.rs`) proves queries parse without error; this
+//! suite goes further and asserts the exact tree for one query per
+//! construct, so structural regressions — mis-grouped precedence, dropped
+//! stages, a matcher parsed as the wrong operator — are caught even when
+//! the query still parses.
+
+use logql::{
+    AggregationFunction, BinOp, BinaryExpr, Expr, FilterOp, FilterValue, Grouping, LabelExtraction,
+    LabelFilterExpr, LabelFilterPred, LabelFormat, LabelFormatValue, LabelMatcher, LabelPredicate,
+    LineFilter, LineFilterOp, LogQuery, LogfmtStage, MatchOp, MetricQuery, PipelineStage,
+    RangeAggregation, RangeFunction, StreamSelector, Unwrap, VectorAggregation, parse,
+};
+use std::time::Duration;
+
+// --- small constructors to keep the expected trees readable ---
+
+fn m(name: &str, op: MatchOp, value: &str) -> LabelMatcher {
+    LabelMatcher {
+        name: name.into(),
+        op,
+        value: value.into(),
+    }
+}
+
+fn selector(matchers: Vec<LabelMatcher>) -> StreamSelector {
+    StreamSelector { matchers }
+}
+
+fn log(selector: StreamSelector, pipeline: Vec<PipelineStage>) -> Expr {
+    Expr::Log(LogQuery { selector, pipeline })
+}
+
+fn line(op: LineFilterOp, value: &str) -> PipelineStage {
+    PipelineStage::LineFilter(LineFilter {
+        op,
+        value: value.into(),
+        is_ip: false,
+    })
+}
+
+fn pred(name: &str, op: FilterOp, value: FilterValue) -> LabelFilterExpr {
+    LabelFilterExpr::Pred(LabelFilterPred {
+        name: name.into(),
+        op,
+        value,
+    })
+}
+
+fn range(
+    function: RangeFunction,
+    selector: StreamSelector,
+    pipeline: Vec<PipelineStage>,
+    range: Duration,
+) -> MetricQuery {
+    MetricQuery::Range(Box::new(RangeAggregation {
+        function,
+        log_query: LogQuery { selector, pipeline },
+        range,
+        offset: None,
+        unwrap: None,
+        param: None,
+        grouping: None,
+    }))
+}
+
+/// The heart of this suite: each case is `(query, expected AST)`.
+fn cases() -> Vec<(&'static str, Expr)> {
+    vec![
+        // --- stream selectors ---
+        (
+            r#"{job="api"}"#,
+            log(selector(vec![m("job", MatchOp::Eq, "api")]), vec![]),
+        ),
+        (
+            r#"{job!="api", env=~"prod-.*", region!~"eu.*"}"#,
+            log(
+                selector(vec![
+                    m("job", MatchOp::Neq, "api"),
+                    m("env", MatchOp::Re, "prod-.*"),
+                    m("region", MatchOp::Nre, "eu.*"),
+                ]),
+                vec![],
+            ),
+        ),
+        // --- line filters (order + operators preserved) ---
+        (
+            r#"{a="b"} |= "keep" != "drop" |~ "re" !~ "nre""#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![
+                    line(LineFilterOp::Contains, "keep"),
+                    line(LineFilterOp::NotContains, "drop"),
+                    line(LineFilterOp::Regex, "re"),
+                    line(LineFilterOp::NotRegex, "nre"),
+                ],
+            ),
+        ),
+        // --- ip line filter carries the is_ip flag ---
+        (
+            r#"{a="b"} |= ip("10.0.0.0/8")"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![PipelineStage::LineFilter(LineFilter {
+                    op: LineFilterOp::Contains,
+                    value: "10.0.0.0/8".into(),
+                    is_ip: true,
+                })],
+            ),
+        ),
+        // --- json extraction expressions ---
+        (
+            r#"{a="b"} | json status="response.status", level"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![PipelineStage::Json(vec![
+                    LabelExtraction {
+                        name: "status".into(),
+                        expr: Some("response.status".into()),
+                    },
+                    LabelExtraction {
+                        name: "level".into(),
+                        expr: None,
+                    },
+                ])],
+            ),
+        ),
+        // --- logfmt flags ---
+        (
+            r#"{a="b"} | logfmt --strict --keep-empty host"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![PipelineStage::Logfmt(LogfmtStage {
+                    flags: vec!["strict".into(), "keep-empty".into()],
+                    extractions: vec![LabelExtraction {
+                        name: "host".into(),
+                        expr: None,
+                    }],
+                })],
+            ),
+        ),
+        // --- label_format rename vs template ---
+        (
+            r#"{a="b"} | label_format out="{{.src}}", renamed=orig"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![PipelineStage::LabelFormat(vec![
+                    LabelFormat {
+                        dst: "out".into(),
+                        value: LabelFormatValue::Template("{{.src}}".into()),
+                    },
+                    LabelFormat {
+                        dst: "renamed".into(),
+                        value: LabelFormatValue::Rename("orig".into()),
+                    },
+                ])],
+            ),
+        ),
+        // --- drop with a bare label and a matcher ---
+        (
+            r#"{a="b"} | drop __error__, method="GET""#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![PipelineStage::Drop(vec![
+                    LabelPredicate {
+                        name: "__error__".into(),
+                        matcher: None,
+                    },
+                    LabelPredicate {
+                        name: "method".into(),
+                        matcher: Some((MatchOp::Eq, "GET".into())),
+                    },
+                ])],
+            ),
+        ),
+        // --- label filter: comma is AND ---
+        (
+            r#"{a="b"} | logfmt | level="error", status>=500"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![
+                    PipelineStage::Logfmt(LogfmtStage::default()),
+                    PipelineStage::LabelFilter(LabelFilterExpr::And(
+                        Box::new(pred(
+                            "level",
+                            FilterOp::Eq,
+                            FilterValue::String("error".into()),
+                        )),
+                        Box::new(pred("status", FilterOp::Gte, FilterValue::Number(500.0))),
+                    )),
+                ],
+            ),
+        ),
+        // --- label filter: bytes + duration values ---
+        (
+            r#"{a="b"} | logfmt | size > 20KB"#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![
+                    PipelineStage::Logfmt(LogfmtStage::default()),
+                    PipelineStage::LabelFilter(pred(
+                        "size",
+                        FilterOp::Gt,
+                        FilterValue::Bytes(20_000),
+                    )),
+                ],
+            ),
+        ),
+        // --- label filter: and binds tighter than or ---
+        (
+            r#"{a="b"} | logfmt | x="1" and y="2" or z="3""#,
+            log(
+                selector(vec![m("a", MatchOp::Eq, "b")]),
+                vec![
+                    PipelineStage::Logfmt(LogfmtStage::default()),
+                    PipelineStage::LabelFilter(LabelFilterExpr::Or(
+                        Box::new(LabelFilterExpr::And(
+                            Box::new(pred("x", FilterOp::Eq, FilterValue::String("1".into()))),
+                            Box::new(pred("y", FilterOp::Eq, FilterValue::String("2".into()))),
+                        )),
+                        Box::new(pred("z", FilterOp::Eq, FilterValue::String("3".into()))),
+                    )),
+                ],
+            ),
+        ),
+        // --- range aggregation over a line filter ---
+        (
+            r#"count_over_time({job="api"} |= "error" [5m])"#,
+            Expr::Metric(range(
+                RangeFunction::CountOverTime,
+                selector(vec![m("job", MatchOp::Eq, "api")]),
+                vec![line(LineFilterOp::Contains, "error")],
+                Duration::from_secs(300),
+            )),
+        ),
+        // --- unwrap is lifted out of the pipeline into the aggregation ---
+        (
+            r#"avg_over_time({a="b"} | json | unwrap duration [5m])"#,
+            Expr::Metric(MetricQuery::Range(Box::new(RangeAggregation {
+                function: RangeFunction::AvgOverTime,
+                log_query: LogQuery {
+                    selector: selector(vec![m("a", MatchOp::Eq, "b")]),
+                    pipeline: vec![PipelineStage::Json(vec![])],
+                },
+                range: Duration::from_secs(300),
+                offset: None,
+                unwrap: Some(Unwrap {
+                    label: "duration".into(),
+                    conversion: None,
+                }),
+                param: None,
+                grouping: None,
+            }))),
+        ),
+        // --- vector aggregation with grouping wrapping a range agg ---
+        (
+            r#"sum by (level) (rate({job="api"}[1m]))"#,
+            Expr::Metric(MetricQuery::Vector(Box::new(VectorAggregation {
+                function: AggregationFunction::Sum,
+                param: None,
+                grouping: Some(Grouping {
+                    without: false,
+                    labels: vec!["level".into()],
+                }),
+                inner: range(
+                    RangeFunction::Rate,
+                    selector(vec![m("job", MatchOp::Eq, "api")]),
+                    vec![],
+                    Duration::from_secs(60),
+                ),
+            }))),
+        ),
+        // --- topk carries its scalar param ---
+        (
+            r#"topk(3, sum(rate({a="b"}[1m])))"#,
+            Expr::Metric(MetricQuery::Vector(Box::new(VectorAggregation {
+                function: AggregationFunction::Topk,
+                param: Some(3.0),
+                grouping: None,
+                inner: MetricQuery::Vector(Box::new(VectorAggregation {
+                    function: AggregationFunction::Sum,
+                    param: None,
+                    grouping: None,
+                    inner: range(
+                        RangeFunction::Rate,
+                        selector(vec![m("a", MatchOp::Eq, "b")]),
+                        vec![],
+                        Duration::from_secs(60),
+                    ),
+                })),
+            }))),
+        ),
+        // --- binary op precedence: a + b * c ---
+        (
+            r#"rate({a="b"}[1m]) + rate({a="c"}[1m]) * 2"#,
+            Expr::Metric(MetricQuery::Binary(Box::new(BinaryExpr {
+                op: BinOp::Add,
+                left: range(
+                    RangeFunction::Rate,
+                    selector(vec![m("a", MatchOp::Eq, "b")]),
+                    vec![],
+                    Duration::from_secs(60),
+                ),
+                right: MetricQuery::Binary(Box::new(BinaryExpr {
+                    op: BinOp::Mul,
+                    left: range(
+                        RangeFunction::Rate,
+                        selector(vec![m("a", MatchOp::Eq, "c")]),
+                        vec![],
+                        Duration::from_secs(60),
+                    ),
+                    right: MetricQuery::Literal(2.0),
+                    bool_modifier: false,
+                })),
+                bool_modifier: false,
+            }))),
+        ),
+        // --- bool modifier on a comparison ---
+        (
+            r#"count_over_time({a="b"}[1m]) > bool 10"#,
+            Expr::Metric(MetricQuery::Binary(Box::new(BinaryExpr {
+                op: BinOp::Gt,
+                left: range(
+                    RangeFunction::CountOverTime,
+                    selector(vec![m("a", MatchOp::Eq, "b")]),
+                    vec![],
+                    Duration::from_secs(60),
+                ),
+                right: MetricQuery::Literal(10.0),
+                bool_modifier: true,
+            }))),
+        ),
+        // --- vector(0) fallback ---
+        (
+            r#"vector(0)"#,
+            Expr::Metric(MetricQuery::VectorLiteral(0.0)),
+        ),
+        // --- offset after the aggregation lands on the range agg ---
+        (
+            r#"count_over_time({a="b"}[5m]) offset 1h"#,
+            Expr::Metric(MetricQuery::Range(Box::new(RangeAggregation {
+                function: RangeFunction::CountOverTime,
+                log_query: LogQuery {
+                    selector: selector(vec![m("a", MatchOp::Eq, "b")]),
+                    pipeline: vec![],
+                },
+                range: Duration::from_secs(300),
+                offset: Some(Duration::from_secs(3600)),
+                unwrap: None,
+                param: None,
+                grouping: None,
+            }))),
+        ),
+    ]
+}
+
+#[test]
+fn expected_asts_match() {
+    let mut failures = Vec::new();
+    for (query, expected) in cases() {
+        match parse(query) {
+            Ok(actual) if actual == expected => {}
+            Ok(actual) => failures.push(format!(
+                "  {query}\n    expected: {expected:?}\n    actual:   {actual:?}"
+            )),
+            Err(e) => failures.push(format!("  {query}\n    parse error: {e}")),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} AST mismatches:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/src/logql/tests/corpus.rs
+++ b/src/logql/tests/corpus.rs
@@ -99,6 +99,22 @@ const SUPPORTED: &[&str] = &[
     r#"count_over_time({foo="bar"}[1m]) > bool 10"#,
     r#"sum without(app) (count_over_time({app="foo"}[1m])) > sum without(app) (count_over_time({app="bar"}[1m]))"#,
     r#"sum without(app) (count_over_time({app="foo"}[1m])) > bool sum without(app) (count_over_time({app="bar"}[1m]))"#,
+    // --- bytes literals in label filters ---
+    r#"{app="foo"} | logfmt | duration > 1m and bytes_consumed > 20MB"#,
+    r#"{app="foo"} | logfmt | size == 20KB"#,
+    // --- parenthesized label filter (with bytes) ---
+    r#"{app="foo"} | logfmt | ((duration >= 20ms or method="GET") and size <= 20KB)"#,
+    // --- decolorize ---
+    r#"{job="example"} | decolorize"#,
+    // --- drop/keep with matcher expressions ---
+    r#"{job="varlogs"}|json|drop level, method="GET""#,
+    r#"{job="varlogs"}|json|keep level, app=~"some-api.*""#,
+    // --- logfmt flags ---
+    r#"{job="varlogs"} | logfmt --strict"#,
+    r#"{job="varlogs"} | logfmt --keep-empty --strict host"#,
+    // --- ip() line and label filters ---
+    r#"{job_name="myapp"} |= ip("192.168.4.5/16")"#,
+    r#"{job_name="myapp"} | logfmt | addr = ip("192.168.4.0/24") or addr = ip("10.10.15.0/24")"#,
 ];
 
 /// Documented LogQL features the parser does NOT support yet. Each MUST
@@ -106,22 +122,12 @@ const SUPPORTED: &[&str] = &[
 /// `SUPPORTED` and the failing assertion here will flag it. The trailing
 /// comment names the missing feature.
 const KNOWN_UNSUPPORTED: &[&str] = &[
-    r#"{app="foo"} | logfmt | duration > 1m and bytes_consumed > 20MB"#, // bytes literal (20MB)
-    r#"{app="foo"} | logfmt | size == 20KB"#,                            // bytes literal (20KB)
-    r#"{app="foo"} | logfmt | ((duration >= 20ms or method="GET") and size <= 20KB)"#, // parenthesized label filter + bytes
-    r#"{job="example"} | decolorize"#, // decolorize stage
-    r#"{job="varlogs"}|json|drop level, method="GET""#, // drop with matcher expression
-    r#"{job="varlogs"}|json|keep level, app=~"some-api.*""#, // keep with matcher expression
-    r#"{job="varlogs"} | logfmt --strict"#, // logfmt flags
-    r#"{job="varlogs"} | logfmt --keep-empty --strict host"#, // logfmt flags
     r#"count_over_time({job="mysql"}[5m]) offset 5m"#, // offset after aggregation
     r#"rate(({job="mysql"} |= "error" != "timeout")[10s])"#, // parenthesized selector in range
     r#"avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)"#, // parenthesized selector in range
     r#"sum(count_over_time({namespace="traefik"}[5m])) or vector(0)"#, // vector() function
     r#"label_replace(sum(rate({job="api"}[5m])) by (instance), "host", "$1", "instance", "(.*):.*")"#, // label_replace()
-    r#"{job_name="myapp"} |= ip("192.168.4.5/16")"#, // ip() line filter
-    r#"{job_name="myapp"} | logfmt | addr = ip("192.168.4.0/24") or addr = ip("10.10.15.0/24")"#, // ip() label filter
-    r#"{$label_name=~"$label_value"}"#, // Grafana template variables
+    r#"{$label_name=~"$label_value"}"#, // Grafana template variables (interpolated before LogQL parsing)
 ];
 
 #[test]
@@ -159,9 +165,9 @@ fn known_unsupported_corpus_is_rejected() {
 fn corpus_is_non_trivial() {
     // Guard against accidental truncation of the corpus.
     assert!(
-        SUPPORTED.len() >= 70,
+        SUPPORTED.len() >= 80,
         "supported corpus shrank: {}",
         SUPPORTED.len()
     );
-    assert!(KNOWN_UNSUPPORTED.len() >= 10);
+    assert!(!KNOWN_UNSUPPORTED.is_empty());
 }

--- a/src/logql/tests/corpus.rs
+++ b/src/logql/tests/corpus.rs
@@ -115,6 +115,14 @@ const SUPPORTED: &[&str] = &[
     // --- ip() line and label filters ---
     r#"{job_name="myapp"} |= ip("192.168.4.5/16")"#,
     r#"{job_name="myapp"} | logfmt | addr = ip("192.168.4.0/24") or addr = ip("10.10.15.0/24")"#,
+    // --- offset after aggregation ---
+    r#"count_over_time({job="mysql"}[5m]) offset 5m"#,
+    // --- parenthesized selector in range ---
+    r#"rate(({job="mysql"} |= "error" != "timeout")[10s])"#,
+    r#"avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)"#,
+    // --- vector() and label_replace() ---
+    r#"sum(count_over_time({namespace="traefik"}[5m])) or vector(0)"#,
+    r#"label_replace(sum(rate({job="api"}[5m])) by (instance), "host", "$1", "instance", "(.*):.*")"#,
 ];
 
 /// Documented LogQL features the parser does NOT support yet. Each MUST
@@ -122,12 +130,10 @@ const SUPPORTED: &[&str] = &[
 /// `SUPPORTED` and the failing assertion here will flag it. The trailing
 /// comment names the missing feature.
 const KNOWN_UNSUPPORTED: &[&str] = &[
-    r#"count_over_time({job="mysql"}[5m]) offset 5m"#, // offset after aggregation
-    r#"rate(({job="mysql"} |= "error" != "timeout")[10s])"#, // parenthesized selector in range
-    r#"avg(rate(({job="nginx"} |= "GET" | json | path="/home")[10s])) by (region)"#, // parenthesized selector in range
-    r#"sum(count_over_time({namespace="traefik"}[5m])) or vector(0)"#, // vector() function
-    r#"label_replace(sum(rate({job="api"}[5m])) by (instance), "host", "$1", "instance", "(.*):.*")"#, // label_replace()
-    r#"{$label_name=~"$label_value"}"#, // Grafana template variables (interpolated before LogQL parsing)
+    // Grafana dashboard template variables are interpolated by the
+    // datasource before the query reaches LogQL, so they are
+    // intentionally out of scope for the parser.
+    r#"{$label_name=~"$label_value"}"#,
 ];
 
 #[test]

--- a/src/logql/tests/corpus.rs
+++ b/src/logql/tests/corpus.rs
@@ -6,6 +6,10 @@
 //! two purposes: prove the parser accepts the breadth of syntax users
 //! actually write, and pin down — honestly — the features it does not
 //! support yet, so those gaps are visible and regression-guarded.
+//!
+//! This suite only checks that queries parse; `ast.rs` asserts the exact
+//! tree for one query per construct, catching structural regressions the
+//! parse-only check would miss.
 
 use logql::parse;
 


### PR DESCRIPTION
## Summary

Closes #661. Follow-up to the parser work (#369–#372): implements the common LogQL features the metric-query corpus had flagged as not-yet-supported, so SignalDB now parses essentially the full common LogQL surface. Three focused commits (lexer → pipeline/filters → metric).

### Lexer
- **Bytes literals** (`20KB`, `5MB`, `1GiB`, `512B`) as a distinct token from durations (decimal units ×1000, `*iB` ×1024)
- **Parser-stage flags** (`--strict`, `--keep-empty`); a lone `-` stays subtraction

### Pipeline & filters
- `decolorize`, `distinct` stages
- `logfmt` flags
- `drop`/`keep` with matcher expressions (`drop level, method="GET"`)
- `ip("...")` as line filters and label-filter values
- **Bytes values** in label filters; **parenthesized** label-filter groups
- Type-checking updated: bytes with ordered comparisons, ip() with string matchers

### Metric queries
- `vector(N)` scalar-to-vector literal (for `... or vector(0)`)
- `label_replace(v, dst, replacement, src, regex)`
- `offset` after an aggregation
- Parenthesized selectors inside a range (`rate(({...})[5m])`)

## Corpus

The real-world corpus now has **90 SUPPORTED** queries and **1 KNOWN_UNSUPPORTED** — Grafana dashboard template variables (`$var`), which the datasource interpolates before LogQL parsing and are intentionally out of scope.

## Testing

82 tests (72 unit + 7 structural integration + 3 corpus), all green.

Closes #661 (part of #366)