### PR TITLE
feat(logs): end-to-end LogQL log queries (querier service + router)

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -63,7 +63,7 @@ Key details:
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
 4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
-6. Router also nests a Pyroscope-compatible profile API at `/pyroscope` and a Loki-compatible logs API at `/loki` (the latter returns wire-format stubs until LogQL execution lands, epic #366)
+6. Router also nests a Pyroscope-compatible profile API at `/pyroscope` and a Loki-compatible logs API at `/loki`. LogQL log queries (selectors, line filters, label filters) execute end-to-end: the querier's `LogsService` lowers the parsed query to a DataFusion filter and streams matching log lines back as Loki streams; LogQL metric queries (`rate`, `count_over_time`, ...) are not implemented yet (epic #366)
 
 ## Service Components
 

--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -156,6 +156,10 @@ Any other `do_get` ticket (including `find_trace:...`, `search_traces:...`, and 
 |--------|-------------|
 | `find_trace:{tenant_slug}:{dataset_slug}:{trace_id}[:{start}:{end}]` | Single trace lookup; the optional trailing segments are unix-second time hints (either may be empty) that prune the scanned range. Routers only append them when a hint is present, so the 3-part form remains valid. A missing trace yields a Flight `not_found` status, not an empty stream |
 | `search_traces:{tenant_slug}:{dataset_slug}:{params_json}` | Trace search (`SearchQueryParams` as JSON; unknown fields are ignored on deserialization) |
+| `query_logs:{tenant_slug}:{dataset_slug}:{params_json}` | LogQL log query (`LogQueryParams` as JSON: LogQL string, nanosecond start/end, limit, direction). Returns the projected log columns ordered by timestamp |
+| `query_logs_labels:{tenant_slug}:{dataset_slug}:{start}:{end}` | Log label names in the nanosecond window |
+| `query_logs_label_values:{tenant_slug}:{dataset_slug}:{label}:{start}:{end}` | Distinct values of one log label in the window |
+| `query_logs_series:{tenant_slug}:{dataset_slug}:{params_json}` | Series (label sets) matching a stream selector (`LogSeriesParams` as JSON) |
 | anything else | Treated as a raw SQL query executed via DataFusion |
 
 The standalone querier binary additionally serves Tempo's `tempopb.Querier`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -210,17 +210,17 @@ flowchart LR
 | `GET /pyroscope/label-names`, `/label-values`, `/profile-types` | Implemented -- discovery via Querier |
 | `GET /api/profiles/trace/{trace_id}` | Implemented -- profiles linked to a trace |
 
-**Loki API Endpoints** (logs, nested at `/loki`; wire-format stubs until LogQL
-execution lands, see epic #366):
+**Loki API Endpoints** (logs, nested at `/loki`; see epic #366):
 
 | Endpoint | Status |
 |----------|--------|
-| `GET /loki/api/v1/query` | Stub -- validates params, returns empty streams |
-| `GET /loki/api/v1/query_range` | Stub -- validates params, returns empty streams |
-| `GET /loki/api/v1/labels` | Stub -- returns empty label list |
-| `GET /loki/api/v1/label/{name}/values` | Stub -- returns empty value list |
-| `GET /loki/api/v1/series` | Stub -- returns empty series list |
+| `GET /loki/api/v1/query` | Implemented -- log query over a one-hour window ending at `time` |
+| `GET /loki/api/v1/query_range` | Implemented -- transpiles LogQL to a querier filter, returns Loki streams |
+| `GET /loki/api/v1/labels` | Implemented -- known + attribute label names via Querier |
+| `GET /loki/api/v1/label/{name}/values` | Implemented -- distinct label values via Querier |
+| `GET /loki/api/v1/series` | Implemented -- label sets matching a selector via Querier |
 | `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
+| LogQL metric queries (`rate`, `count_over_time`, ...) | Not implemented yet (#374) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -25,12 +25,13 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tracing::Instrument;
 
+use crate::query::logs::LogsService;
 use crate::query::profile::{
     FindProfileByIdParams, ProfileDiffParams, ProfileDiscoveryParams, ProfileSearchParams,
     ProfileService,
 };
 use crate::query::trace::TraceService;
-use crate::query::{FindTraceByIdParams, SearchQueryParams};
+use crate::query::{FindTraceByIdParams, LogQueryParams, LogSeriesParams, SearchQueryParams};
 
 /// Queries the Iceberg catalog directly, bypassing `datafusion_iceberg`'s
 /// stale `Mirror` cache so newly-created tables are immediately visible.
@@ -210,6 +211,29 @@ enum TicketRequest {
         trace_id: String,
         span_id: Option<String>,
     },
+    QueryLogs {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: LogQueryParams,
+    },
+    QueryLogsLabels {
+        tenant_slug: String,
+        dataset_slug: String,
+        start: i64,
+        end: i64,
+    },
+    QueryLogsLabelValues {
+        tenant_slug: String,
+        dataset_slug: String,
+        label: String,
+        start: i64,
+        end: i64,
+    },
+    QueryLogsSeries {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: LogSeriesParams,
+    },
 }
 
 /// Flight service for query execution against stored data
@@ -222,6 +246,7 @@ pub struct QuerierFlightService {
     session_ctx: Arc<SessionContext>,
     trace_service: TraceService,
     profile_service: ProfileService,
+    logs_service: LogsService,
     #[allow(dead_code)]
     iceberg_catalog: Option<Arc<dyn iceberg_rust::catalog::Catalog>>,
     limits: QuerierConfig,
@@ -302,6 +327,7 @@ impl QuerierFlightService {
             .with_max_search_limit(limits.max_search_limit);
         let profile_service = ProfileService::new(session_ctx.as_ref().clone())
             .with_max_search_limit(limits.max_search_limit);
+        let logs_service = LogsService::new(session_ctx.as_ref().clone());
 
         Self {
             object_store,
@@ -310,6 +336,7 @@ impl QuerierFlightService {
             session_ctx,
             trace_service,
             profile_service,
+            logs_service,
             iceberg_catalog: None,
             limits,
             query_permits: dashmap::DashMap::new(),
@@ -397,6 +424,7 @@ impl QuerierFlightService {
             .with_max_search_limit(limits.max_search_limit);
         let profile_service = ProfileService::new(session_ctx.as_ref().clone())
             .with_max_search_limit(limits.max_search_limit);
+        let logs_service = LogsService::new(session_ctx.as_ref().clone());
 
         Ok(Self {
             object_store,
@@ -405,6 +433,7 @@ impl QuerierFlightService {
             session_ctx,
             trace_service,
             profile_service,
+            logs_service,
             iceberg_catalog: Some(iceberg_catalog),
             limits,
             query_permits: dashmap::DashMap::new(),
@@ -662,6 +691,77 @@ impl QuerierFlightService {
             }
             return Err(Status::invalid_argument(
                 "Invalid sql_profiles ticket format. Expected: sql_profiles:tenant_slug:dataset_slug:sql",
+            ));
+        }
+
+        // LogQL log query: query_logs:{tenant}:{dataset}:{json LogQueryParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_logs:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: LogQueryParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid query_logs parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::QueryLogs {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_logs ticket format. Expected: query_logs:tenant:dataset:{json}",
+            ));
+        }
+
+        // Label names: query_logs_labels:{tenant}:{dataset}:{start}:{end}
+        if let Some(remainder) = ticket_content.strip_prefix("query_logs_labels:") {
+            let parts: Vec<&str> = remainder.splitn(4, ':').collect();
+            if parts.len() == 4 {
+                let (start, end) = parse_ns_window(parts[2], parts[3])?;
+                return Ok(TicketRequest::QueryLogsLabels {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    start,
+                    end,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_logs_labels ticket format. Expected: query_logs_labels:tenant:dataset:start:end",
+            ));
+        }
+
+        // Label values: query_logs_label_values:{tenant}:{dataset}:{label}:{start}:{end}
+        if let Some(remainder) = ticket_content.strip_prefix("query_logs_label_values:") {
+            let parts: Vec<&str> = remainder.splitn(5, ':').collect();
+            if parts.len() == 5 {
+                let (start, end) = parse_ns_window(parts[3], parts[4])?;
+                return Ok(TicketRequest::QueryLogsLabelValues {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    label: parts[2].to_string(),
+                    start,
+                    end,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_logs_label_values ticket format. Expected: query_logs_label_values:tenant:dataset:label:start:end",
+            ));
+        }
+
+        // Series: query_logs_series:{tenant}:{dataset}:{json LogSeriesParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_logs_series:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: LogSeriesParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid query_logs_series parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::QueryLogsSeries {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_logs_series ticket format. Expected: query_logs_series:tenant:dataset:{json}",
             ));
         }
 
@@ -960,7 +1060,11 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
                     | TicketRequest::ProfileDiff { tenant_slug, .. }
                     | TicketRequest::SqlProfiles { tenant_slug, .. }
-                    | TicketRequest::ProfilesByTrace { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::ProfilesByTrace { tenant_slug, .. }
+                    | TicketRequest::QueryLogs { tenant_slug, .. }
+                    | TicketRequest::QueryLogsLabels { tenant_slug, .. }
+                    | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
+                    | TicketRequest::QueryLogsSeries { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -988,6 +1092,10 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::ProfileDiff { .. } => "profile_diff",
                 TicketRequest::SqlProfiles { .. } => "sql_profiles",
                 TicketRequest::ProfilesByTrace { .. } => "profiles_by_trace",
+                TicketRequest::QueryLogs { .. } => "query_logs",
+                TicketRequest::QueryLogsLabels { .. } => "query_logs_labels",
+                TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
+                TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -1009,7 +1117,11 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
                     | TicketRequest::ProfileDiff { tenant_slug, .. }
                     | TicketRequest::SqlProfiles { tenant_slug, .. }
-                    | TicketRequest::ProfilesByTrace { tenant_slug, .. } => {
+                    | TicketRequest::ProfilesByTrace { tenant_slug, .. }
+                    | TicketRequest::QueryLogs { tenant_slug, .. }
+                    | TicketRequest::QueryLogsLabels { tenant_slug, .. }
+                    | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
+                    | TicketRequest::QueryLogsSeries { tenant_slug, .. } => {
                         Some(tenant_slug.clone())
                     }
                     TicketRequest::SqlQuery { .. } => None,
@@ -1261,6 +1373,67 @@ impl FlightService for QuerierFlightService {
                             .await
                             .map_err(querier_error_to_status)?
                     }
+                    TicketRequest::QueryLogs {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        tracing::info!(
+                            tenant_slug = %tenant_slug,
+                            dataset_slug = %dataset_slug,
+                            query = %params.query,
+                            "Executing query_logs"
+                        );
+                        self.logs_service
+                            .query_logs(&params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?
+                    }
+                    TicketRequest::QueryLogsLabels {
+                        tenant_slug,
+                        dataset_slug,
+                        start,
+                        end,
+                    } => {
+                        let labels = self
+                            .logs_service
+                            .get_labels(start, end, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![strings_to_batch("label", labels)?]
+                    }
+                    TicketRequest::QueryLogsLabelValues {
+                        tenant_slug,
+                        dataset_slug,
+                        label,
+                        start,
+                        end,
+                    } => {
+                        let values = self
+                            .logs_service
+                            .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![strings_to_batch("value", values)?]
+                    }
+                    TicketRequest::QueryLogsSeries {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        let series = self
+                            .logs_service
+                            .get_series(
+                                &params.selector,
+                                params.start,
+                                params.end,
+                                &tenant_slug,
+                                &dataset_slug,
+                            )
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![json_to_batch("series", &series)?]
+                    }
                     TicketRequest::SqlProfiles {
                         tenant_slug,
                         dataset_slug,
@@ -1406,6 +1579,19 @@ impl FlightService for QuerierFlightService {
         let out = stream::empty().boxed();
         Ok(Response::new(out))
     }
+}
+
+/// Parse a `start:end` nanosecond window from ticket segments.
+#[allow(clippy::result_large_err)]
+fn parse_ns_window(start: &str, end: &str) -> Result<(i64, i64), Status> {
+    let parse = |name: &str, value: &str| -> Result<i64, Status> {
+        value.parse::<i64>().map_err(|_| {
+            Status::invalid_argument(format!(
+                "{name} '{value}' is not a unix-nanosecond timestamp"
+            ))
+        })
+    };
+    Ok((parse("start", start)?, parse("end", end)?))
 }
 
 /// Parse the optional JSON tail of a profile discovery ticket.
@@ -1700,6 +1886,84 @@ mod tests {
             }
             other => panic!("expected FindTrace, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn parse_query_logs_ticket() {
+        let service = make_service().await;
+        let ticket = r#"query_logs:acme:prod:{"query":"{service_name=\"api\"}","start":10,"end":20,"limit":50,"direction":"forward"}"#;
+        match service.parse_ticket(ticket).unwrap() {
+            TicketRequest::QueryLogs {
+                tenant_slug,
+                dataset_slug,
+                params,
+            } => {
+                assert_eq!(tenant_slug, "acme");
+                assert_eq!(dataset_slug, "prod");
+                assert_eq!(params.query, r#"{service_name="api"}"#);
+                assert_eq!((params.start, params.end, params.limit), (10, 20, 50));
+                assert_eq!(params.direction.as_deref(), Some("forward"));
+            }
+            other => panic!("expected QueryLogs, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_query_logs_metadata_tickets() {
+        let service = make_service().await;
+
+        match service
+            .parse_ticket("query_logs_labels:acme:prod:10:20")
+            .unwrap()
+        {
+            TicketRequest::QueryLogsLabels {
+                start,
+                end,
+                tenant_slug,
+                ..
+            } => {
+                assert_eq!((start, end), (10, 20));
+                assert_eq!(tenant_slug, "acme");
+            }
+            other => panic!("expected QueryLogsLabels, got {other:?}"),
+        }
+
+        match service
+            .parse_ticket("query_logs_label_values:acme:prod:service_name:10:20")
+            .unwrap()
+        {
+            TicketRequest::QueryLogsLabelValues {
+                label, start, end, ..
+            } => {
+                assert_eq!(label, "service_name");
+                assert_eq!((start, end), (10, 20));
+            }
+            other => panic!("expected QueryLogsLabelValues, got {other:?}"),
+        }
+
+        let series = r#"query_logs_series:acme:prod:{"selector":"{service_name=\"api\"}","start":10,"end":20}"#;
+        match service.parse_ticket(series).unwrap() {
+            TicketRequest::QueryLogsSeries { params, .. } => {
+                assert_eq!(params.selector, r#"{service_name="api"}"#);
+                assert_eq!((params.start, params.end), (10, 20));
+            }
+            other => panic!("expected QueryLogsSeries, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_query_logs_tickets_are_rejected() {
+        let service = make_service().await;
+        assert!(
+            service
+                .parse_ticket("query_logs:acme:prod:not-json")
+                .is_err()
+        );
+        assert!(
+            service
+                .parse_ticket("query_logs_labels:acme:prod:notanumber:20")
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -1,0 +1,615 @@
+//! # Log Query Service
+//!
+//! DataFusion-backed execution of LogQL log queries against the
+//! tenant-scoped `logs` Iceberg table. Parses a LogQL query, lowers it to
+//! a filter [`Expr`](datafusion::logical_expr::Expr) via
+//! [`super::logql::log_query_filter`], and runs it through the DataFrame
+//! API — the same shape as [`super::trace`] and [`super::profile`], so
+//! user-controlled query values never enter a SQL string.
+//!
+//! Alongside line queries this service backs the Loki metadata endpoints:
+//! label names, label values, and series discovery.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use datafusion::{
+    arrow::array::{Array, RecordBatch, StringArray},
+    logical_expr::{Expr, col, lit},
+    prelude::{DataFrame, SessionContext},
+    scalar::ScalarValue,
+};
+use logql::{LogQuery, parse_query, parse_selector};
+
+use super::logql::log_query_filter;
+use super::{LogQueryParams, error::QuerierError, table_ref::build_table_reference};
+
+/// Columns projected for a log-line query, in wire order. The Flight
+/// layer streams these; the router shapes them into Loki streams.
+pub const LOG_COLUMNS: &[&str] = &[
+    "timestamp",
+    "body",
+    "service_name",
+    "severity_text",
+    "trace_id",
+    "span_id",
+    "log_attributes",
+    "resource_attributes",
+];
+
+/// LogQL label names backed by dedicated columns, in Loki label form.
+const KNOWN_LABELS: &[&str] = &[
+    "detected_level",
+    "level",
+    "service_name",
+    "span_id",
+    "trace_id",
+];
+
+/// Columns whose distinct values define a series' identity.
+const SERIES_COLUMNS: &[&str] = &["service_name", "severity_text"];
+
+/// Upper bound on distinct attribute documents scanned for discovery.
+const LABEL_SCAN_LIMIT: usize = 1000;
+
+/// Scan direction for a log query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Forward,
+    Backward,
+}
+
+impl Direction {
+    /// Parse the Loki `direction` string, defaulting to `Backward`.
+    pub fn parse(value: Option<&str>) -> Self {
+        match value {
+            Some("forward") => Direction::Forward,
+            _ => Direction::Backward,
+        }
+    }
+
+    fn ascending(self) -> bool {
+        matches!(self, Direction::Forward)
+    }
+}
+
+/// Executes LogQL log queries and Loki metadata lookups.
+pub struct LogsService {
+    session_context: Arc<SessionContext>,
+}
+
+impl Debug for LogsService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogsService")
+            .field("session_context", &"set")
+            .finish()
+    }
+}
+
+impl Clone for LogsService {
+    fn clone(&self) -> Self {
+        Self {
+            session_context: Arc::clone(&self.session_context),
+        }
+    }
+}
+
+impl LogsService {
+    pub fn new(session_context: SessionContext) -> Self {
+        Self {
+            session_context: Arc::new(session_context),
+        }
+    }
+
+    async fn logs_table(
+        &self,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<DataFrame, QuerierError> {
+        let table_ref = build_table_reference(tenant_slug, dataset_slug, "logs")
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        self.session_context.table(table_ref).await.map_err(|e| {
+            log::error!(
+                "Failed to access logs table for tenant_slug={tenant_slug}, dataset_slug={dataset_slug}: {e}"
+            );
+            QuerierError::QueryFailed(e)
+        })
+    }
+
+    /// Execute a LogQL log query, returning the projected log-line
+    /// RecordBatches ordered by timestamp per the request's direction.
+    /// The window (`start`/`end`) is inclusive unix-epoch nanoseconds.
+    pub async fn query_logs(
+        &self,
+        params: &LogQueryParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let parsed =
+            parse_query(&params.query).map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        let filter = log_query_filter(&parsed)?;
+        let direction = Direction::parse(params.direction.as_deref());
+
+        let df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let df = shape_log_query(
+            df,
+            filter,
+            params.start,
+            params.end,
+            params.limit,
+            direction,
+        )?;
+        df.collect().await.map_err(QuerierError::QueryFailed)
+    }
+
+    /// List the label names available for logs. Returns the labels backed
+    /// by dedicated columns plus any attribute keys discovered in the
+    /// window's `log_attributes` / `resource_attributes` documents.
+    pub async fn get_labels(
+        &self,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<String>, QuerierError> {
+        let mut labels: BTreeSet<String> = KNOWN_LABELS.iter().map(|s| s.to_string()).collect();
+
+        let df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let df = apply_window(df, start, end)?;
+        let batches = df
+            .select_columns(&["log_attributes", "resource_attributes"])
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        for batch in &batches {
+            for column in ["log_attributes", "resource_attributes"] {
+                let attrs = string_column(batch, column)?;
+                for i in 0..batch.num_rows() {
+                    if attrs.is_null(i) {
+                        continue;
+                    }
+                    if let Ok(serde_json::Value::Object(map)) =
+                        serde_json::from_str::<serde_json::Value>(attrs.value(i))
+                    {
+                        labels.extend(map.keys().cloned());
+                    }
+                }
+            }
+        }
+
+        Ok(labels.into_iter().collect())
+    }
+
+    /// List the distinct values of one label in the window.
+    pub async fn get_label_values(
+        &self,
+        label: &str,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<String>, QuerierError> {
+        if label.is_empty() {
+            return Err(QuerierError::InvalidInput(
+                "label name must not be empty".to_string(),
+            ));
+        }
+
+        let df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let df = apply_window(df, start, end)?;
+
+        // Known labels are dedicated columns: distinct on the column.
+        if let Some(column) = column_for_label(label) {
+            let batches = df
+                .select_columns(&[column])
+                .map_err(QuerierError::QueryFailed)?
+                .distinct()
+                .map_err(QuerierError::QueryFailed)?
+                .collect()
+                .await
+                .map_err(QuerierError::QueryFailed)?;
+            return distinct_non_empty(&batches, column);
+        }
+
+        // Otherwise pull the value out of the attribute documents.
+        let batches = df
+            .select_columns(&["log_attributes", "resource_attributes"])
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        let mut values = BTreeSet::new();
+        for batch in &batches {
+            for column in ["log_attributes", "resource_attributes"] {
+                let attrs = string_column(batch, column)?;
+                for i in 0..batch.num_rows() {
+                    if attrs.is_null(i) {
+                        continue;
+                    }
+                    if let Ok(serde_json::Value::Object(map)) =
+                        serde_json::from_str::<serde_json::Value>(attrs.value(i))
+                        && let Some(value) = map.get(label)
+                    {
+                        match value {
+                            serde_json::Value::String(s) => {
+                                values.insert(s.clone());
+                            }
+                            other => {
+                                values.insert(other.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(values.into_iter().collect())
+    }
+
+    /// List the distinct series (label sets) matching a stream selector.
+    /// Series identity is the dedicated columns in [`SERIES_COLUMNS`].
+    pub async fn get_series(
+        &self,
+        selector: &str,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<BTreeMap<String, String>>, QuerierError> {
+        // An empty matcher list is invalid in Loki's /series.
+        let parsed = parse_selector(selector.trim())
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        let filter = log_query_filter(&LogQuery {
+            selector: parsed,
+            pipeline: Vec::new(),
+        })?;
+
+        let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
+        df = apply_window(df, start, end)?;
+        if let Some(filter) = filter {
+            df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
+        }
+
+        let batches = df
+            .select_columns(SERIES_COLUMNS)
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        let mut series = BTreeSet::new();
+        for batch in &batches {
+            let service = string_column(batch, "service_name")?;
+            let severity = string_column(batch, "severity_text")?;
+            for i in 0..batch.num_rows() {
+                let mut labels = BTreeMap::new();
+                if !service.is_null(i) && !service.value(i).is_empty() {
+                    labels.insert("service_name".to_string(), service.value(i).to_string());
+                }
+                if !severity.is_null(i) && !severity.value(i).is_empty() {
+                    labels.insert("level".to_string(), severity.value(i).to_string());
+                }
+                if !labels.is_empty() {
+                    series.insert(labels);
+                }
+            }
+        }
+        Ok(series.into_iter().collect())
+    }
+}
+
+/// Apply the projection, filter, ordering, and limit of a log-line query
+/// to a base DataFrame. Split out so it can be tested against an
+/// in-memory table.
+pub fn shape_log_query(
+    df: DataFrame,
+    filter: Option<Expr>,
+    start: i64,
+    end: i64,
+    limit: u32,
+    direction: Direction,
+) -> Result<DataFrame, QuerierError> {
+    let mut df = apply_window(df, start, end)?;
+    if let Some(filter) = filter {
+        df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
+    }
+    df.select_columns(LOG_COLUMNS)
+        .map_err(QuerierError::QueryFailed)?
+        .sort(vec![col("timestamp").sort(direction.ascending(), true)])
+        .map_err(QuerierError::QueryFailed)?
+        .limit(0, Some(limit as usize))
+        .map_err(QuerierError::QueryFailed)
+}
+
+/// Inclusive nanosecond bounds on the `timestamp` column.
+fn apply_window(df: DataFrame, start: i64, end: i64) -> Result<DataFrame, QuerierError> {
+    df.filter(col("timestamp").gt_eq(lit(ScalarValue::TimestampNanosecond(Some(start), None))))
+        .map_err(QuerierError::QueryFailed)?
+        .filter(col("timestamp").lt_eq(lit(ScalarValue::TimestampNanosecond(Some(end), None))))
+        .map_err(QuerierError::QueryFailed)
+}
+
+/// The dedicated column a known label maps to.
+fn column_for_label(label: &str) -> Option<&'static str> {
+    match label {
+        "service_name" | "service" | "job" => Some("service_name"),
+        "level" | "severity" | "detected_level" => Some("severity_text"),
+        "trace_id" => Some("trace_id"),
+        "span_id" => Some("span_id"),
+        _ => None,
+    }
+}
+
+/// Collect the sorted, distinct, non-empty values of a string column.
+fn distinct_non_empty(batches: &[RecordBatch], column: &str) -> Result<Vec<String>, QuerierError> {
+    let mut values = BTreeSet::new();
+    for batch in batches {
+        let col = string_column(batch, column)?;
+        for i in 0..batch.num_rows() {
+            if !col.is_null(i) && !col.value(i).is_empty() {
+                values.insert(col.value(i).to_string());
+            }
+        }
+    }
+    Ok(values.into_iter().collect())
+}
+
+fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, QuerierError> {
+    batch
+        .column_by_name(name)
+        .ok_or_else(|| QuerierError::InvalidInput(format!("missing column '{name}'")))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            QuerierError::InvalidInput(format!("column '{name}' is not a string column"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::TimestampNanosecondArray;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::catalog::memory::MemTable;
+    use datafusion::catalog::{
+        CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider,
+    };
+
+    fn logs_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("body", DataType::Utf8, true),
+            Field::new("service_name", DataType::Utf8, true),
+            Field::new("severity_text", DataType::Utf8, true),
+            Field::new("trace_id", DataType::Utf8, true),
+            Field::new("span_id", DataType::Utf8, true),
+            Field::new("log_attributes", DataType::Utf8, true),
+            Field::new("resource_attributes", DataType::Utf8, true),
+        ]))
+    }
+
+    fn str_col(values: &[&str]) -> Arc<StringArray> {
+        Arc::new(StringArray::from(values.to_vec()))
+    }
+
+    /// A context with a `t.d.logs` table holding three sample rows.
+    fn service_with_data() -> LogsService {
+        let schema = logs_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300])),
+                str_col(&["boom happened", "all good", "boom again"]),
+                str_col(&["api", "api", "web"]),
+                str_col(&["error", "info", "error"]),
+                str_col(&["t1", "t2", "t3"]),
+                str_col(&["s1", "s2", "s3"]),
+                str_col(&[
+                    r#"{"namespace":"prod","pod":"api-1"}"#,
+                    r#"{"namespace":"prod","pod":"api-2"}"#,
+                    r#"{"namespace":"staging","pod":"web-1"}"#,
+                ]),
+                str_col(&["{}", "{}", "{}"]),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("logs".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+
+        LogsService::new(ctx)
+    }
+
+    fn params(query: &str, start: i64, end: i64, direction: Direction) -> LogQueryParams {
+        LogQueryParams {
+            query: query.to_string(),
+            start,
+            end,
+            limit: 100,
+            direction: Some(
+                if direction == Direction::Forward {
+                    "forward"
+                } else {
+                    "backward"
+                }
+                .to_string(),
+            ),
+        }
+    }
+
+    async fn rows(service: &LogsService, query: &str, direction: Direction) -> Vec<(i64, String)> {
+        let batches = service
+            .query_logs(&params(query, 0, 1000, direction), "t", "d")
+            .await
+            .expect("query");
+        let mut out = Vec::new();
+        for batch in &batches {
+            let ts = batch
+                .column_by_name("timestamp")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .unwrap();
+            let body = string_column(batch, "body").unwrap();
+            for i in 0..batch.num_rows() {
+                out.push((ts.value(i), body.value(i).to_string()));
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn selector_query_returns_matching_lines() {
+        let service = service_with_data();
+        let out = rows(&service, r#"{service_name="api"}"#, Direction::Forward).await;
+        assert_eq!(
+            out,
+            vec![
+                (100, "boom happened".to_string()),
+                (200, "all good".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn line_filter_narrows_results() {
+        let service = service_with_data();
+        let out = rows(
+            &service,
+            r#"{service_name="api"} |= "boom""#,
+            Direction::Forward,
+        )
+        .await;
+        assert_eq!(out, vec![(100, "boom happened".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn attribute_label_matches_json() {
+        let service = service_with_data();
+        let out = rows(&service, r#"{namespace="staging"}"#, Direction::Forward).await;
+        assert_eq!(out, vec![(300, "boom again".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn direction_backward_orders_newest_first() {
+        let service = service_with_data();
+        let out = rows(&service, r#"{service_name="api"}"#, Direction::Backward).await;
+        assert_eq!(out.first().unwrap().0, 200);
+        assert_eq!(out.last().unwrap().0, 100);
+    }
+
+    #[tokio::test]
+    async fn time_window_bounds_are_applied() {
+        let service = service_with_data();
+        let batches = service
+            .query_logs(
+                &params(r#"{service_name="api"}"#, 150, 1000, Direction::Forward),
+                "t",
+                "d",
+            )
+            .await
+            .unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1); // only ts=200 falls in [150, 1000]
+    }
+
+    #[tokio::test]
+    async fn get_label_values_for_known_columns() {
+        let service = service_with_data();
+        assert_eq!(
+            service
+                .get_label_values("service_name", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["api".to_string(), "web".to_string()]
+        );
+        assert_eq!(
+            service
+                .get_label_values("level", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["error".to_string(), "info".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_label_values_from_attributes() {
+        let service = service_with_data();
+        assert_eq!(
+            service
+                .get_label_values("namespace", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["prod".to_string(), "staging".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_labels_includes_known_and_attribute_keys() {
+        let service = service_with_data();
+        let labels = service.get_labels(0, 1000, "t", "d").await.unwrap();
+        assert!(labels.contains(&"service_name".to_string()));
+        assert!(labels.contains(&"level".to_string()));
+        assert!(labels.contains(&"namespace".to_string()));
+        assert!(labels.contains(&"pod".to_string()));
+    }
+
+    #[tokio::test]
+    async fn get_series_returns_distinct_label_sets() {
+        let service = service_with_data();
+        let series = service
+            .get_series(r#"{service_name="api"}"#, 0, 1000, "t", "d")
+            .await
+            .unwrap();
+        // api has both error and info severities.
+        assert_eq!(series.len(), 2);
+        assert!(
+            series
+                .iter()
+                .all(|s| s.get("service_name") == Some(&"api".to_string()))
+        );
+        let levels: BTreeSet<_> = series
+            .iter()
+            .filter_map(|s| s.get("level").cloned())
+            .collect();
+        assert_eq!(
+            levels,
+            BTreeSet::from(["error".to_string(), "info".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_label_name_is_rejected() {
+        let service = service_with_data();
+        assert!(matches!(
+            service.get_label_values("", 0, 1000, "t", "d").await,
+            Err(QuerierError::InvalidInput(_))
+        ));
+    }
+}

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -1,9 +1,40 @@
 pub mod error;
 pub mod logql;
+pub mod logs;
 pub mod profile;
 pub mod search_filter;
 pub mod table_ref;
 pub mod trace;
+
+/// Parameters carried in the `query_logs` Flight ticket (JSON-encoded).
+///
+/// Mirrors Loki's range/instant query surface: a LogQL string plus a
+/// nanosecond time window, a row limit, and the scan direction.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogQueryParams {
+    /// The LogQL query string.
+    pub query: String,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+    /// Maximum rows to return.
+    pub limit: u32,
+    /// `"forward"` or `"backward"` (default).
+    #[serde(default)]
+    pub direction: Option<String>,
+}
+
+/// Parameters carried in the `query_logs_series` Flight ticket.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogSeriesParams {
+    /// The stream selector, e.g. `{service_name="api"}`.
+    pub selector: String,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+}
 
 /// Parameters for single-trace lookup.
 #[derive(Debug)]

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -14,7 +14,10 @@
 //! log service (#373–#377). The `/api/v1/tail` WebSocket endpoint is
 //! tracked separately (#380).
 
+use std::collections::HashMap;
+
 use crate::RouterState;
+use arrow_flight::{Ticket, utils::flight_data_to_batches};
 use axum::{
     Router,
     extract::{Path, Query, State},
@@ -22,7 +25,10 @@ use axum::{
     routing::get,
 };
 use common::auth::TenantContextExtractor;
-use loki_api::{LabelsResponse, QueryResponse, QueryResult, SeriesResponse};
+use common::flight::transport::ServiceCapability;
+use datafusion::arrow::array::{Array, RecordBatch, StringArray, TimestampNanosecondArray};
+use futures::StreamExt;
+use loki_api::{LabelsResponse, LogEntry, QueryResponse, QueryResult, SeriesResponse, Stream};
 use serde::Deserialize;
 
 pub fn router<S: RouterState>() -> Router<S> {
@@ -112,70 +118,103 @@ fn validate_direction(direction: &str) -> Result<(), StatusCode> {
 }
 
 /// GET /loki/api/v1/query — instant query.
+///
+/// For a log selector this returns the most recent lines in the window;
+/// the instant `time` (or now) is treated as the window end with a
+/// default one-hour lookback, matching how Grafana renders instant log
+/// panels.
 #[tracing::instrument(
-    skip(_state, tenant_ctx, params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id
     )
 )]
 pub async fn query<S: RouterState>(
-    State(_state): State<S>,
+    State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<InstantQueryParams>,
 ) -> Result<axum::Json<QueryResponse>, StatusCode> {
     let logql = require_query(&params.query)?;
     validate_direction(&params.direction)?;
-    tracing::debug!(query = %logql, "LogQL instant query (stub)");
 
-    // Instant queries over log selectors return streams; execution is
-    // wired up in #376. Until then, answer with an empty stream set.
+    let end = parse_timestamp_ns(params.time.as_deref()).unwrap_or_else(now_ns);
+    let start = end - HOUR_NS;
+    let streams = run_log_query(
+        &state,
+        &tenant_ctx,
+        &logql,
+        start,
+        end,
+        params.limit,
+        &params.direction,
+    )
+    .await?;
     Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
-        vec![],
+        streams,
     ))))
 }
 
 /// GET /loki/api/v1/query_range — range query.
 #[tracing::instrument(
-    skip(_state, tenant_ctx, params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id
     )
 )]
 pub async fn query_range<S: RouterState>(
-    State(_state): State<S>,
+    State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<RangeQueryParams>,
 ) -> Result<axum::Json<QueryResponse>, StatusCode> {
     let logql = require_query(&params.query)?;
     validate_direction(&params.direction)?;
-    tracing::debug!(query = %logql, "LogQL range query (stub)");
 
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    let streams = run_log_query(
+        &state,
+        &tenant_ctx,
+        &logql,
+        start,
+        end,
+        params.limit,
+        &params.direction,
+    )
+    .await?;
     Ok(axum::Json(QueryResponse::success(QueryResult::Streams(
-        vec![],
+        streams,
     ))))
 }
 
 /// GET /loki/api/v1/labels — list label names.
 #[tracing::instrument(
-    skip(_state, tenant_ctx, _params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id
     )
 )]
 pub async fn labels<S: RouterState>(
-    State(_state): State<S>,
+    State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
-    Query(_params): Query<MetadataParams>,
+    Query(params): Query<MetadataParams>,
 ) -> Result<axum::Json<LabelsResponse>, StatusCode> {
-    Ok(axum::Json(LabelsResponse::success(vec![])))
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_logs_labels:{}:{}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "label",
+    ))))
 }
 
 /// GET /loki/api/v1/label/{name}/values — list values of one label.
 #[tracing::instrument(
-    skip(_state, tenant_ctx, _params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id,
@@ -183,31 +222,277 @@ pub async fn labels<S: RouterState>(
     )
 )]
 pub async fn label_values<S: RouterState>(
-    State(_state): State<S>,
+    State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Path(name): Path<String>,
-    Query(_params): Query<MetadataParams>,
+    Query(params): Query<MetadataParams>,
 ) -> Result<axum::Json<LabelsResponse>, StatusCode> {
     if name.trim().is_empty() {
         return Err(StatusCode::BAD_REQUEST);
     }
-    Ok(axum::Json(LabelsResponse::success(vec![])))
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_logs_label_values:{}:{}:{name}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "value",
+    ))))
 }
 
 /// GET /loki/api/v1/series — list series matching a selector.
 #[tracing::instrument(
-    skip(_state, tenant_ctx, _params),
+    skip(state, tenant_ctx, params),
     fields(
         tenant_id = %tenant_ctx.0.tenant_id,
         dataset_id = %tenant_ctx.0.dataset_id
     )
 )]
 pub async fn series<S: RouterState>(
-    State(_state): State<S>,
+    State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
-    Query(_params): Query<MetadataParams>,
+    Query(params): Query<MetadataParams>,
 ) -> Result<axum::Json<SeriesResponse>, StatusCode> {
-    Ok(axum::Json(SeriesResponse::success(vec![])))
+    let selector = params
+        .matcher
+        .as_deref()
+        .or(params.query.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let (start, end) = metadata_window(&params);
+
+    let payload = serde_json::json!({ "selector": selector, "start": start, "end": end });
+    let ticket = format!(
+        "query_logs_series:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(SeriesResponse::success(series_from_batches(
+        &batches,
+    ))))
+}
+
+// ---- execution + conversion ----
+
+/// One hour in nanoseconds, the default lookback window.
+const HOUR_NS: i64 = 3_600_000_000_000;
+
+/// Build and execute a `query_logs` ticket, converting the result batches
+/// into Loki streams.
+async fn run_log_query<S: RouterState>(
+    state: &S,
+    tenant_ctx: &TenantContextExtractor,
+    logql: &str,
+    start: i64,
+    end: i64,
+    limit: u32,
+    direction: &str,
+) -> Result<Vec<Stream>, StatusCode> {
+    let payload = serde_json::json!({
+        "query": logql,
+        "start": start,
+        "end": end,
+        "limit": limit,
+        "direction": direction,
+    });
+    let ticket = format!(
+        "query_logs:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(state, ticket).await?;
+    Ok(batches_to_streams(&batches))
+}
+
+/// Send a Flight ticket to a querier and collect the result batches.
+async fn execute_ticket<S: RouterState>(
+    state: &S,
+    ticket_content: String,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let mut client = state
+        .service_registry()
+        .get_flight_client_for_capability(ServiceCapability::QueryExecution)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to get Flight client for log query");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    let ticket = Ticket::new(ticket_content);
+    let mut flight_request = tonic::Request::new(ticket);
+    common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
+
+    let mut stream = client
+        .do_get(flight_request)
+        .await
+        .map_err(|e| flight_status_to_http(&e))?
+        .into_inner();
+
+    let mut data = Vec::new();
+    while let Some(flight_data) = stream.next().await {
+        data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
+    }
+
+    flight_data_to_batches(&data).map_err(|e| {
+        tracing::error!(error = %e, "Failed to decode log Flight data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+fn flight_status_to_http(status: &tonic::Status) -> StatusCode {
+    match status.code() {
+        tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+        _ => {
+            tracing::error!(error = %status, "Log Flight query failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// Group the projected log rows into Loki streams by their label set,
+/// preserving row order (the querier already sorts by direction).
+fn batches_to_streams(batches: &[RecordBatch]) -> Vec<Stream> {
+    // Preserve first-seen label-set order for stable output.
+    let mut order: Vec<String> = Vec::new();
+    let mut streams: HashMap<String, Stream> = HashMap::new();
+
+    for batch in batches {
+        let Some(timestamps) = batch
+            .column_by_name("timestamp")
+            .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+        else {
+            continue;
+        };
+        let body = str_col(batch, "body");
+        let service = str_col(batch, "service_name");
+        let severity = str_col(batch, "severity_text");
+
+        for i in 0..batch.num_rows() {
+            let mut label_set: HashMap<String, String> = HashMap::new();
+            if let Some(v) = value_at(&service, i) {
+                label_set.insert("service_name".to_string(), v);
+            }
+            if let Some(v) = value_at(&severity, i) {
+                label_set.insert("level".to_string(), v);
+            }
+            let key = label_key(&label_set);
+            let entry = LogEntry::new(
+                if timestamps.is_null(i) {
+                    0
+                } else {
+                    timestamps.value(i)
+                },
+                value_at(&body, i).unwrap_or_default(),
+            );
+            streams
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    order.push(key.clone());
+                    Stream {
+                        stream: label_set,
+                        values: Vec::new(),
+                    }
+                })
+                .values
+                .push(entry);
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| streams.remove(&k))
+        .collect()
+}
+
+/// A deterministic key for a label set (sorted `k=v` pairs).
+fn label_key(labels: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = labels.iter().collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Decode a `series` JSON batch (from `query_logs_series`) into label maps.
+fn series_from_batches(batches: &[RecordBatch]) -> Vec<HashMap<String, String>> {
+    let mut out = Vec::new();
+    for value in string_column(batches, "series") {
+        if let Ok(series) = serde_json::from_str::<Vec<HashMap<String, String>>>(&value) {
+            out.extend(series);
+        }
+    }
+    out
+}
+
+/// Collect the values of a single-string-column result batch.
+fn string_column(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let col = str_col(batch, column);
+        if let Some(col) = col {
+            for i in 0..col.len() {
+                if !col.is_null(i) {
+                    out.push(col.value(i).to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+}
+
+fn value_at(col: &Option<&StringArray>, i: usize) -> Option<String> {
+    col.filter(|c| !c.is_null(i) && !c.value(i).is_empty())
+        .map(|c| c.value(i).to_string())
+}
+
+/// Resolve a metadata endpoint's `[start, end]` window in nanoseconds,
+/// defaulting to the last hour.
+fn metadata_window(params: &MetadataParams) -> (i64, i64) {
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    (start, end)
+}
+
+/// Current time as unix-epoch nanoseconds.
+fn now_ns() -> i64 {
+    chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() * 1_000_000)
+}
+
+/// Parse a Loki timestamp parameter into unix-epoch nanoseconds. Accepts
+/// a nanosecond integer, a smaller unix-seconds integer, or an RFC3339
+/// string. Returns `None` when absent or unparseable.
+fn parse_timestamp_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(n) = value.parse::<i64>() {
+        // Heuristic: values below ~year 2286 in seconds are seconds.
+        return Some(if n < 10_000_000_000 {
+            n.saturating_mul(1_000_000_000)
+        } else {
+            n
+        });
+    }
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .and_then(|dt| dt.timestamp_nanos_opt())
 }
 
 #[cfg(test)]
@@ -261,32 +546,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_range_returns_empty_streams_stub() {
-        let app = test_app().await;
-        let (status, body) = get_json(
-            &app,
-            "/loki/api/v1/query_range?query=%7Bservice_name%3D%22api%22%7D&limit=50",
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            body.unwrap(),
-            serde_json::json!({
-                "status": "success",
-                "data": {"resultType": "streams", "result": []}
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn instant_query_returns_empty_streams_stub() {
-        let app = test_app().await;
-        let (status, body) = get_json(&app, "/loki/api/v1/query?query=%7Bjob%3D%22x%22%7D").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body.unwrap()["data"]["resultType"], "streams");
-    }
-
-    #[tokio::test]
     async fn query_without_query_param_is_bad_request() {
         let app = test_app().await;
         let (status, _) = get_json(&app, "/loki/api/v1/query").await;
@@ -307,27 +566,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn metadata_endpoints_return_empty_stubs() {
+    async fn series_without_selector_is_bad_request() {
         let app = test_app().await;
+        let (status, _) = get_json(&app, "/loki/api/v1/series").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
 
-        let (status, body) = get_json(&app, "/loki/api/v1/labels").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            body.unwrap(),
-            serde_json::json!({"status": "success", "data": []})
-        );
-
-        let (status, body) = get_json(&app, "/loki/api/v1/label/service_name/values").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body.unwrap()["status"], "success");
-
-        let (status, body) =
-            get_json(&app, "/loki/api/v1/series?match%5B%5D=%7Bjob%3D%22x%22%7D").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(
-            body.unwrap(),
-            serde_json::json!({"status": "success", "data": []})
-        );
+    #[tokio::test]
+    async fn query_without_a_querier_is_service_unavailable() {
+        // A valid query with no discovered querier surfaces 503, not 200.
+        let app = test_app().await;
+        let (status, _) = get_json(&app, "/loki/api/v1/query?query=%7Bjob%3D%22x%22%7D").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
@@ -351,5 +601,110 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ---- Arrow -> Loki conversion (#377) ----
+
+    mod convert {
+        use super::super::{
+            batches_to_streams, parse_timestamp_ns, series_from_batches, string_column,
+        };
+        use datafusion::arrow::array::{RecordBatch, StringArray, TimestampNanosecondArray};
+        use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+        use std::sync::Arc;
+
+        fn log_batch() -> RecordBatch {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new(
+                    "timestamp",
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    false,
+                ),
+                Field::new("body", DataType::Utf8, true),
+                Field::new("service_name", DataType::Utf8, true),
+                Field::new("severity_text", DataType::Utf8, true),
+            ]));
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300])),
+                    Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                    Arc::new(StringArray::from(vec!["api", "api", "web"])),
+                    Arc::new(StringArray::from(vec!["error", "error", "info"])),
+                ],
+            )
+            .unwrap()
+        }
+
+        #[test]
+        fn groups_rows_into_streams_by_label_set() {
+            let streams = batches_to_streams(&[log_batch()]);
+            // {api,error} has two entries; {web,info} has one.
+            assert_eq!(streams.len(), 2);
+            let api = streams
+                .iter()
+                .find(|s| s.stream.get("service_name") == Some(&"api".to_string()))
+                .unwrap();
+            assert_eq!(api.stream.get("level"), Some(&"error".to_string()));
+            assert_eq!(api.values.len(), 2);
+            assert_eq!(api.values[0], loki_api::LogEntry::new(100, "a"));
+            assert_eq!(api.values[1], loki_api::LogEntry::new(200, "b"));
+
+            let web = streams
+                .iter()
+                .find(|s| s.stream.get("service_name") == Some(&"web".to_string()))
+                .unwrap();
+            assert_eq!(web.values, vec![loki_api::LogEntry::new(300, "c")]);
+        }
+
+        #[test]
+        fn string_column_collects_non_null_values() {
+            let schema = Arc::new(Schema::new(vec![Field::new("label", DataType::Utf8, true)]));
+            let batch = RecordBatch::try_new(
+                schema,
+                vec![Arc::new(StringArray::from(vec![
+                    Some("a"),
+                    None,
+                    Some("b"),
+                ]))],
+            )
+            .unwrap();
+            assert_eq!(string_column(&[batch], "label"), vec!["a", "b"]);
+        }
+
+        #[test]
+        fn series_json_is_decoded() {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "series",
+                DataType::Utf8,
+                true,
+            )]));
+            let json = r#"[{"service_name":"api","level":"error"}]"#;
+            let batch = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec![json]))])
+                .unwrap();
+            let series = series_from_batches(&[batch]);
+            assert_eq!(series.len(), 1);
+            assert_eq!(series[0].get("service_name"), Some(&"api".to_string()));
+        }
+
+        #[test]
+        fn timestamp_parsing_handles_ns_seconds_and_rfc3339() {
+            assert_eq!(
+                parse_timestamp_ns(Some("1700000000000000000")),
+                Some(1_700_000_000_000_000_000)
+            );
+            // Seconds are scaled up to nanoseconds.
+            assert_eq!(
+                parse_timestamp_ns(Some("1700000000")),
+                Some(1_700_000_000_000_000_000)
+            );
+            assert_eq!(
+                parse_timestamp_ns(Some("2023-11-14T22:13:20Z")),
+                Some(1_700_000_000_000_000_000)
+            );
+            assert_eq!(parse_timestamp_ns(None), None);
+            assert_eq!(parse_timestamp_ns(Some("")), None);
+            assert_eq!(parse_timestamp_ns(Some("garbage")), None);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The full log-query vertical slice, from the `/loki` HTTP API through the querier to stored logs. Combines #375 (querier), #376 (router wiring), and #377 (Arrow→Loki conversion) — the stacked router PR (#666) merged into this branch, so it carries both ends.

### Querier — `query::logs::LogsService` (#375)
- **query_logs** — parse LogQL → `log_query_filter` → DataFrame (nanosecond time-range on `timestamp`, transpiled filter, projection, timestamp sort by direction, limit) → RecordBatches.
- **get_labels / get_label_values / get_series** — Loki metadata: known + attribute label names, distinct column/attribute values, and distinct `service_name`/`level` label sets matching a selector.
- Four Flight tickets (`query_logs`, `query_logs_labels`, `query_logs_label_values`, `query_logs_series`) wired through parse/auth/metric/dispatch.

### Router — `/loki` handlers (#376/#377)
- **query / query_range** build the ticket (parsing Loki ns/seconds/RFC3339 timestamps, one-hour default window), execute via Flight, and convert batches into Loki streams grouped by label set.
- **labels / label values / series** issue the metadata tickets and shape string/JSON results into `loki-api` types.

## Testing

10 data-backed `LogsService` tests, 4 ticket-parse tests, router conversion unit tests (stream grouping, string extraction, series JSON, timestamp parsing), and handler tests (param validation, 503 without a querier). Architecture docs updated (Flight ticket grammar + Loki endpoint status).

Closes #375, #376, #377 (part of #366)