### PR TITLE
feat(logql): execute LogQL metric queries end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,6 +6037,7 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
+ "logql",
  "loki-api",
  "pyroscope-api",
  "serde",

--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -160,6 +160,7 @@ Any other `do_get` ticket (including `find_trace:...`, `search_traces:...`, and 
 | `query_logs_labels:{tenant_slug}:{dataset_slug}:{start}:{end}` | Log label names in the nanosecond window |
 | `query_logs_label_values:{tenant_slug}:{dataset_slug}:{label}:{start}:{end}` | Distinct values of one log label in the window |
 | `query_logs_series:{tenant_slug}:{dataset_slug}:{params_json}` | Series (label sets) matching a stream selector (`LogSeriesParams` as JSON) |
+| `query_metric:{tenant_slug}:{dataset_slug}:{params_json}` | LogQL metric query (`MetricQueryParams` as JSON: LogQL string, nanosecond start/end, step). Returns a matrix bucketed by `date_bin(step)` |
 | anything else | Treated as a raw SQL query executed via DataFusion |
 
 The standalone querier binary additionally serves Tempo's `tempopb.Querier`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -220,7 +220,7 @@ flowchart LR
 | `GET /loki/api/v1/label/{name}/values` | Implemented -- distinct label values via Querier |
 | `GET /loki/api/v1/series` | Implemented -- label sets matching a selector via Querier |
 | `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
-| LogQL metric queries (`rate`, `count_over_time`, ...) | Not implemented yet (#374) |
+| LogQL metric queries (`rate`, `count_over_time`, `sum by (...)`) | Implemented via `query_range` -- `date_bin(step)` bucketed matrix (no binary ops / `topk` / `quantile` yet) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -31,7 +31,9 @@ use crate::query::profile::{
     ProfileService,
 };
 use crate::query::trace::TraceService;
-use crate::query::{FindTraceByIdParams, LogQueryParams, LogSeriesParams, SearchQueryParams};
+use crate::query::{
+    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, SearchQueryParams,
+};
 
 /// Queries the Iceberg catalog directly, bypassing `datafusion_iceberg`'s
 /// stale `Mirror` cache so newly-created tables are immediately visible.
@@ -233,6 +235,11 @@ enum TicketRequest {
         tenant_slug: String,
         dataset_slug: String,
         params: LogSeriesParams,
+    },
+    QueryMetric {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: MetricQueryParams,
     },
 }
 
@@ -765,6 +772,24 @@ impl QuerierFlightService {
             ));
         }
 
+        // LogQL metric query: query_metric:{tenant}:{dataset}:{json MetricQueryParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_metric:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: MetricQueryParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid query_metric parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::QueryMetric {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_metric ticket format. Expected: query_metric:tenant:dataset:{json}",
+            ));
+        }
+
         // Fall back to raw SQL query
         Ok(TicketRequest::SqlQuery {
             sql: ticket_content.to_string(),
@@ -1064,7 +1089,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogs { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
-                    | TicketRequest::QueryLogsSeries { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::QueryLogsSeries { tenant_slug, .. }
+                    | TicketRequest::QueryMetric { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -1096,6 +1122,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::QueryLogsLabels { .. } => "query_logs_labels",
                 TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
                 TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
+                TicketRequest::QueryMetric { .. } => "query_metric",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -1121,9 +1148,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogs { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
-                    | TicketRequest::QueryLogsSeries { tenant_slug, .. } => {
-                        Some(tenant_slug.clone())
-                    }
+                    | TicketRequest::QueryLogsSeries { tenant_slug, .. }
+                    | TicketRequest::QueryMetric { tenant_slug, .. } => Some(tenant_slug.clone()),
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1433,6 +1459,22 @@ impl FlightService for QuerierFlightService {
                             .await
                             .map_err(querier_error_to_status)?;
                         vec![json_to_batch("series", &series)?]
+                    }
+                    TicketRequest::QueryMetric {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        tracing::info!(
+                            tenant_slug = %tenant_slug,
+                            dataset_slug = %dataset_slug,
+                            query = %params.query,
+                            "Executing query_metric"
+                        );
+                        self.logs_service
+                            .query_metric(&params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?
                     }
                     TicketRequest::SqlProfiles {
                         tenant_slug,

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -1,0 +1,276 @@
+//! # LogQL metric-query lowering
+//!
+//! Lowers a parsed [`logql::MetricQuery`] into a [`MetricPlan`] — a
+//! backend-neutral description of the aggregation the querier executes:
+//! which log rows to scan, how to bucket them in time, what to compute
+//! per bucket, and how to group series. The [`super::logs`] service turns
+//! this into a DataFusion aggregate over the logs table.
+//!
+//! ## Scope and approximation
+//!
+//! Range aggregations are evaluated over **fixed, step-aligned buckets**
+//! (`date_bin(step, timestamp)`), not Loki's sliding `[range]` window —
+//! exact when the caller's step equals the range (Grafana's default for
+//! `count_over_time` panels), an approximation otherwise. The common
+//! shapes are supported:
+//!
+//! - Range aggregations: `count_over_time`, `rate`, `bytes_over_time`,
+//!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`.
+//! - A single outer `sum by (...)` / `sum without ()` vector aggregation
+//!   wrapping one of the above (sum-of-counts folds into a grouped
+//!   count/rate).
+//!
+//! Binary operators, `topk`/`bottomk`, `quantile*`, `vector()`,
+//! `label_replace`, and non-`sum` outer aggregations return
+//! [`QuerierError::Unsupported`].
+
+use logql::{AggregationFunction, Grouping, LogQuery, MetricQuery, RangeFunction};
+
+use super::error::QuerierError;
+
+/// The per-bucket, per-series aggregate to compute.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Aggregate {
+    /// `count(*)` — row count in the bucket.
+    Count,
+    /// `sum(character_length(body))` — total log bytes.
+    BytesSum,
+    /// `sum(<unwrapped label>)`.
+    UnwrapSum(String),
+    /// `avg(<unwrapped label>)`.
+    UnwrapAvg(String),
+    /// `min(<unwrapped label>)`.
+    UnwrapMin(String),
+    /// `max(<unwrapped label>)`.
+    UnwrapMax(String),
+}
+
+/// A lowered metric query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricPlan {
+    /// The log selector and pipeline whose matching rows are aggregated.
+    pub log_query: LogQuery,
+    /// Labels to group series by (logical names, mapped to columns by the
+    /// executor). Empty means group by the natural series columns.
+    pub group_labels: Vec<String>,
+    /// The aggregate computed per bucket per series.
+    pub aggregate: Aggregate,
+    /// When set, divide the aggregate by this many seconds (`rate`).
+    pub rate_divisor_seconds: Option<f64>,
+    /// The `[range]` window in nanoseconds (informational; bucketing uses
+    /// the caller's step).
+    pub range_ns: u128,
+}
+
+/// Lower a metric query to a [`MetricPlan`].
+pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError> {
+    match query {
+        MetricQuery::Range(range) => plan_range(range, Vec::new()),
+        MetricQuery::Vector(vector) => {
+            // Only a `sum` outer aggregation folds cleanly into grouped
+            // counts/rates; others need per-series values we don't
+            // materialize.
+            if vector.function != AggregationFunction::Sum {
+                return Err(QuerierError::Unsupported(format!(
+                    "outer aggregation '{:?}' over a range aggregation",
+                    vector.function
+                )));
+            }
+            if vector.param.is_some() {
+                return Err(QuerierError::Unsupported(
+                    "parameterized outer aggregation".to_string(),
+                ));
+            }
+            let group_labels = grouping_labels(vector.grouping.as_ref())?;
+            match &vector.inner {
+                MetricQuery::Range(range) => plan_range(range, group_labels),
+                other => Err(QuerierError::Unsupported(format!(
+                    "nested metric expression: {other:?}"
+                ))),
+            }
+        }
+        MetricQuery::Binary(_) => Err(QuerierError::Unsupported(
+            "binary operations between metric queries".to_string(),
+        )),
+        MetricQuery::Literal(_) | MetricQuery::VectorLiteral(_) => Err(QuerierError::Unsupported(
+            "scalar/vector literal metric query".to_string(),
+        )),
+        MetricQuery::LabelReplace(_) => Err(QuerierError::Unsupported("label_replace".to_string())),
+    }
+}
+
+fn plan_range(
+    range: &logql::RangeAggregation,
+    group_labels: Vec<String>,
+) -> Result<MetricPlan, QuerierError> {
+    let range_seconds = range.range.as_secs_f64();
+    let unwrap_label = || {
+        range
+            .unwrap
+            .as_ref()
+            .map(|u| u.label.clone())
+            .ok_or_else(|| {
+                QuerierError::Unsupported(format!(
+                    "{:?} requires an unwrap expression",
+                    range.function
+                ))
+            })
+    };
+
+    let (aggregate, rate_divisor_seconds) = match range.function {
+        RangeFunction::CountOverTime => (Aggregate::Count, None),
+        RangeFunction::Rate => (Aggregate::Count, Some(range_seconds)),
+        RangeFunction::BytesOverTime => (Aggregate::BytesSum, None),
+        RangeFunction::BytesRate => (Aggregate::BytesSum, Some(range_seconds)),
+        RangeFunction::SumOverTime => (Aggregate::UnwrapSum(unwrap_label()?), None),
+        RangeFunction::AvgOverTime => (Aggregate::UnwrapAvg(unwrap_label()?), None),
+        RangeFunction::MinOverTime => (Aggregate::UnwrapMin(unwrap_label()?), None),
+        RangeFunction::MaxOverTime => (Aggregate::UnwrapMax(unwrap_label()?), None),
+        other => {
+            return Err(QuerierError::Unsupported(format!(
+                "range function {other:?}"
+            )));
+        }
+    };
+
+    // A grouping directly on the range aggregation (unwrapped forms) is
+    // honored too, unless the caller already supplied an outer grouping.
+    let group_labels = if group_labels.is_empty() {
+        grouping_labels(range.grouping.as_ref())?
+    } else {
+        group_labels
+    };
+
+    Ok(MetricPlan {
+        log_query: range.log_query.clone(),
+        group_labels,
+        aggregate,
+        rate_divisor_seconds,
+        range_ns: range.range.as_nanos(),
+    })
+}
+
+/// Extract the `by (...)` labels. `without` is only supported when empty
+/// (i.e. aggregate across all series), since resolving its complement
+/// needs the full label set.
+fn grouping_labels(grouping: Option<&Grouping>) -> Result<Vec<String>, QuerierError> {
+    match grouping {
+        None => Ok(Vec::new()),
+        Some(g) if !g.without => Ok(g.labels.clone()),
+        Some(g) if g.labels.is_empty() => Ok(Vec::new()),
+        Some(_) => Err(QuerierError::Unsupported(
+            "'without (labels)' grouping".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logql::parse;
+
+    fn plan(query: &str) -> MetricPlan {
+        let logql::Expr::Metric(mq) = parse(query).expect("parse") else {
+            panic!("expected a metric query");
+        };
+        plan_metric_query(&mq).expect("plan")
+    }
+
+    fn err(query: &str) -> QuerierError {
+        let logql::Expr::Metric(mq) = parse(query).expect("parse") else {
+            panic!("expected a metric query");
+        };
+        plan_metric_query(&mq).unwrap_err()
+    }
+
+    #[test]
+    fn count_over_time_is_a_plain_count() {
+        let p = plan(r#"count_over_time({service_name="api"}[5m])"#);
+        assert_eq!(p.aggregate, Aggregate::Count);
+        assert_eq!(p.rate_divisor_seconds, None);
+        assert!(p.group_labels.is_empty());
+        assert_eq!(p.log_query.selector.matchers.len(), 1);
+    }
+
+    #[test]
+    fn rate_divides_by_the_range_seconds() {
+        let p = plan(r#"rate({service_name="api"}[5m])"#);
+        assert_eq!(p.aggregate, Aggregate::Count);
+        assert_eq!(p.rate_divisor_seconds, Some(300.0));
+    }
+
+    #[test]
+    fn bytes_functions() {
+        assert_eq!(
+            plan(r#"bytes_over_time({a="b"}[1m])"#).aggregate,
+            Aggregate::BytesSum
+        );
+        let br = plan(r#"bytes_rate({a="b"}[1m])"#);
+        assert_eq!(br.aggregate, Aggregate::BytesSum);
+        assert_eq!(br.rate_divisor_seconds, Some(60.0));
+    }
+
+    #[test]
+    fn unwrap_aggregations() {
+        assert_eq!(
+            plan(r#"sum_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapSum("latency".to_string())
+        );
+        assert_eq!(
+            plan(r#"avg_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapAvg("latency".to_string())
+        );
+        assert_eq!(
+            plan(r#"max_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapMax("latency".to_string())
+        );
+    }
+
+    #[test]
+    fn sum_by_pushes_grouping_down() {
+        let p = plan(r#"sum by (level) (count_over_time({a="b"}[5m]))"#);
+        assert_eq!(p.aggregate, Aggregate::Count);
+        assert_eq!(p.group_labels, vec!["level".to_string()]);
+    }
+
+    #[test]
+    fn sum_by_over_rate_keeps_the_divisor() {
+        let p = plan(r#"sum by (level) (rate({a="b"}[5m]))"#);
+        assert_eq!(p.rate_divisor_seconds, Some(300.0));
+        assert_eq!(p.group_labels, vec!["level".to_string()]);
+    }
+
+    #[test]
+    fn range_level_grouping_is_honored() {
+        let p = plan(r#"avg_over_time({a="b"} | unwrap x [5m]) by (level)"#);
+        assert_eq!(p.group_labels, vec!["level".to_string()]);
+    }
+
+    #[test]
+    fn unsupported_shapes_are_rejected() {
+        assert!(matches!(
+            err(r#"topk(5, rate({a="b"}[5m]))"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"avg(rate({a="b"}[5m]))"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"quantile_over_time(0.9, {a="b"} | unwrap x [5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"sum_over_time({a="b"}[5m])"#), // no unwrap
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"sum without (level) (rate({a="b"}[5m]))"#),
+            QuerierError::Unsupported(_)
+        ));
+    }
+}

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -16,14 +16,21 @@ use std::sync::Arc;
 
 use datafusion::{
     arrow::array::{Array, RecordBatch, StringArray},
-    logical_expr::{Expr, col, lit},
+    arrow::datatypes::{DataType, IntervalMonthDayNano},
+    functions::datetime::expr_fn::date_bin,
+    functions::unicode::expr_fn::character_length,
+    functions_aggregate::expr_fn::{avg, count, max, min, sum},
+    logical_expr::{Expr, cast, col, lit},
     prelude::{DataFrame, SessionContext},
     scalar::ScalarValue,
 };
-use logql::{LogQuery, parse_query, parse_selector};
+use logql::{Expr as LogqlExpr, LogQuery, parse, parse_query, parse_selector};
 
 use super::logql::log_query_filter;
-use super::{LogQueryParams, error::QuerierError, table_ref::build_table_reference};
+use super::logql_metric::{Aggregate, plan_metric_query};
+use super::{
+    LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
+};
 
 /// Columns projected for a log-line query, in wire order. The Flight
 /// layer streams these; the router shapes them into Loki streams.
@@ -141,6 +148,87 @@ impl LogsService {
             direction,
         )?;
         df.collect().await.map_err(QuerierError::QueryFailed)
+    }
+
+    /// Execute a LogQL metric query, returning a matrix: one row per
+    /// (time bucket, series) with a `bucket` timestamp, the grouping
+    /// columns, and a `value`. Rows are bucketed by `step` via
+    /// `date_bin` (see [`super::logql_metric`] for the semantics).
+    pub async fn query_metric(
+        &self,
+        params: &MetricQueryParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        if params.step <= 0 {
+            return Err(QuerierError::InvalidInput(
+                "step must be a positive nanosecond interval".to_string(),
+            ));
+        }
+        let LogqlExpr::Metric(metric) =
+            parse(&params.query).map_err(|e| QuerierError::InvalidInput(e.to_string()))?
+        else {
+            return Err(QuerierError::InvalidInput(
+                "not a metric query (use query_logs for log queries)".to_string(),
+            ));
+        };
+        let plan = plan_metric_query(&metric)?;
+        let filter = log_query_filter(&plan.log_query)?;
+
+        // Resolve the grouping columns; unknown labels can't be grouped
+        // with the substring attribute model.
+        let group_cols: Vec<&'static str> = if plan.group_labels.is_empty() {
+            SERIES_COLUMNS.to_vec()
+        } else {
+            plan.group_labels
+                .iter()
+                .map(|label| {
+                    column_for_label(label).ok_or_else(|| {
+                        QuerierError::Unsupported(format!("grouping by attribute label '{label}'"))
+                    })
+                })
+                .collect::<Result<_, _>>()?
+        };
+
+        let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
+        df = apply_window(df, params.start, params.end)?;
+        if let Some(filter) = filter {
+            df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
+        }
+
+        // Bucket timestamps into step-aligned windows.
+        let stride = lit(ScalarValue::IntervalMonthDayNano(Some(
+            IntervalMonthDayNano::new(0, 0, params.step),
+        )));
+        // Align buckets to the unix epoch.
+        let origin = lit(ScalarValue::TimestampNanosecond(Some(0), None));
+        let bucket = date_bin(stride, col("timestamp"), origin).alias("bucket");
+
+        let mut group_exprs = vec![bucket];
+        group_exprs.extend(group_cols.iter().map(|c| col(*c)));
+
+        let value = aggregate_expr(&plan.aggregate).alias("value");
+        df = df
+            .aggregate(group_exprs, vec![value])
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Normalize `value` to Float64 (count/bytes aggregate to Int64)
+        // and apply the `rate` divisor in the same projection.
+        let mut proj = vec![col("bucket")];
+        proj.extend(group_cols.iter().map(|c| col(*c)));
+        let value = cast(col("value"), DataType::Float64);
+        let value = match plan.rate_divisor_seconds {
+            Some(seconds) => value / lit(seconds),
+            None => value,
+        };
+        proj.push(value.alias("value"));
+        df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+
+        df.sort(vec![col("bucket").sort(true, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)
     }
 
     /// List the label names available for logs. Returns the labels backed
@@ -342,6 +430,27 @@ fn apply_window(df: DataFrame, start: i64, end: i64) -> Result<DataFrame, Querie
         .map_err(QuerierError::QueryFailed)?
         .filter(col("timestamp").lt_eq(lit(ScalarValue::TimestampNanosecond(Some(end), None))))
         .map_err(QuerierError::QueryFailed)
+}
+
+/// Build the DataFusion aggregate expression for a metric plan's value.
+/// Unwrapped labels are cast from their stored string form to `Float64`.
+fn aggregate_expr(aggregate: &Aggregate) -> Expr {
+    match aggregate {
+        Aggregate::Count => count(lit(1i64)),
+        Aggregate::BytesSum => sum(character_length(col("body"))),
+        Aggregate::UnwrapSum(label) => sum(unwrap_value(label)),
+        Aggregate::UnwrapAvg(label) => avg(unwrap_value(label)),
+        Aggregate::UnwrapMin(label) => min(unwrap_value(label)),
+        Aggregate::UnwrapMax(label) => max(unwrap_value(label)),
+    }
+}
+
+/// The unwrapped label's numeric value: the dedicated column when the
+/// label maps to one, else the value pulled from the attribute JSON is
+/// not addressable here, so unwrap is limited to numeric columns.
+fn unwrap_value(label: &str) -> Expr {
+    let column = column_for_label(label).unwrap_or(label);
+    cast(col(column), DataType::Float64)
 }
 
 /// The dedicated column a known label maps to.
@@ -609,6 +718,137 @@ mod tests {
         let service = service_with_data();
         assert!(matches!(
             service.get_label_values("", 0, 1000, "t", "d").await,
+            Err(QuerierError::InvalidInput(_))
+        ));
+    }
+
+    // ---- metric queries (#374) ----
+
+    fn metric_params(query: &str, step: i64) -> MetricQueryParams {
+        MetricQueryParams {
+            query: query.to_string(),
+            start: 0,
+            end: 1000,
+            step,
+        }
+    }
+
+    /// Collect a matrix result as (value, service_name?, level?) tuples.
+    async fn matrix(service: &LogsService, query: &str, step: i64) -> Vec<(f64, Option<String>)> {
+        use datafusion::arrow::array::Float64Array;
+        let batches = service
+            .query_metric(&metric_params(query, step), "t", "d")
+            .await
+            .expect("metric query");
+        let mut out = Vec::new();
+        for batch in &batches {
+            let value = batch
+                .column_by_name("value")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            let service_col = string_column(batch, "service_name").ok();
+            for i in 0..batch.num_rows() {
+                let svc = service_col.and_then(|c| {
+                    if c.is_null(i) {
+                        None
+                    } else {
+                        Some(c.value(i).to_string())
+                    }
+                });
+                out.push((value.value(i), svc));
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn count_over_time_counts_rows_per_series() {
+        let service = service_with_data();
+        // Step 1000ns puts all three rows in one bucket. api has 2 rows,
+        // web has 1.
+        let out = matrix(
+            &service,
+            r#"count_over_time({service_name=~".+"}[1000ns])"#,
+            1000,
+        )
+        .await;
+        // Natural series group by (service_name, severity_text): the two
+        // api rows differ in severity, so there are three series of 1.
+        assert_eq!(out.len(), 3);
+        assert!(out.iter().all(|(v, _)| *v == 1.0));
+    }
+
+    #[tokio::test]
+    async fn sum_by_groups_across_series() {
+        let service = service_with_data();
+        // sum by (service_name) over count — api=2, web=1.
+        let out = matrix(
+            &service,
+            r#"sum by (service_name) (count_over_time({service_name=~".+"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        let api = out
+            .iter()
+            .find(|(_, s)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.0, 2.0);
+    }
+
+    #[tokio::test]
+    async fn rate_divides_count_by_range_seconds() {
+        let service = service_with_data();
+        // Each api series has 1 row; rate = 1 / (1000ns as seconds) = 1e6.
+        let out = matrix(&service, r#"rate({service_name="api"}[1000ns])"#, 1000).await;
+        assert!(!out.is_empty());
+        for (value, _) in &out {
+            assert!((value - 1.0 / 0.000_001).abs() < 1.0, "got {value}");
+        }
+    }
+
+    #[tokio::test]
+    async fn step_buckets_split_rows_over_time() {
+        let service = service_with_data();
+        // Step 150ns: ts=100 in bucket [0,150), ts=200/300 in later
+        // buckets. api rows at 100 and 200 land in different buckets.
+        let out = matrix(
+            &service,
+            r#"count_over_time({service_name="api"}[150ns])"#,
+            150,
+        )
+        .await;
+        // Two buckets, each with count 1 for api.
+        assert_eq!(out.len(), 2);
+        assert!(
+            out.iter()
+                .all(|(v, s)| *v == 1.0 && s.as_deref() == Some("api"))
+        );
+    }
+
+    #[tokio::test]
+    async fn log_query_rejected_as_metric() {
+        let service = service_with_data();
+        assert!(matches!(
+            service
+                .query_metric(&metric_params(r#"{service_name="api"}"#, 1000), "t", "d")
+                .await,
+            Err(QuerierError::InvalidInput(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn non_positive_step_is_rejected() {
+        let service = service_with_data();
+        assert!(matches!(
+            service
+                .query_metric(
+                    &metric_params(r#"count_over_time({a="b"}[5m])"#, 0),
+                    "t",
+                    "d"
+                )
+                .await,
             Err(QuerierError::InvalidInput(_))
         ));
     }

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod logql;
+pub mod logql_metric;
 pub mod logs;
 pub mod profile;
 pub mod search_filter;
@@ -23,6 +24,19 @@ pub struct LogQueryParams {
     /// `"forward"` or `"backward"` (default).
     #[serde(default)]
     pub direction: Option<String>,
+}
+
+/// Parameters carried in the `query_metric` Flight ticket (JSON-encoded).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MetricQueryParams {
+    /// The LogQL metric query string.
+    pub query: String,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+    /// Bucket width (query resolution) in nanoseconds.
+    pub step: i64,
 }
 
 /// Parameters carried in the `query_logs_series` Flight ticket.

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 common.workspace = true
 signaldb-api.workspace = true
+logql.workspace = true
 loki-api.workspace = true
 pyroscope-api.workspace = true
 tempo-api.workspace = true

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -173,6 +173,17 @@ pub async fn query_range<S: RouterState>(
 
     let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
     let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+
+    // A metric query returns a matrix; a log query returns streams.
+    if is_metric_query(&logql) {
+        let step =
+            parse_step_ns(params.step.as_deref()).unwrap_or_else(|| default_step_ns(start, end));
+        let matrix = run_metric_query(&state, &tenant_ctx, &logql, start, end, step).await?;
+        return Ok(axum::Json(QueryResponse::success(QueryResult::Matrix(
+            matrix,
+        ))));
+    }
+
     let streams = run_log_query(
         &state,
         &tenant_ctx,
@@ -303,6 +314,143 @@ async fn run_log_query<S: RouterState>(
     );
     let batches = execute_ticket(state, ticket).await?;
     Ok(batches_to_streams(&batches))
+}
+
+/// Whether a LogQL string is a metric query (returns samples) rather than
+/// a log query (returns lines).
+fn is_metric_query(logql: &str) -> bool {
+    matches!(logql::parse(logql), Ok(logql::Expr::Metric(_)))
+}
+
+/// Build and execute a `query_metric` ticket, converting the result into a
+/// Loki matrix.
+async fn run_metric_query<S: RouterState>(
+    state: &S,
+    tenant_ctx: &TenantContextExtractor,
+    logql: &str,
+    start: i64,
+    end: i64,
+    step: i64,
+) -> Result<Vec<loki_api::MetricSeries>, StatusCode> {
+    let payload = serde_json::json!({
+        "query": logql,
+        "start": start,
+        "end": end,
+        "step": step,
+    });
+    let ticket = format!(
+        "query_metric:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(state, ticket).await?;
+    Ok(batches_to_matrix(&batches))
+}
+
+/// Group matrix rows (`bucket`, label columns, `value`) into Loki metric
+/// series. The `bucket` column is nanoseconds; Loki matrix samples use
+/// unix seconds.
+fn batches_to_matrix(batches: &[RecordBatch]) -> Vec<loki_api::MetricSeries> {
+    use loki_api::{MetricSeries, Sample};
+
+    let mut order: Vec<String> = Vec::new();
+    let mut series: HashMap<String, MetricSeries> = HashMap::new();
+
+    for batch in batches {
+        let Some(buckets) = batch
+            .column_by_name("bucket")
+            .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+        else {
+            continue;
+        };
+        let value = batch.column_by_name("value").and_then(|c| {
+            c.as_any()
+                .downcast_ref::<datafusion::arrow::array::Float64Array>()
+        });
+
+        // Every string column other than the value is a series label;
+        // `severity_text` is presented as Loki's `level`.
+        let schema = batch.schema();
+        let label_cols: Vec<(String, &StringArray)> = schema
+            .fields()
+            .iter()
+            .filter_map(|f| {
+                let name = f.name();
+                if name == "bucket" || name == "value" {
+                    return None;
+                }
+                str_col(batch, name).map(|c| (name.clone(), c))
+            })
+            .collect();
+
+        for i in 0..batch.num_rows() {
+            let mut labels: HashMap<String, String> = HashMap::new();
+            for (name, col) in &label_cols {
+                if !col.is_null(i) && !col.value(i).is_empty() {
+                    let key = if name == "severity_text" {
+                        "level"
+                    } else {
+                        name.as_str()
+                    };
+                    labels.insert(key.to_string(), col.value(i).to_string());
+                }
+            }
+            let key = label_key(&labels);
+            let seconds = if buckets.is_null(i) {
+                0.0
+            } else {
+                buckets.value(i) as f64 / 1_000_000_000.0
+            };
+            let v = value
+                .map(|c| if c.is_null(i) { 0.0 } else { c.value(i) })
+                .unwrap_or(0.0);
+            series
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    order.push(key.clone());
+                    MetricSeries {
+                        metric: labels,
+                        values: Vec::new(),
+                    }
+                })
+                .values
+                .push(Sample::new(seconds, format_value(v)));
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| series.remove(&k))
+        .collect()
+}
+
+/// Render a matrix value the way Loki does: an integer when whole.
+fn format_value(v: f64) -> String {
+    if v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+/// Parse the `step` parameter (Go duration or seconds) into nanoseconds.
+fn parse_step_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(seconds) = value.parse::<f64>() {
+        return Some((seconds * 1_000_000_000.0) as i64);
+    }
+    // Reuse the LogQL lexer for durations like `30s`, `5m`.
+    let tokens = logql::tokenize(value).ok()?;
+    match tokens.first().map(|t| &t.token) {
+        Some(logql::Token::Duration(d)) => Some(d.as_nanos() as i64),
+        _ => None,
+    }
+}
+
+/// A sensible default step when the caller omits one: aim for ~250 points
+/// across the window, at least one second.
+fn default_step_ns(start: i64, end: i64) -> i64 {
+    let span = (end - start).max(1);
+    (span / 250).max(1_000_000_000)
 }
 
 /// Send a Flight ticket to a querier and collect the result batches.
@@ -607,9 +755,12 @@ mod tests {
 
     mod convert {
         use super::super::{
-            batches_to_streams, parse_timestamp_ns, series_from_batches, string_column,
+            batches_to_matrix, batches_to_streams, default_step_ns, is_metric_query, parse_step_ns,
+            parse_timestamp_ns, series_from_batches, string_column,
         };
-        use datafusion::arrow::array::{RecordBatch, StringArray, TimestampNanosecondArray};
+        use datafusion::arrow::array::{
+            Float64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+        };
         use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
         use std::sync::Arc;
 
@@ -705,6 +856,77 @@ mod tests {
             assert_eq!(parse_timestamp_ns(None), None);
             assert_eq!(parse_timestamp_ns(Some("")), None);
             assert_eq!(parse_timestamp_ns(Some("garbage")), None);
+        }
+
+        fn matrix_batch() -> RecordBatch {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new(
+                    "bucket",
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    false,
+                ),
+                Field::new("service_name", DataType::Utf8, true),
+                Field::new("severity_text", DataType::Utf8, true),
+                Field::new("value", DataType::Float64, false),
+            ]));
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    // Two buckets for the api/error series, one for web/info.
+                    Arc::new(TimestampNanosecondArray::from(vec![
+                        1_000_000_000,
+                        2_000_000_000,
+                        1_000_000_000,
+                    ])),
+                    Arc::new(StringArray::from(vec!["api", "api", "web"])),
+                    Arc::new(StringArray::from(vec!["error", "error", "info"])),
+                    Arc::new(Float64Array::from(vec![2.0, 3.0, 1.5])),
+                ],
+            )
+            .unwrap()
+        }
+
+        #[test]
+        fn groups_matrix_rows_into_series() {
+            let series = batches_to_matrix(&[matrix_batch()]);
+            assert_eq!(series.len(), 2);
+            let api = series
+                .iter()
+                .find(|s| s.metric.get("service_name") == Some(&"api".to_string()))
+                .unwrap();
+            // severity_text is presented as Loki's `level`.
+            assert_eq!(api.metric.get("level"), Some(&"error".to_string()));
+            // Samples: (seconds, value string); whole values render as ints.
+            assert_eq!(api.values.len(), 2);
+            assert_eq!(api.values[0], loki_api::Sample::new(1.0, "2"));
+            assert_eq!(api.values[1], loki_api::Sample::new(2.0, "3"));
+
+            let web = series
+                .iter()
+                .find(|s| s.metric.get("service_name") == Some(&"web".to_string()))
+                .unwrap();
+            assert_eq!(web.values, vec![loki_api::Sample::new(1.0, "1.5")]);
+        }
+
+        #[test]
+        fn detects_metric_vs_log_queries() {
+            assert!(is_metric_query(r#"rate({app="x"}[5m])"#));
+            assert!(is_metric_query(
+                r#"sum by (level) (count_over_time({a="b"}[1m]))"#
+            ));
+            assert!(!is_metric_query(r#"{app="x"}"#));
+            assert!(!is_metric_query(r#"{app="x"} |= "err""#));
+        }
+
+        #[test]
+        fn step_parsing_handles_seconds_and_durations() {
+            assert_eq!(parse_step_ns(Some("30")), Some(30_000_000_000));
+            assert_eq!(parse_step_ns(Some("5m")), Some(300_000_000_000));
+            assert_eq!(parse_step_ns(Some("1h")), Some(3_600_000_000_000));
+            assert_eq!(parse_step_ns(None), None);
+            // ~250 points across a 1000s window, floored at one second.
+            assert_eq!(default_step_ns(0, 1_000_000_000_000), 4_000_000_000);
+            assert_eq!(default_step_ns(0, 10), 1_000_000_000);
         }
     }
 }


### PR DESCRIPTION
## Summary

#374 — LogQL metric queries (`rate`, `count_over_time`, `sum by (level) (...)`) executed end-to-end, so `/loki/api/v1/query_range` now returns matrices as well as log streams.

### Lowering — `query::logql_metric`
Pure lowering of a parsed `MetricQuery` into a `MetricPlan` (aggregate kind, grouping labels, rate divisor). Supported shapes:
- Range aggregations: `count_over_time`, `rate`, `bytes_over_time`, `bytes_rate`, and unwrap-based `sum/avg/min/max_over_time`.
- One outer `sum by (...)` vector aggregation (sum-of-counts folds into a grouped count/rate).
- Binary ops, `topk`/`quantile`, non-`sum` outer aggregations, and `without` grouping → `Unsupported`.

### Execution — `LogsService::query_metric`
Buckets rows with `date_bin(step)` and aggregates per (bucket, series) into a matrix, dividing by the range seconds for `rate`. Range aggregations use **fixed step-aligned buckets** (exact when `step == range`, approximate otherwise — documented), matching how most LogQL backends render stepped panels.

### Wiring
- `query_metric` Flight ticket + dispatch.
- Router `query_range` detects metric queries via `logql::parse`, parses `step` (Go duration or seconds, sensible default), and converts matrix batches into Loki metric series (nanosecond buckets → unix-second samples, `severity_text` → `level`).

### Testing
8 metric-plan lowering tests, 6 data-backed `query_metric` tests (count/sum-by/rate/step-bucketing + rejections), and router matrix-conversion / step-parsing / dispatch-detection tests. Full querier (89) and router (41) suites green.

Refs #374 (part of #366)