### PR TITLE
feat: PromQL query support — /prometheus API (epic #328)

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -63,7 +63,10 @@ Key details:
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
 4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
-6. Router also nests a Pyroscope-compatible profile API at `/pyroscope` and a Loki-compatible logs API at `/loki`. LogQL log queries (selectors, line filters, label filters) execute end-to-end: the querier's `LogsService` lowers the parsed query to a DataFusion filter and streams matching log lines back as Loki streams; LogQL metric queries (`rate`, `count_over_time`, ...) are not implemented yet (epic #366)
+6. Router also nests query APIs for every signal, each lowering a parsed query to a DataFusion `Expr`/aggregate over the signal's Iceberg tables (never a SQL string, matching the trace path):
+   - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series.
+   - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix); metadata endpoints and `histogram_quantile` are pending (#339/#335).
+   - `/pyroscope` (profiles) via `ProfileService`.
 
 ## Service Components
 

--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -21,6 +21,7 @@ sources:
 | **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **prometheus-api** | `src/prometheus-api/` | Library | Prometheus HTTP API response types (PromQL query surface) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, dataset management |
@@ -78,6 +79,8 @@ This is the shared foundation. Key modules:
 | `query` | `src/querier/src/query/` | Query execution modules |
 | `query/table_ref.rs` | `src/querier/src/query/table_ref.rs` | Safe table reference with slug validation |
 | `query/trace.rs` | `src/querier/src/query/trace.rs` | Trace query handlers |
+| `query/logs.rs` / `query/logql.rs` | `src/querier/src/query/` | LogQL log query execution + Expr lowering |
+| `query/metrics.rs` / `query/promql.rs` | `src/querier/src/query/` | PromQL metrics query execution + lowering |
 | `query/error.rs` | `src/querier/src/query/error.rs` | Query error types |
 | `query/search_filter.rs` | `src/querier/src/query/search_filter.rs` | Search filter parsing/handling |
 | `services` | `src/querier/src/services/` | Service implementations |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,6 +6165,7 @@ dependencies = [
  "log",
  "logql",
  "loki-api",
+ "prometheus-api",
  "pyroscope-api",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cactus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbc26382d871df4b7442e3df10a9402bf3cf5e55cbd66f12be38861425f0564"
+
+[[package]]
 name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1064,20 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cfgrammar"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe45e18904af7af10e4312df7c97251e98af98c70f42f1f2587aecfcbee56bf"
+dependencies = [
+ "indexmap 2.14.0",
+ "lazy_static",
+ "num-traits",
+ "regex",
+ "serde",
+ "vob 4.0.0",
+]
 
 [[package]]
 name = "chacha20"
@@ -2804,6 +2824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3061,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4060,6 +4099,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "lrlex"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71364e868116ee891b0f93559eb9eca5675bec28b22d33c58481e66c3951d7e"
+dependencies = [
+ "cfgrammar",
+ "getopts",
+ "lazy_static",
+ "lrpar",
+ "num-traits",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "vergen",
+]
+
+[[package]]
+name = "lrpar"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b265a81193d94c92d1c9c715498d6fa505bce3f789ceecb24ab5d6fa2dbc71"
+dependencies = [
+ "bincode",
+ "cactus",
+ "cfgrammar",
+ "filetime",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "lrtable",
+ "num-traits",
+ "packedvec",
+ "regex",
+ "serde",
+ "static_assertions",
+ "vergen",
+ "vob 4.0.0",
+]
+
+[[package]]
+name = "lrtable"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc36d15214ca997a5097845be1f932b7ee6125c36f5c5e55f6c49e027ddeb6de"
+dependencies = [
+ "cfgrammar",
+ "fnv",
+ "num-traits",
+ "serde",
+ "sparsevec",
+ "vob 4.0.0",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,6 +4803,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "packedvec"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,6 +5383,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "promql-parser"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8c90c956be4237a93be6f2298302b56974ef862ab11e0f98869d1f27c69f88"
+dependencies = [
+ "cfgrammar",
+ "chrono",
+ "lazy_static",
+ "lrlex",
+ "lrpar",
+ "regex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,6 +5578,7 @@ dependencies = [
  "logql",
  "object_store",
  "opentelemetry",
+ "promql-parser",
  "serde",
  "serde_json",
  "tempo-api",
@@ -6750,6 +6868,18 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sparsevec"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b4a8ce3045f0fe173fb5ae3c6b7dcfbec02bfa650bb8618b2301f52af0134d"
+dependencies = [
+ "num-traits",
+ "packedvec",
+ "serde",
+ "vob 3.0.6",
 ]
 
 [[package]]
@@ -8247,10 +8377,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vob"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc936b5a7202a703aeaf7ce05e7931db2e0c8126813f97db3e9e06d867b0bb38"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "vob"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e840c5339237ded42621d3e376ed7008bf79b68574e97454c2a46fe6f3bbe7f"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "vtparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ prost-build = "0.14"
 snap = "1.1"
 
 # PromQL parser for Prometheus query compatibility
+promql-parser = "0.10"
 
 thiserror = "2.0.12"
 

--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -161,6 +161,7 @@ Any other `do_get` ticket (including `find_trace:...`, `search_traces:...`, and 
 | `query_logs_label_values:{tenant_slug}:{dataset_slug}:{label}:{start}:{end}` | Distinct values of one log label in the window |
 | `query_logs_series:{tenant_slug}:{dataset_slug}:{params_json}` | Series (label sets) matching a stream selector (`LogSeriesParams` as JSON) |
 | `query_metric:{tenant_slug}:{dataset_slug}:{params_json}` | LogQL metric query (`MetricQueryParams` as JSON: LogQL string, nanosecond start/end, step). Returns a matrix bucketed by `date_bin(step)` |
+| `query_promql:{tenant_slug}:{dataset_slug}:{params_json}` | PromQL query (`PromQlQueryParams` as JSON: PromQL string, nanosecond start/end, step). Returns a matrix over the metrics tables |
 | anything else | Treated as a raw SQL query executed via DataFusion |
 
 The standalone querier binary additionally serves Tempo's `tempopb.Querier`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -223,6 +223,16 @@ flowchart LR
 | `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
 | LogQL metric queries (`rate`, `count_over_time`, `sum by (...)`) | Implemented via `query_range` -- `date_bin(step)` bucketed matrix (no binary ops / `topk` / `quantile` yet) |
 
+**Prometheus API Endpoints** (metrics, nested at `/prometheus`; see epic #328):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET\|POST /prometheus/api/v1/query_range` | Implemented -- PromQL over `metrics_gauge`+`metrics_sum`, `date_bin(step)` matrix |
+| `GET\|POST /prometheus/api/v1/query` | Implemented -- instant vector (latest sample per series) |
+| `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Implemented -- metric label names/values and `{__name__, job}` series via Querier |
+| PromQL `rate`/`increase` | Implemented -- counter delta over `date_bin` buckets |
+| PromQL `histogram_quantile`, binary ops, `topk` | Not implemented yet (#335) |
+
 **Admin API Endpoints** (requires `admin_api_key`):
 
 | Endpoint | Description |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -79,6 +79,7 @@ Parquet storage with DataFusion query processing:
 | **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
 | **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
 | **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
+| **prometheus-api** | `src/prometheus-api/` | Library | Prometheus HTTP API response types (PromQL query surface) |
 | **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
 | **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
 | **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI and TUI for tenant, API key, and dataset management |

--- a/docs/users/querying-promql.md
+++ b/docs/users/querying-promql.md
@@ -1,0 +1,102 @@
+---
+audience: user
+type: how-to
+status: living
+sources:
+  - src/router/src/endpoints/promql.rs
+  - src/prometheus-api/src/lib.rs
+---
+
+# Query metrics with PromQL
+
+Goal: query your stored metrics with PromQL over SignalDB's
+Prometheus-compatible HTTP API, so a Grafana Prometheus data source (or `curl`)
+can read them back.
+
+The endpoints are nested under `/prometheus` on the router and speak the
+Prometheus `api/v1` response format. They translate a PromQL expression into a
+querier plan over the `metrics_gauge` and `metrics_sum` Iceberg tables — the
+same query path used for traces and logs.
+
+## Prerequisites
+
+- A running SignalDB deployment (`./scripts/run-dev.sh` is enough locally); the
+  router listens on port 3000.
+- Metrics already ingested (via OTLP or [Prometheus
+  remote_write](prometheus-remote-write.md)).
+- An API key and tenant, sent as `Authorization: Bearer <key>` and
+  `X-Tenant-ID: <tenant>` headers (see [Authentication](authentication.md)).
+
+## Range query (matrix)
+
+`query_range` returns a matrix — one time series per label set, sampled at
+`step`:
+
+```bash
+curl -sG http://localhost:3000/prometheus/api/v1/query_range \
+  -H "Authorization: Bearer $SIGNALDB_API_KEY" \
+  -H "X-Tenant-ID: $SIGNALDB_TENANT" \
+  --data-urlencode 'query=sum(rate(http_requests_total[5m]))' \
+  --data-urlencode "start=$(date -d '-1 hour' +%s)" \
+  --data-urlencode "end=$(date +%s)" \
+  --data-urlencode 'step=60'
+```
+
+`start`/`end` are unix seconds; `step` is a duration (`60`, `1m`, `1h`).
+
+Supported so far: instant/range selectors with label matchers
+(`=`, `!=`, `=~`, `!~`); the aggregations `sum`, `avg`, `min`, `max`, `count`,
+optionally with `by (label)`; and the range functions `rate` and `increase`.
+`histogram_quantile`, binary operators, and `topk` are not implemented yet
+(#335).
+
+## Instant query (vector)
+
+`query` evaluates a single point in time (default: now), returning a vector —
+the latest sample of each series:
+
+```bash
+curl -sG http://localhost:3000/prometheus/api/v1/query \
+  -H "Authorization: Bearer $SIGNALDB_API_KEY" \
+  -H "X-Tenant-ID: $SIGNALDB_TENANT" \
+  --data-urlencode 'query=up' \
+  --data-urlencode "time=$(date +%s)"
+```
+
+## Discover labels and series
+
+```bash
+# label names in a window
+curl -sG http://localhost:3000/prometheus/api/v1/labels ...
+# values of one label
+curl -sG http://localhost:3000/prometheus/api/v1/label/__name__/values ...
+# series ({__name__, job}) matching a selector
+curl -sG http://localhost:3000/prometheus/api/v1/series \
+  --data-urlencode 'match[]=http_requests_total' ...
+```
+
+Prometheus labels map onto SignalDB columns: `__name__` is the metric name,
+`job` is the service name, and other labels are matched against the metric's
+attributes.
+
+## Verify
+
+A successful response is `{"status":"success","data":{...}}`. An empty
+result — a window with no matching data — returns an empty `result` array with
+HTTP 200, not an error.
+
+## Troubleshooting
+
+- **Empty `result` when you expect data**: check that `start`/`end` bracket the
+  sample timestamps (they are unix seconds, not milliseconds) and that the
+  `X-Tenant-ID` matches the tenant the metrics were ingested under.
+- **`resultType` is `vector` but you wanted `matrix`**: use `query_range`, not
+  `query`.
+- **404**: confirm the path is nested under `/prometheus` (e.g.
+  `/prometheus/api/v1/query_range`).
+
+## Configure Grafana
+
+Point a Grafana **Prometheus** data source at
+`http://<router-host>:3000/prometheus` and add the `Authorization` and
+`X-Tenant-ID` headers under *Custom HTTP Headers*.

--- a/docs/users/querying-sql.md
+++ b/docs/users/querying-sql.md
@@ -101,6 +101,9 @@ signaldb-cli query sql "SELECT DISTINCT service_name FROM traces" --format json 
 
 ## Where to go next
 
+- SQL is for ad-hoc exploration; to query metrics with PromQL over the
+  Prometheus-compatible HTTP API, see [Query metrics with
+  PromQL](querying-promql.md).
 - `signaldb-cli tui` starts an interactive terminal UI over the same
   endpoints.
 - The Tempo-compatible HTTP API serves Grafana trace views — see the

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -33,6 +33,7 @@ iceberg-rust.workspace = true
 datafusion_iceberg.workspace = true
 
 thiserror.workspace = true
+promql-parser.workspace = true
 
 # PromQL support
 

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -26,13 +26,15 @@ use tonic::{Request, Response, Status};
 use tracing::Instrument;
 
 use crate::query::logs::LogsService;
+use crate::query::metrics::MetricsService;
 use crate::query::profile::{
     FindProfileByIdParams, ProfileDiffParams, ProfileDiscoveryParams, ProfileSearchParams,
     ProfileService,
 };
 use crate::query::trace::TraceService;
 use crate::query::{
-    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, SearchQueryParams,
+    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, PromQlQueryParams,
+    SearchQueryParams,
 };
 
 /// Queries the Iceberg catalog directly, bypassing `datafusion_iceberg`'s
@@ -241,6 +243,11 @@ enum TicketRequest {
         dataset_slug: String,
         params: MetricQueryParams,
     },
+    QueryPromql {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: PromQlQueryParams,
+    },
 }
 
 /// Flight service for query execution against stored data
@@ -254,6 +261,7 @@ pub struct QuerierFlightService {
     trace_service: TraceService,
     profile_service: ProfileService,
     logs_service: LogsService,
+    metrics_service: MetricsService,
     #[allow(dead_code)]
     iceberg_catalog: Option<Arc<dyn iceberg_rust::catalog::Catalog>>,
     limits: QuerierConfig,
@@ -335,6 +343,7 @@ impl QuerierFlightService {
         let profile_service = ProfileService::new(session_ctx.as_ref().clone())
             .with_max_search_limit(limits.max_search_limit);
         let logs_service = LogsService::new(session_ctx.as_ref().clone());
+        let metrics_service = MetricsService::new(session_ctx.as_ref().clone());
 
         Self {
             object_store,
@@ -344,6 +353,7 @@ impl QuerierFlightService {
             trace_service,
             profile_service,
             logs_service,
+            metrics_service,
             iceberg_catalog: None,
             limits,
             query_permits: dashmap::DashMap::new(),
@@ -432,6 +442,7 @@ impl QuerierFlightService {
         let profile_service = ProfileService::new(session_ctx.as_ref().clone())
             .with_max_search_limit(limits.max_search_limit);
         let logs_service = LogsService::new(session_ctx.as_ref().clone());
+        let metrics_service = MetricsService::new(session_ctx.as_ref().clone());
 
         Ok(Self {
             object_store,
@@ -441,6 +452,7 @@ impl QuerierFlightService {
             trace_service,
             profile_service,
             logs_service,
+            metrics_service,
             iceberg_catalog: Some(iceberg_catalog),
             limits,
             query_permits: dashmap::DashMap::new(),
@@ -790,6 +802,24 @@ impl QuerierFlightService {
             ));
         }
 
+        // PromQL query: query_promql:{tenant}:{dataset}:{json PromQlQueryParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_promql:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: PromQlQueryParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid query_promql parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::QueryPromql {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_promql ticket format. Expected: query_promql:tenant:dataset:{json}",
+            ));
+        }
+
         // Fall back to raw SQL query
         Ok(TicketRequest::SqlQuery {
             sql: ticket_content.to_string(),
@@ -1090,7 +1120,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
-                    | TicketRequest::QueryMetric { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::QueryMetric { tenant_slug, .. }
+                    | TicketRequest::QueryPromql { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -1123,6 +1154,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
                 TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
                 TicketRequest::QueryMetric { .. } => "query_metric",
+                TicketRequest::QueryPromql { .. } => "query_promql",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -1149,7 +1181,8 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
-                    | TicketRequest::QueryMetric { tenant_slug, .. } => Some(tenant_slug.clone()),
+                    | TicketRequest::QueryMetric { tenant_slug, .. }
+                    | TicketRequest::QueryPromql { tenant_slug, .. } => Some(tenant_slug.clone()),
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1473,6 +1506,29 @@ impl FlightService for QuerierFlightService {
                         );
                         self.logs_service
                             .query_metric(&params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?
+                    }
+                    TicketRequest::QueryPromql {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        tracing::info!(
+                            tenant_slug = %tenant_slug,
+                            dataset_slug = %dataset_slug,
+                            query = %params.query,
+                            "Executing query_promql"
+                        );
+                        self.metrics_service
+                            .query_range(
+                                &params.query,
+                                params.start,
+                                params.end,
+                                params.step,
+                                &tenant_slug,
+                                &dataset_slug,
+                            )
                             .await
                             .map_err(querier_error_to_status)?
                     }
@@ -1991,6 +2047,31 @@ mod tests {
             }
             other => panic!("expected QueryLogsSeries, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn parse_query_promql_ticket() {
+        let service = make_service().await;
+        let ticket =
+            r#"query_promql:acme:prod:{"query":"sum(rate(up[5m]))","start":10,"end":20,"step":15}"#;
+        match service.parse_ticket(ticket).unwrap() {
+            TicketRequest::QueryPromql {
+                tenant_slug,
+                dataset_slug,
+                params,
+            } => {
+                assert_eq!(tenant_slug, "acme");
+                assert_eq!(dataset_slug, "prod");
+                assert_eq!(params.query, "sum(rate(up[5m]))");
+                assert_eq!((params.start, params.end, params.step), (10, 20, 15));
+            }
+            other => panic!("expected QueryPromql, got {other:?}"),
+        }
+        assert!(
+            service
+                .parse_ticket("query_promql:acme:prod:not-json")
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -33,8 +33,8 @@ use crate::query::profile::{
 };
 use crate::query::trace::TraceService;
 use crate::query::{
-    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, PromQlQueryParams,
-    SearchQueryParams,
+    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, MetricSeriesParams,
+    PromQlQueryParams, SearchQueryParams,
 };
 
 /// Queries the Iceberg catalog directly, bypassing `datafusion_iceberg`'s
@@ -247,6 +247,24 @@ enum TicketRequest {
         tenant_slug: String,
         dataset_slug: String,
         params: PromQlQueryParams,
+    },
+    QueryMetricLabels {
+        tenant_slug: String,
+        dataset_slug: String,
+        start: i64,
+        end: i64,
+    },
+    QueryMetricLabelValues {
+        tenant_slug: String,
+        dataset_slug: String,
+        label: String,
+        start: i64,
+        end: i64,
+    },
+    QueryMetricSeries {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: MetricSeriesParams,
     },
 }
 
@@ -820,6 +838,59 @@ impl QuerierFlightService {
             ));
         }
 
+        // Metric label names: query_metric_labels:{tenant}:{dataset}:{start}:{end}
+        if let Some(remainder) = ticket_content.strip_prefix("query_metric_labels:") {
+            let parts: Vec<&str> = remainder.splitn(4, ':').collect();
+            if parts.len() == 4 {
+                let (start, end) = parse_ns_window(parts[2], parts[3])?;
+                return Ok(TicketRequest::QueryMetricLabels {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    start,
+                    end,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_metric_labels ticket format. Expected: query_metric_labels:tenant:dataset:start:end",
+            ));
+        }
+
+        // Metric label values: query_metric_label_values:{tenant}:{dataset}:{label}:{start}:{end}
+        if let Some(remainder) = ticket_content.strip_prefix("query_metric_label_values:") {
+            let parts: Vec<&str> = remainder.splitn(5, ':').collect();
+            if parts.len() == 5 {
+                let (start, end) = parse_ns_window(parts[3], parts[4])?;
+                return Ok(TicketRequest::QueryMetricLabelValues {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    label: parts[2].to_string(),
+                    start,
+                    end,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_metric_label_values ticket format. Expected: query_metric_label_values:tenant:dataset:label:start:end",
+            ));
+        }
+
+        // Metric series: query_metric_series:{tenant}:{dataset}:{json MetricSeriesParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_metric_series:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: MetricSeriesParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!("Invalid query_metric_series parameters: {e}"))
+                })?;
+                return Ok(TicketRequest::QueryMetricSeries {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_metric_series ticket format. Expected: query_metric_series:tenant:dataset:{json}",
+            ));
+        }
+
         // Fall back to raw SQL query
         Ok(TicketRequest::SqlQuery {
             sql: ticket_content.to_string(),
@@ -1121,7 +1192,10 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
                     | TicketRequest::QueryMetric { tenant_slug, .. }
-                    | TicketRequest::QueryPromql { tenant_slug, .. } => Some(tenant_slug),
+                    | TicketRequest::QueryPromql { tenant_slug, .. }
+                    | TicketRequest::QueryMetricLabels { tenant_slug, .. }
+                    | TicketRequest::QueryMetricLabelValues { tenant_slug, .. }
+                    | TicketRequest::QueryMetricSeries { tenant_slug, .. } => Some(tenant_slug),
                     TicketRequest::SqlQuery { .. } => None,
                 };
                 if let Some(ticket_tenant) = ticket_tenant
@@ -1155,6 +1229,9 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
                 TicketRequest::QueryMetric { .. } => "query_metric",
                 TicketRequest::QueryPromql { .. } => "query_promql",
+                TicketRequest::QueryMetricLabels { .. } => "query_metric_labels",
+                TicketRequest::QueryMetricLabelValues { .. } => "query_metric_label_values",
+                TicketRequest::QueryMetricSeries { .. } => "query_metric_series",
                 TicketRequest::SqlQuery { .. } => "sql",
             };
 
@@ -1182,7 +1259,12 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
                     | TicketRequest::QueryMetric { tenant_slug, .. }
-                    | TicketRequest::QueryPromql { tenant_slug, .. } => Some(tenant_slug.clone()),
+                    | TicketRequest::QueryPromql { tenant_slug, .. }
+                    | TicketRequest::QueryMetricLabels { tenant_slug, .. }
+                    | TicketRequest::QueryMetricLabelValues { tenant_slug, .. }
+                    | TicketRequest::QueryMetricSeries { tenant_slug, .. } => {
+                        Some(tenant_slug.clone())
+                    }
                     TicketRequest::SqlQuery { .. } => None,
                 });
             // Held until the query's batches are fully computed.
@@ -1531,6 +1613,51 @@ impl FlightService for QuerierFlightService {
                             )
                             .await
                             .map_err(querier_error_to_status)?
+                    }
+                    TicketRequest::QueryMetricLabels {
+                        tenant_slug,
+                        dataset_slug,
+                        start,
+                        end,
+                    } => {
+                        let labels = self
+                            .metrics_service
+                            .get_labels(start, end, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![strings_to_batch("label", labels)?]
+                    }
+                    TicketRequest::QueryMetricLabelValues {
+                        tenant_slug,
+                        dataset_slug,
+                        label,
+                        start,
+                        end,
+                    } => {
+                        let values = self
+                            .metrics_service
+                            .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![strings_to_batch("value", values)?]
+                    }
+                    TicketRequest::QueryMetricSeries {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        let series = self
+                            .metrics_service
+                            .get_series(
+                                &params.selector,
+                                params.start,
+                                params.end,
+                                &tenant_slug,
+                                &dataset_slug,
+                            )
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![json_to_batch("series", &series)?]
                     }
                     TicketRequest::SqlProfiles {
                         tenant_slug,

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -1,0 +1,427 @@
+//! # Metrics Query Service (PromQL)
+//!
+//! DataFusion-backed execution of PromQL queries against the tenant's
+//! metrics Iceberg tables. Parses PromQL, lowers it to a
+//! [`MetricPlan`](super::promql::MetricPlan), and runs a bucketed
+//! aggregation over the union of the gauge and sum tables — the same
+//! DataFrame-first approach as the trace/log/profile paths.
+//!
+//! The result is a matrix: one row per (time bucket, series) with a
+//! `bucket` timestamp, `metric_name`, the grouping columns, and a
+//! `value`. The router shapes that into Prometheus matrix JSON.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::{DataType, IntervalMonthDayNano, TimeUnit};
+use datafusion::functions::datetime::expr_fn::date_bin;
+use datafusion::functions::regex::expr_fn::regexp_like;
+use datafusion::functions::string::expr_fn::contains;
+use datafusion::functions_aggregate::expr_fn::{avg, count, last_value, max, min, sum};
+use datafusion::logical_expr::{Expr, SortExpr, col, lit, not};
+use datafusion::prelude::{DataFrame, SessionContext};
+use datafusion::scalar::ScalarValue;
+
+use super::promql::{Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, plan_promql};
+use super::{error::QuerierError, table_ref::build_table_reference};
+
+/// The metrics tables a PromQL query scans (gauge + sum cover counters
+/// and gauges; histograms are handled separately with histogram_quantile).
+const METRIC_TABLES: &[&str] = &["metrics_gauge", "metrics_sum"];
+
+/// Columns projected from each metrics table before the union.
+const SCAN_COLUMNS: &[&str] = &[
+    "timestamp",
+    "service_name",
+    "metric_name",
+    "value",
+    "attributes",
+    "resource_attributes",
+];
+
+const LOG_ATTRIBUTES: &str = "attributes";
+const RESOURCE_ATTRIBUTES: &str = "resource_attributes";
+
+/// Executes PromQL queries against the metrics tables.
+pub struct MetricsService {
+    session_context: Arc<SessionContext>,
+}
+
+impl Debug for MetricsService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsService")
+            .field("session_context", &"set")
+            .finish()
+    }
+}
+
+impl Clone for MetricsService {
+    fn clone(&self) -> Self {
+        Self {
+            session_context: Arc::clone(&self.session_context),
+        }
+    }
+}
+
+impl MetricsService {
+    pub fn new(session_context: SessionContext) -> Self {
+        Self {
+            session_context: Arc::new(session_context),
+        }
+    }
+
+    /// Execute a PromQL range query, returning matrix RecordBatches.
+    /// `start`/`end` are inclusive unix nanoseconds; `step` is the bucket
+    /// width in nanoseconds.
+    pub async fn query_range(
+        &self,
+        query: &str,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        if step <= 0 {
+            return Err(QuerierError::InvalidInput(
+                "step must be a positive nanosecond interval".to_string(),
+            ));
+        }
+        let plan = plan_promql(query)?;
+        let group_cols = self.group_columns(&plan)?;
+
+        let df = self.scan_union(tenant_slug, dataset_slug).await?;
+        let df = apply_filters(df, &plan, start, end)?;
+
+        // Bucket timestamps into step-aligned windows (cast the
+        // microsecond storage timestamp to nanoseconds first).
+        let stride = lit(ScalarValue::IntervalMonthDayNano(Some(
+            IntervalMonthDayNano::new(0, 0, step),
+        )));
+        let origin = lit(ScalarValue::TimestampNanosecond(Some(0), None));
+        let timestamp_ns = cast_ns(col("timestamp"));
+        let bucket = date_bin(stride, timestamp_ns, origin).alias("bucket");
+
+        // Group by bucket, metric_name, and the grouping columns.
+        let mut group_exprs = vec![bucket, col("metric_name")];
+        group_exprs.extend(group_cols.iter().map(|c| col(*c)));
+
+        let value = aggregate_expr(plan.aggregate).alias("value");
+        let df = df
+            .aggregate(group_exprs, vec![value])
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Normalize `value` to Float64 (count aggregates to Int64).
+        let mut proj = vec![col("bucket"), col("metric_name")];
+        proj.extend(group_cols.iter().map(|c| col(*c)));
+        proj.push(cast_ns_value(col("value")).alias("value"));
+        let df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+
+        df.sort(vec![SortExpr::new(col("bucket"), true, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)
+    }
+
+    /// Resolve the grouping labels to physical columns. Only labels backed
+    /// by a dedicated column can be grouped.
+    fn group_columns(&self, plan: &MetricPlan) -> Result<Vec<&'static str>, QuerierError> {
+        match &plan.grouping {
+            // Bare selector: one series per service.
+            Grouping::Natural => Ok(vec!["service_name"]),
+            // sum(x): collapse everything.
+            Grouping::Collapse => Ok(vec![]),
+            Grouping::By(labels) => labels
+                .iter()
+                .map(|l| {
+                    column_for_label(l).ok_or_else(|| {
+                        QuerierError::Unsupported(format!("grouping by attribute label '{l}'"))
+                    })
+                })
+                .collect(),
+        }
+    }
+
+    /// The union of the metrics tables, each projected to [`SCAN_COLUMNS`].
+    async fn scan_union(
+        &self,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<DataFrame, QuerierError> {
+        let mut union: Option<DataFrame> = None;
+        for table in METRIC_TABLES {
+            let table_ref = build_table_reference(tenant_slug, dataset_slug, table)
+                .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+            // A missing table (e.g. no sum metrics ingested yet) is not an
+            // error — skip it.
+            let Ok(df) = self.session_context.table(table_ref).await else {
+                continue;
+            };
+            let projected = df
+                .select_columns(SCAN_COLUMNS)
+                .map_err(QuerierError::QueryFailed)?;
+            union = Some(match union {
+                None => projected,
+                Some(existing) => existing
+                    .union(projected)
+                    .map_err(QuerierError::QueryFailed)?,
+            });
+        }
+        union.ok_or_else(|| {
+            QuerierError::InvalidInput("no metrics tables available for this dataset".to_string())
+        })
+    }
+}
+
+/// Apply the metric-name filter, label matchers, and time window.
+fn apply_filters(
+    df: DataFrame,
+    plan: &MetricPlan,
+    start: i64,
+    end: i64,
+) -> Result<DataFrame, QuerierError> {
+    let mut predicate = col("metric_name").eq(lit(plan.metric_name.clone()));
+    for m in &plan.matchers {
+        predicate = predicate.and(matcher_expr(m)?);
+    }
+    df.filter(
+        col("timestamp")
+            .gt_eq(lit(ScalarValue::TimestampNanosecond(Some(start), None)))
+            .and(col("timestamp").lt_eq(lit(ScalarValue::TimestampNanosecond(Some(end), None))))
+            .and(predicate),
+    )
+    .map_err(QuerierError::QueryFailed)
+}
+
+/// Lower one label matcher to a filter expression, mapping well-known
+/// labels to columns and others to the attribute JSON.
+fn matcher_expr(m: &LabelMatch) -> Result<Expr, QuerierError> {
+    match column_for_label(&m.name) {
+        Some(column) => Ok(match m.op {
+            MatchKind::Eq => col(column).eq(lit(m.value.clone())),
+            MatchKind::Neq => col(column).not_eq(lit(m.value.clone())),
+            MatchKind::Re => regexp_like(col(column), lit(m.value.clone()), None),
+            MatchKind::Nre => not(regexp_like(col(column), lit(m.value.clone()), None)),
+        }),
+        None => {
+            let fragment = attribute_fragment(&m.name, &m.value);
+            let present = contains(col(LOG_ATTRIBUTES), lit(fragment.clone()))
+                .or(contains(col(RESOURCE_ATTRIBUTES), lit(fragment.clone())));
+            match m.op {
+                MatchKind::Eq => Ok(present),
+                MatchKind::Neq => Ok(not(present)),
+                _ => Err(QuerierError::Unsupported(format!(
+                    "regex matcher on attribute label '{}'",
+                    m.name
+                ))),
+            }
+        }
+    }
+}
+
+/// Well-known PromQL labels mapped to dedicated columns.
+fn column_for_label(label: &str) -> Option<&'static str> {
+    match label {
+        "job" | "service" | "service_name" => Some("service_name"),
+        _ => None,
+    }
+}
+
+fn attribute_fragment(key: &str, value: &str) -> String {
+    let json_key = serde_json::to_string(key).unwrap_or_else(|_| format!("\"{key}\""));
+    let json_value = serde_json::to_string(value).unwrap_or_else(|_| format!("\"{value}\""));
+    format!("{json_key}:{json_value}")
+}
+
+fn aggregate_expr(agg: MetricAgg) -> Expr {
+    let value = col("value");
+    match agg {
+        MetricAgg::Sum => sum(value),
+        MetricAgg::Avg => avg(value),
+        MetricAgg::Min => min(value),
+        MetricAgg::Max => max(value),
+        MetricAgg::Count => count(value),
+        // Last value in the bucket, ordered by timestamp.
+        MetricAgg::Last => last_value(value, vec![SortExpr::new(col("timestamp"), true, true)]),
+    }
+}
+
+fn cast_ns(expr: Expr) -> Expr {
+    datafusion::logical_expr::cast(expr, DataType::Timestamp(TimeUnit::Nanosecond, None))
+}
+
+/// Cast an aggregate value to Float64 for a uniform matrix value column.
+fn cast_ns_value(expr: Expr) -> Expr {
+    datafusion::logical_expr::cast(expr, DataType::Float64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
+    use datafusion::arrow::datatypes::{Field, Schema};
+    use datafusion::catalog::memory::MemTable;
+    use datafusion::catalog::{
+        CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider,
+    };
+
+    fn metrics_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new(
+                "start_timestamp",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("attributes", DataType::Utf8, true),
+            Field::new("resource_attributes", DataType::Utf8, true),
+        ]))
+    }
+
+    fn service_with_data() -> MetricsService {
+        let schema = metrics_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300])),
+                Arc::new(TimestampNanosecondArray::from(vec![None, None, None])),
+                Arc::new(StringArray::from(vec!["api", "api", "web"])),
+                Arc::new(StringArray::from(vec!["reqs", "reqs", "reqs"])),
+                Arc::new(Float64Array::from(vec![1.0, 3.0, 5.0])),
+                Arc::new(StringArray::from(vec![
+                    r#"{"code":"200"}"#,
+                    r#"{"code":"500"}"#,
+                    r#"{"code":"200"}"#,
+                ])),
+                Arc::new(StringArray::from(vec!["{}", "{}", "{}"])),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("metrics_gauge".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+        MetricsService::new(ctx)
+    }
+
+    /// Collect (metric_name, service?, value) tuples from a matrix.
+    async fn matrix(
+        service: &MetricsService,
+        query: &str,
+        step: i64,
+    ) -> Vec<(String, Option<String>, f64)> {
+        let batches = service
+            .query_range(query, 0, 1000, step, "t", "d")
+            .await
+            .expect("query");
+        let mut out = Vec::new();
+        for batch in &batches {
+            let name = batch
+                .column_by_name("metric_name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let value = batch
+                .column_by_name("value")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            let service_col = batch
+                .column_by_name("service_name")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            for i in 0..batch.num_rows() {
+                let svc = service_col.map(|c| c.value(i).to_string());
+                out.push((name.value(i).to_string(), svc, value.value(i)));
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn bare_selector_last_value_per_series() {
+        let service = service_with_data();
+        // Step 1000ns: one bucket. Bare selector -> last value per service.
+        let out = matrix(&service, "reqs", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        let web = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("web"))
+            .unwrap();
+        assert_eq!(api.2, 3.0); // last of [1,3]
+        assert_eq!(web.2, 5.0);
+    }
+
+    #[tokio::test]
+    async fn sum_collapses_series() {
+        let service = service_with_data();
+        let out = matrix(&service, "sum(reqs)", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 9.0); // 1+3+5
+    }
+
+    #[tokio::test]
+    async fn sum_by_service() {
+        let service = service_with_data();
+        let out = matrix(&service, "sum by (job) (reqs)", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 4.0); // 1+3
+    }
+
+    #[tokio::test]
+    async fn label_matcher_filters_attributes() {
+        let service = service_with_data();
+        // code="500" only matches the api/500 row (value 3).
+        let out = matrix(&service, r#"sum(reqs{code="500"})"#, 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 3.0);
+    }
+
+    #[tokio::test]
+    async fn count_and_max() {
+        let service = service_with_data();
+        assert_eq!(matrix(&service, "count(reqs)", 1000).await[0].2, 3.0);
+        assert_eq!(matrix(&service, "max(reqs)", 1000).await[0].2, 5.0);
+    }
+
+    #[tokio::test]
+    async fn step_splits_buckets() {
+        let service = service_with_data();
+        // Step 150ns → buckets [0,150),[150,300),[300,450): ts 100/200/300
+        // land in three distinct buckets.
+        let out = matrix(&service, "sum(reqs)", 150).await;
+        assert_eq!(out.len(), 3);
+        assert_eq!(out.iter().map(|(_, _, v)| *v).sum::<f64>(), 9.0);
+    }
+
+    #[tokio::test]
+    async fn non_positive_step_rejected() {
+        let service = service_with_data();
+        assert!(matches!(
+            service.query_range("reqs", 0, 1000, 0, "t", "d").await,
+            Err(QuerierError::InvalidInput(_))
+        ));
+    }
+}

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -10,10 +10,11 @@
 //! `bucket` timestamp, `metric_name`, the grouping columns, and a
 //! `value`. The router shapes that into Prometheus matrix JSON.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::array::{Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, IntervalMonthDayNano, TimeUnit};
 use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
@@ -44,6 +45,9 @@ const SCAN_COLUMNS: &[&str] = &[
 
 const LOG_ATTRIBUTES: &str = "attributes";
 const RESOURCE_ATTRIBUTES: &str = "resource_attributes";
+
+/// Upper bound on distinct attribute documents scanned for discovery.
+const LABEL_SCAN_LIMIT: usize = 1000;
 
 /// Executes PromQL queries against the metrics tables.
 pub struct MetricsService {
@@ -239,6 +243,221 @@ impl MetricsService {
             QuerierError::InvalidInput("no metrics tables available for this dataset".to_string())
         })
     }
+
+    /// List the Prometheus label names present in the window: the
+    /// well-known ones (`__name__`, `job`) plus attribute keys discovered
+    /// in the `attributes`/`resource_attributes` documents.
+    pub async fn get_labels(
+        &self,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<String>, QuerierError> {
+        let mut labels: BTreeSet<String> =
+            ["__name__", "job"].iter().map(|s| s.to_string()).collect();
+        let df = self.scan_union(tenant_slug, dataset_slug).await?;
+        let df = window(df, start, end)?;
+        let batches = df
+            .select_columns(&[LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES])
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+        for batch in &batches {
+            for column in [LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES] {
+                collect_attribute_keys(batch, column, &mut labels)?;
+            }
+        }
+        Ok(labels.into_iter().collect())
+    }
+
+    /// List the distinct values of one Prometheus label in the window.
+    pub async fn get_label_values(
+        &self,
+        label: &str,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<String>, QuerierError> {
+        if label.is_empty() {
+            return Err(QuerierError::InvalidInput(
+                "label name must not be empty".to_string(),
+            ));
+        }
+        let df = self.scan_union(tenant_slug, dataset_slug).await?;
+        let df = window(df, start, end)?;
+
+        // `__name__` → metric_name; other known labels → their column.
+        let column = match label {
+            "__name__" => Some("metric_name"),
+            _ => column_for_label(label),
+        };
+        if let Some(column) = column {
+            let batches = df
+                .select_columns(&[column])
+                .map_err(QuerierError::QueryFailed)?
+                .distinct()
+                .map_err(QuerierError::QueryFailed)?
+                .collect()
+                .await
+                .map_err(QuerierError::QueryFailed)?;
+            return distinct_non_empty(&batches, column);
+        }
+
+        // Otherwise pull the value out of the attribute documents.
+        let batches = df
+            .select_columns(&[LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES])
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+        let mut values = BTreeSet::new();
+        for batch in &batches {
+            for column in [LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES] {
+                collect_attribute_values(batch, column, label, &mut values)?;
+            }
+        }
+        Ok(values.into_iter().collect())
+    }
+
+    /// List the distinct series (label sets) matching a PromQL selector.
+    /// Series identity is `__name__` (metric_name) and `job` (service_name).
+    pub async fn get_series(
+        &self,
+        selector: &str,
+        start: i64,
+        end: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<BTreeMap<String, String>>, QuerierError> {
+        let plan = plan_promql(selector.trim())?;
+        let df = self.scan_union(tenant_slug, dataset_slug).await?;
+        let df = apply_filters(df, &plan, start, end)?;
+
+        let batches = df
+            .select_columns(&["metric_name", "service_name"])
+            .map_err(QuerierError::QueryFailed)?
+            .distinct()
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        let mut series = BTreeSet::new();
+        for batch in &batches {
+            let name = string_column(batch, "metric_name")?;
+            let service = string_column(batch, "service_name")?;
+            for i in 0..batch.num_rows() {
+                let mut labels = BTreeMap::new();
+                if !name.is_null(i) && !name.value(i).is_empty() {
+                    labels.insert("__name__".to_string(), name.value(i).to_string());
+                }
+                if !service.is_null(i) && !service.value(i).is_empty() {
+                    labels.insert("job".to_string(), service.value(i).to_string());
+                }
+                if !labels.is_empty() {
+                    series.insert(labels);
+                }
+            }
+        }
+        Ok(series.into_iter().collect())
+    }
+}
+
+/// Inclusive nanosecond time-window filter on `timestamp`.
+fn window(df: DataFrame, start: i64, end: i64) -> Result<DataFrame, QuerierError> {
+    df.filter(
+        col("timestamp")
+            .gt_eq(lit(ScalarValue::TimestampNanosecond(Some(start), None)))
+            .and(col("timestamp").lt_eq(lit(ScalarValue::TimestampNanosecond(Some(end), None)))),
+    )
+    .map_err(QuerierError::QueryFailed)
+}
+
+/// Collect the sorted, distinct, non-empty values of a string column.
+fn distinct_non_empty(batches: &[RecordBatch], column: &str) -> Result<Vec<String>, QuerierError> {
+    let mut values = BTreeSet::new();
+    for batch in batches {
+        let col = string_column(batch, column)?;
+        for i in 0..batch.num_rows() {
+            if !col.is_null(i) && !col.value(i).is_empty() {
+                values.insert(col.value(i).to_string());
+            }
+        }
+    }
+    Ok(values.into_iter().collect())
+}
+
+/// Add every JSON object key from an attribute column to `keys`.
+fn collect_attribute_keys(
+    batch: &RecordBatch,
+    column: &str,
+    keys: &mut BTreeSet<String>,
+) -> Result<(), QuerierError> {
+    let attrs = string_column(batch, column)?;
+    for i in 0..batch.num_rows() {
+        if attrs.is_null(i) {
+            continue;
+        }
+        if let Ok(serde_json::Value::Object(map)) =
+            serde_json::from_str::<serde_json::Value>(attrs.value(i))
+        {
+            keys.extend(map.keys().cloned());
+        }
+    }
+    Ok(())
+}
+
+/// Add the value of `label` from each attribute document to `values`.
+fn collect_attribute_values(
+    batch: &RecordBatch,
+    column: &str,
+    label: &str,
+    values: &mut BTreeSet<String>,
+) -> Result<(), QuerierError> {
+    let attrs = string_column(batch, column)?;
+    for i in 0..batch.num_rows() {
+        if attrs.is_null(i) {
+            continue;
+        }
+        if let Ok(serde_json::Value::Object(map)) =
+            serde_json::from_str::<serde_json::Value>(attrs.value(i))
+            && let Some(value) = map.get(label)
+        {
+            match value {
+                serde_json::Value::String(s) => {
+                    values.insert(s.clone());
+                }
+                other => {
+                    values.insert(other.to_string());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, QuerierError> {
+    batch
+        .column_by_name(name)
+        .ok_or_else(|| QuerierError::InvalidInput(format!("missing column '{name}'")))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            QuerierError::InvalidInput(format!("column '{name}' is not a string column"))
+        })
 }
 
 /// Apply the metric-name filter, label matchers, and time window.
@@ -524,6 +743,58 @@ mod tests {
         let out = matrix(&service, "sum(increase(reqs[1m]))", 1000).await;
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].2, 2.0);
+    }
+
+    #[tokio::test]
+    async fn label_names_include_known_and_attribute_keys() {
+        let service = service_with_data();
+        let labels = service.get_labels(0, 1000, "t", "d").await.unwrap();
+        assert!(labels.contains(&"__name__".to_string()));
+        assert!(labels.contains(&"job".to_string()));
+        assert!(labels.contains(&"code".to_string()));
+    }
+
+    #[tokio::test]
+    async fn label_values_for_name_job_and_attribute() {
+        let service = service_with_data();
+        assert_eq!(
+            service
+                .get_label_values("__name__", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["reqs".to_string()]
+        );
+        assert_eq!(
+            service
+                .get_label_values("job", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["api".to_string(), "web".to_string()]
+        );
+        assert_eq!(
+            service
+                .get_label_values("code", 0, 1000, "t", "d")
+                .await
+                .unwrap(),
+            vec!["200".to_string(), "500".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn series_returns_name_and_job_sets() {
+        let service = service_with_data();
+        let series = service.get_series("reqs", 0, 1000, "t", "d").await.unwrap();
+        assert_eq!(series.len(), 2);
+        assert!(
+            series
+                .iter()
+                .all(|s| s.get("__name__") == Some(&"reqs".to_string()))
+        );
+        let jobs: BTreeSet<_> = series
+            .iter()
+            .filter_map(|s| s.get("job").cloned())
+            .collect();
+        assert_eq!(jobs, BTreeSet::from(["api".to_string(), "web".to_string()]));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -18,7 +18,9 @@ use datafusion::arrow::datatypes::{DataType, IntervalMonthDayNano, TimeUnit};
 use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
-use datafusion::functions_aggregate::expr_fn::{avg, count, last_value, max, min, sum};
+use datafusion::functions_aggregate::expr_fn::{
+    avg, count, first_value, last_value, max, min, sum,
+};
 use datafusion::logical_expr::{Expr, SortExpr, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
@@ -96,18 +98,33 @@ impl MetricsService {
 
         // Bucket timestamps into step-aligned windows (cast the
         // microsecond storage timestamp to nanoseconds first).
-        let stride = lit(ScalarValue::IntervalMonthDayNano(Some(
-            IntervalMonthDayNano::new(0, 0, step),
-        )));
-        let origin = lit(ScalarValue::TimestampNanosecond(Some(0), None));
-        let timestamp_ns = cast_ns(col("timestamp"));
-        let bucket = date_bin(stride, timestamp_ns, origin).alias("bucket");
+        let bucket = bucket_expr(step);
 
-        // Group by bucket, metric_name, and the grouping columns.
+        let df = if let Some(range) = plan.range {
+            self.range_query(df, bucket, range, plan.aggregate, &group_cols)?
+        } else {
+            self.simple_query(df, bucket, plan.aggregate, &group_cols)?
+        };
+
+        df.sort(vec![SortExpr::new(col("bucket"), true, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)
+    }
+
+    /// Aggregate `value` per (bucket, metric_name, group) directly.
+    fn simple_query(
+        &self,
+        df: DataFrame,
+        bucket: Expr,
+        aggregate: MetricAgg,
+        group_cols: &[&str],
+    ) -> Result<DataFrame, QuerierError> {
         let mut group_exprs = vec![bucket, col("metric_name")];
         group_exprs.extend(group_cols.iter().map(|c| col(*c)));
 
-        let value = aggregate_expr(plan.aggregate).alias("value");
+        let value = aggregate_expr(aggregate).alias("value");
         let df = df
             .aggregate(group_exprs, vec![value])
             .map_err(QuerierError::QueryFailed)?;
@@ -115,14 +132,63 @@ impl MetricsService {
         // Normalize `value` to Float64 (count aggregates to Int64).
         let mut proj = vec![col("bucket"), col("metric_name")];
         proj.extend(group_cols.iter().map(|c| col(*c)));
-        proj.push(cast_ns_value(col("value")).alias("value"));
-        let df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+        proj.push(cast_value_f64(col("value")).alias("value"));
+        df.select(proj).map_err(QuerierError::QueryFailed)
+    }
 
-        df.sort(vec![SortExpr::new(col("bucket"), true, true)])
-            .map_err(QuerierError::QueryFailed)?
-            .collect()
-            .await
-            .map_err(QuerierError::QueryFailed)
+    /// Two-stage `rate`/`increase`: per-series counter delta over the
+    /// bucket, then an optional outer aggregation.
+    fn range_query(
+        &self,
+        df: DataFrame,
+        bucket: Expr,
+        range: super::promql::RangeSpec,
+        aggregate: MetricAgg,
+        group_cols: &[&str],
+    ) -> Result<DataFrame, QuerierError> {
+        use super::promql::RangeFn;
+
+        // Stage 1: (last - first)[/seconds] per (bucket, metric_name, service).
+        let order = vec![SortExpr::new(col("timestamp"), true, true)];
+        let df = df
+            .aggregate(
+                vec![bucket, col("metric_name"), col("service_name")],
+                vec![
+                    first_value(col("value"), order.clone()).alias("first"),
+                    last_value(col("value"), order).alias("last"),
+                ],
+            )
+            .map_err(QuerierError::QueryFailed)?;
+
+        let delta = col("last") - col("first");
+        let per_series = match range.function {
+            RangeFn::Increase => delta,
+            RangeFn::Rate => delta / lit(range.seconds),
+        };
+        let df = df
+            .select(vec![
+                col("bucket"),
+                col("metric_name"),
+                col("service_name"),
+                cast_value_f64(per_series).alias("value"),
+            ])
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Stage 2: an outer aggregation folds the per-series rates. A bare
+        // `rate(...)` (Natural grouping over `service_name`) is already the
+        // result.
+        if group_cols == ["service_name"] {
+            return Ok(df);
+        }
+        let mut group_exprs = vec![col("bucket"), col("metric_name")];
+        group_exprs.extend(group_cols.iter().map(|c| col(*c)));
+        let df = df
+            .aggregate(group_exprs, vec![aggregate_expr(aggregate).alias("value")])
+            .map_err(QuerierError::QueryFailed)?;
+        let mut proj = vec![col("bucket"), col("metric_name")];
+        proj.extend(group_cols.iter().map(|c| col(*c)));
+        proj.push(cast_value_f64(col("value")).alias("value"));
+        df.select(proj).map_err(QuerierError::QueryFailed)
     }
 
     /// Resolve the grouping labels to physical columns. Only labels backed
@@ -252,9 +318,19 @@ fn cast_ns(expr: Expr) -> Expr {
     datafusion::logical_expr::cast(expr, DataType::Timestamp(TimeUnit::Nanosecond, None))
 }
 
-/// Cast an aggregate value to Float64 for a uniform matrix value column.
-fn cast_ns_value(expr: Expr) -> Expr {
+/// Cast a value to Float64 for a uniform matrix value column.
+fn cast_value_f64(expr: Expr) -> Expr {
     datafusion::logical_expr::cast(expr, DataType::Float64)
+}
+
+/// The step-aligned `date_bin` bucket expression, aligned to the epoch.
+/// The microsecond storage timestamp is cast to nanoseconds first.
+fn bucket_expr(step: i64) -> Expr {
+    let stride = lit(ScalarValue::IntervalMonthDayNano(Some(
+        IntervalMonthDayNano::new(0, 0, step),
+    )));
+    let origin = lit(ScalarValue::TimestampNanosecond(Some(0), None));
+    date_bin(stride, cast_ns(col("timestamp")), origin).alias("bucket")
 }
 
 #[cfg(test)]
@@ -414,6 +490,40 @@ mod tests {
         let out = matrix(&service, "sum(reqs)", 150).await;
         assert_eq!(out.len(), 3);
         assert_eq!(out.iter().map(|(_, _, v)| *v).sum::<f64>(), 9.0);
+    }
+
+    #[tokio::test]
+    async fn increase_is_last_minus_first_per_bucket() {
+        let service = service_with_data();
+        // api counter: 1 -> 3 in one bucket => increase 2; web has one
+        // sample => increase 0.
+        let out = matrix(&service, "increase(reqs[1m])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 2.0);
+    }
+
+    #[tokio::test]
+    async fn rate_divides_increase_by_range_seconds() {
+        let service = service_with_data();
+        // increase 2 over a 60s range = rate 2/60.
+        let out = matrix(&service, "rate(reqs[1m])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert!((api.2 - 2.0 / 60.0).abs() < 1e-9, "got {}", api.2);
+    }
+
+    #[tokio::test]
+    async fn sum_over_increase_folds_series() {
+        let service = service_with_data();
+        // api increase 2, web increase 0 => sum 2.
+        let out = matrix(&service, "sum(increase(reqs[1m]))", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 2.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -2,7 +2,9 @@ pub mod error;
 pub mod logql;
 pub mod logql_metric;
 pub mod logs;
+pub mod metrics;
 pub mod profile;
+pub mod promql;
 pub mod search_filter;
 pub mod table_ref;
 pub mod trace;
@@ -30,6 +32,19 @@ pub struct LogQueryParams {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MetricQueryParams {
     /// The LogQL metric query string.
+    pub query: String,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+    /// Bucket width (query resolution) in nanoseconds.
+    pub step: i64,
+}
+
+/// Parameters carried in the `query_promql` Flight ticket (JSON-encoded).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PromQlQueryParams {
+    /// The PromQL query string.
     pub query: String,
     /// Inclusive range start, unix epoch nanoseconds.
     pub start: i64,

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -54,6 +54,17 @@ pub struct PromQlQueryParams {
     pub step: i64,
 }
 
+/// Parameters carried in the `query_metric_series` Flight ticket.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MetricSeriesParams {
+    /// The PromQL selector, e.g. `http_requests_total{job="api"}`.
+    pub selector: String,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+}
+
 /// Parameters carried in the `query_logs_series` Flight ticket.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogSeriesParams {

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -13,9 +13,11 @@
 //!   by step (last value per bucket).
 //! - A vector aggregation `sum|avg|min|max|count [by (labels)] (metric)`.
 //!
-//! Range-vector functions (`rate`, `increase`, `irate`), binary
-//! operators, subqueries, and `histogram_quantile` are not lowered here
-//! yet and return [`QuerierError::Unsupported`] (tracked in #334/#335).
+//! - Range-vector functions `rate(metric[range])` and
+//!   `increase(metric[range])`, optionally under an outer aggregation.
+//!
+//! `irate`, binary operators, subqueries, and `histogram_quantile` are
+//! not lowered yet and return [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -65,17 +67,42 @@ pub enum MatchKind {
     Nre,
 }
 
+/// A range-vector function applied over the `[range]` window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeFn {
+    /// `rate(metric[range])` — per-second average increase of a counter.
+    Rate,
+    /// `increase(metric[range])` — total increase over the window.
+    Increase,
+}
+
+/// A range-vector spec: the function and its window in seconds.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RangeSpec {
+    pub function: RangeFn,
+    pub seconds: f64,
+}
+
+impl Eq for RangeSpec {}
+
 /// A lowered PromQL query.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MetricPlan {
     /// The metric name being queried.
     pub metric_name: String,
     /// Label matchers to filter series (excluding `__name__`).
     pub matchers: Vec<LabelMatch>,
-    /// The aggregate computed per bucket per series.
+    /// The aggregate computed per bucket per series. Ignored for the
+    /// per-series stage of a range function; applied as the outer
+    /// aggregation over a range result.
     pub aggregate: MetricAgg,
     pub grouping: Grouping,
+    /// Set for `rate`/`increase` — a per-series counter delta over the
+    /// window is computed before any outer aggregation.
+    pub range: Option<RangeSpec>,
 }
+
+impl Eq for MetricPlan {}
 
 /// Parse and lower a PromQL query.
 pub fn plan_promql(query: &str) -> Result<MetricPlan, QuerierError> {
@@ -86,8 +113,11 @@ pub fn plan_promql(query: &str) -> Result<MetricPlan, QuerierError> {
 
 fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
     match expr {
-        Expr::VectorSelector(vs) => lower_selector(vs, MetricAgg::Last, Grouping::Natural),
         Expr::Paren(p) => lower(&p.expr),
+        // Bare selector or bare range function.
+        Expr::VectorSelector(_) | Expr::Call(_) => {
+            build_plan(expr, MetricAgg::Last, Grouping::Natural)
+        }
         Expr::Aggregate(agg) => {
             let aggregate = aggregate_op(&format!("{}", agg.op))?;
             if agg.param.is_some() {
@@ -96,18 +126,8 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
                 ));
             }
             let grouping = grouping_from(agg.modifier.as_ref())?;
-            match unwrap_paren(&agg.expr) {
-                Expr::VectorSelector(vs) => lower_selector(vs, aggregate, grouping),
-                other => Err(QuerierError::Unsupported(format!(
-                    "aggregation over {}",
-                    expr_kind(other)
-                ))),
-            }
+            build_plan(unwrap_paren(&agg.expr), aggregate, grouping)
         }
-        Expr::Call(call) => Err(QuerierError::Unsupported(format!(
-            "function '{}' (range functions land in #334)",
-            call.func.name
-        ))),
         Expr::Binary(_) => Err(QuerierError::Unsupported(
             "binary operations between metric queries".to_string(),
         )),
@@ -121,10 +141,55 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
     }
 }
 
+/// Build a plan from the innermost expression (a selector or a range
+/// function over a selector) plus the outer aggregate/grouping.
+fn build_plan(
+    inner: &Expr,
+    aggregate: MetricAgg,
+    grouping: Grouping,
+) -> Result<MetricPlan, QuerierError> {
+    match inner {
+        Expr::Paren(p) => build_plan(&p.expr, aggregate, grouping),
+        Expr::VectorSelector(vs) => lower_selector(vs, aggregate, grouping, None),
+        Expr::Call(call) => {
+            let function = match call.func.name {
+                "rate" => RangeFn::Rate,
+                "increase" => RangeFn::Increase,
+                other => {
+                    return Err(QuerierError::Unsupported(format!(
+                        "function '{other}' (only rate/increase are supported)"
+                    )));
+                }
+            };
+            let arg = call.args.first().ok_or_else(|| {
+                QuerierError::InvalidInput(format!("{} expects one argument", call.func.name))
+            })?;
+            let Expr::MatrixSelector(ms) = unwrap_paren(&arg) else {
+                return Err(QuerierError::Unsupported(format!(
+                    "{} requires a range-vector selector like metric[5m]",
+                    call.func.name
+                )));
+            };
+            let seconds = ms.range.as_secs_f64();
+            lower_selector(
+                &ms.vs,
+                aggregate,
+                grouping,
+                Some(RangeSpec { function, seconds }),
+            )
+        }
+        other => Err(QuerierError::Unsupported(format!(
+            "aggregation over {}",
+            expr_kind(other)
+        ))),
+    }
+}
+
 fn lower_selector(
     vs: &parser::VectorSelector,
     aggregate: MetricAgg,
     grouping: Grouping,
+    range: Option<RangeSpec>,
 ) -> Result<MetricPlan, QuerierError> {
     // The metric name may be given directly or via a `__name__` matcher.
     let mut metric_name = vs.name.clone();
@@ -147,6 +212,7 @@ fn lower_selector(
         matchers,
         aggregate,
         grouping,
+        range,
     })
 }
 
@@ -298,9 +364,41 @@ mod tests {
     }
 
     #[test]
+    fn rate_and_increase() {
+        let r = plan(r#"rate(http_requests_total{job="api"}[5m])"#);
+        assert_eq!(r.metric_name, "http_requests_total");
+        assert_eq!(r.matchers.len(), 1);
+        assert_eq!(
+            r.range,
+            Some(RangeSpec {
+                function: RangeFn::Rate,
+                seconds: 300.0
+            })
+        );
+        assert_eq!(r.grouping, Grouping::Natural);
+
+        let inc = plan(r#"increase(errors[1m])"#);
+        assert_eq!(
+            inc.range,
+            Some(RangeSpec {
+                function: RangeFn::Increase,
+                seconds: 60.0
+            })
+        );
+    }
+
+    #[test]
+    fn sum_over_rate() {
+        let p = plan(r#"sum(rate(http_requests_total[5m]))"#);
+        assert_eq!(p.aggregate, MetricAgg::Sum);
+        assert_eq!(p.grouping, Grouping::Collapse);
+        assert_eq!(p.range.unwrap().function, RangeFn::Rate);
+    }
+
+    #[test]
     fn unsupported_shapes() {
         assert!(matches!(
-            err(r#"rate(x[5m])"#),
+            err(r#"irate(x[5m])"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(err(r#"topk(5, x)"#), QuerierError::Unsupported(_)));

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -1,0 +1,322 @@
+//! # PromQL query lowering
+//!
+//! Parses a PromQL query with `promql-parser` and lowers the supported
+//! subset into a [`MetricPlan`] — a backend-neutral description of the
+//! aggregation the querier runs over the metrics tables. The
+//! [`super::metrics`] service turns this into a DataFusion aggregate.
+//!
+//! ## Scope
+//!
+//! This covers the common instant/range shapes:
+//!
+//! - A bare selector `metric{label="v"}` — the series' samples, bucketed
+//!   by step (last value per bucket).
+//! - A vector aggregation `sum|avg|min|max|count [by (labels)] (metric)`.
+//!
+//! Range-vector functions (`rate`, `increase`, `irate`), binary
+//! operators, subqueries, and `histogram_quantile` are not lowered here
+//! yet and return [`QuerierError::Unsupported`] (tracked in #334/#335).
+//!
+//! Like the log path, range aggregations use fixed step-aligned buckets
+//! (`date_bin`), not Prometheus's sliding window — exact when the step
+//! equals the range.
+
+use promql_parser::parser::{self, Expr, LabelModifier};
+
+use super::error::QuerierError;
+
+/// The per-bucket, per-series aggregate to compute over `value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricAgg {
+    /// Last value in the bucket (bare selector sampling).
+    Last,
+    Sum,
+    Avg,
+    Min,
+    Max,
+    Count,
+}
+
+/// How series are grouped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Grouping {
+    /// Group by the natural series identity (bare selector).
+    Natural,
+    /// Collapse all series into one (`sum(metric)` with no `by`).
+    Collapse,
+    /// Group by the given labels (`sum by (a, b) (metric)`).
+    By(Vec<String>),
+}
+
+/// A label matcher on a selector (excluding `__name__`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelMatch {
+    pub name: String,
+    pub op: MatchKind,
+    pub value: String,
+}
+
+/// Label matcher operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchKind {
+    Eq,
+    Neq,
+    Re,
+    Nre,
+}
+
+/// A lowered PromQL query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricPlan {
+    /// The metric name being queried.
+    pub metric_name: String,
+    /// Label matchers to filter series (excluding `__name__`).
+    pub matchers: Vec<LabelMatch>,
+    /// The aggregate computed per bucket per series.
+    pub aggregate: MetricAgg,
+    pub grouping: Grouping,
+}
+
+/// Parse and lower a PromQL query.
+pub fn plan_promql(query: &str) -> Result<MetricPlan, QuerierError> {
+    let expr = parser::parse(query)
+        .map_err(|e| QuerierError::InvalidInput(format!("invalid PromQL: {e}")))?;
+    lower(&expr)
+}
+
+fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
+    match expr {
+        Expr::VectorSelector(vs) => lower_selector(vs, MetricAgg::Last, Grouping::Natural),
+        Expr::Paren(p) => lower(&p.expr),
+        Expr::Aggregate(agg) => {
+            let aggregate = aggregate_op(&format!("{}", agg.op))?;
+            if agg.param.is_some() {
+                return Err(QuerierError::Unsupported(
+                    "parameterized aggregation (topk/quantile/count_values)".to_string(),
+                ));
+            }
+            let grouping = grouping_from(agg.modifier.as_ref())?;
+            match unwrap_paren(&agg.expr) {
+                Expr::VectorSelector(vs) => lower_selector(vs, aggregate, grouping),
+                other => Err(QuerierError::Unsupported(format!(
+                    "aggregation over {}",
+                    expr_kind(other)
+                ))),
+            }
+        }
+        Expr::Call(call) => Err(QuerierError::Unsupported(format!(
+            "function '{}' (range functions land in #334)",
+            call.func.name
+        ))),
+        Expr::Binary(_) => Err(QuerierError::Unsupported(
+            "binary operations between metric queries".to_string(),
+        )),
+        Expr::MatrixSelector(_) | Expr::Subquery(_) => Err(QuerierError::Unsupported(
+            "range-vector selector without a function".to_string(),
+        )),
+        other => Err(QuerierError::Unsupported(format!(
+            "PromQL expression: {}",
+            expr_kind(other)
+        ))),
+    }
+}
+
+fn lower_selector(
+    vs: &parser::VectorSelector,
+    aggregate: MetricAgg,
+    grouping: Grouping,
+) -> Result<MetricPlan, QuerierError> {
+    // The metric name may be given directly or via a `__name__` matcher.
+    let mut metric_name = vs.name.clone();
+    let mut matchers = Vec::new();
+    for m in &vs.matchers.matchers {
+        if m.name == "__name__" {
+            metric_name.get_or_insert_with(|| m.value.clone());
+            continue;
+        }
+        matchers.push(LabelMatch {
+            name: m.name.clone(),
+            op: match_kind(&m.op),
+            value: m.value.clone(),
+        });
+    }
+    let metric_name = metric_name
+        .ok_or_else(|| QuerierError::InvalidInput("selector has no metric name".to_string()))?;
+    Ok(MetricPlan {
+        metric_name,
+        matchers,
+        aggregate,
+        grouping,
+    })
+}
+
+fn unwrap_paren(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Paren(p) => unwrap_paren(&p.expr),
+        other => other,
+    }
+}
+
+fn aggregate_op(op: &str) -> Result<MetricAgg, QuerierError> {
+    Ok(match op {
+        "sum" => MetricAgg::Sum,
+        "avg" => MetricAgg::Avg,
+        "min" => MetricAgg::Min,
+        "max" => MetricAgg::Max,
+        "count" => MetricAgg::Count,
+        other => {
+            return Err(QuerierError::Unsupported(format!(
+                "aggregation operator '{other}'"
+            )));
+        }
+    })
+}
+
+fn grouping_from(modifier: Option<&LabelModifier>) -> Result<Grouping, QuerierError> {
+    match modifier {
+        None => Ok(Grouping::Collapse),
+        Some(LabelModifier::Include(labels)) => Ok(Grouping::By(labels.labels.clone())),
+        Some(LabelModifier::Exclude(labels)) if labels.is_empty() => Ok(Grouping::Collapse),
+        Some(LabelModifier::Exclude(_)) => Err(QuerierError::Unsupported(
+            "'without (labels)' grouping".to_string(),
+        )),
+    }
+}
+
+fn match_kind(op: &promql_parser::label::MatchOp) -> MatchKind {
+    use promql_parser::label::MatchOp;
+    match op {
+        MatchOp::Equal => MatchKind::Eq,
+        MatchOp::NotEqual => MatchKind::Neq,
+        MatchOp::Re(_) => MatchKind::Re,
+        MatchOp::NotRe(_) => MatchKind::Nre,
+    }
+}
+
+fn expr_kind(expr: &Expr) -> &'static str {
+    match expr {
+        Expr::Aggregate(_) => "an aggregation",
+        Expr::Unary(_) => "a unary expression",
+        Expr::Binary(_) => "a binary expression",
+        Expr::Paren(_) => "a parenthesized expression",
+        Expr::Subquery(_) => "a subquery",
+        Expr::NumberLiteral(_) => "a number literal",
+        Expr::StringLiteral(_) => "a string literal",
+        Expr::VectorSelector(_) => "a vector selector",
+        Expr::MatrixSelector(_) => "a range-vector selector",
+        Expr::Call(_) => "a function call",
+        Expr::Extension(_) => "an extension expression",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(q: &str) -> MetricPlan {
+        plan_promql(q).expect("plan")
+    }
+
+    fn err(q: &str) -> QuerierError {
+        plan_promql(q).unwrap_err()
+    }
+
+    #[test]
+    fn bare_selector() {
+        let p = plan(r#"http_requests_total"#);
+        assert_eq!(p.metric_name, "http_requests_total");
+        assert!(p.matchers.is_empty());
+        assert_eq!(p.aggregate, MetricAgg::Last);
+        assert_eq!(p.grouping, Grouping::Natural);
+    }
+
+    #[test]
+    fn selector_with_matchers() {
+        let p = plan(r#"http_requests_total{job="api", code!="500", path=~"/v1/.*"}"#);
+        assert_eq!(p.metric_name, "http_requests_total");
+        assert_eq!(
+            p.matchers,
+            vec![
+                LabelMatch {
+                    name: "job".into(),
+                    op: MatchKind::Eq,
+                    value: "api".into()
+                },
+                LabelMatch {
+                    name: "code".into(),
+                    op: MatchKind::Neq,
+                    value: "500".into()
+                },
+                LabelMatch {
+                    name: "path".into(),
+                    op: MatchKind::Re,
+                    value: "/v1/.*".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn name_via_name_matcher() {
+        let p = plan(r#"{__name__="up", job="api"}"#);
+        assert_eq!(p.metric_name, "up");
+        assert_eq!(p.matchers.len(), 1);
+        assert_eq!(p.matchers[0].name, "job");
+    }
+
+    #[test]
+    fn sum_collapses_all_series() {
+        let p = plan(r#"sum(http_requests_total)"#);
+        assert_eq!(p.aggregate, MetricAgg::Sum);
+        assert_eq!(p.grouping, Grouping::Collapse);
+    }
+
+    #[test]
+    fn sum_by_labels() {
+        let p = plan(r#"sum by (job, code) (http_requests_total{env="prod"})"#);
+        assert_eq!(p.aggregate, MetricAgg::Sum);
+        assert_eq!(p.grouping, Grouping::By(vec!["job".into(), "code".into()]));
+        assert_eq!(p.matchers.len(), 1);
+    }
+
+    #[test]
+    fn every_supported_aggregate() {
+        for (q, a) in [
+            ("avg(x)", MetricAgg::Avg),
+            ("min(x)", MetricAgg::Min),
+            ("max(x)", MetricAgg::Max),
+            ("count(x)", MetricAgg::Count),
+        ] {
+            assert_eq!(plan(q).aggregate, a, "{q}");
+        }
+    }
+
+    #[test]
+    fn without_empty_collapses() {
+        // `sum without () (x)` collapses like a bare `sum`.
+        assert_eq!(plan(r#"sum without () (x)"#).grouping, Grouping::Collapse);
+    }
+
+    #[test]
+    fn unsupported_shapes() {
+        assert!(matches!(
+            err(r#"rate(x[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(err(r#"topk(5, x)"#), QuerierError::Unsupported(_)));
+        assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
+        assert!(matches!(
+            err(r#"sum without (job) (x)"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"histogram_quantile(0.9, x)"#),
+            QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_promql_is_rejected() {
+        assert!(matches!(err(r#"sum(("#), QuerierError::InvalidInput(_)));
+    }
+}

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -10,6 +10,7 @@ common.workspace = true
 signaldb-api.workspace = true
 logql.workspace = true
 loki-api.workspace = true
+prometheus-api.workspace = true
 pyroscope-api.workspace = true
 tempo-api.workspace = true
 arrow-flight.workspace = true

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod flight;
 pub mod logql;
+pub mod promql;
 pub mod pyroscope;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/endpoints/promql.rs
+++ b/src/router/src/endpoints/promql.rs
@@ -1,0 +1,569 @@
+//! # Prometheus-Compatible HTTP API (PromQL)
+//!
+//! Query endpoints for the metrics signal in the format Grafana's
+//! Prometheus datasource expects, nested under `/prometheus`:
+//!
+//! - `GET|POST /api/v1/query_range` — range query → matrix
+//! - `GET|POST /api/v1/query` — instant query → vector
+//! - `GET /api/v1/labels`, `/api/v1/label/{name}/values`, `/api/v1/series`
+//!
+//! Handlers build a `query_promql` Flight ticket, execute it against a
+//! querier, and convert the returned matrix RecordBatches into Prometheus
+//! JSON. Metadata endpoints (labels/values/series) query the metrics tables via the querier.
+
+use std::collections::HashMap;
+
+use crate::RouterState;
+use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use axum::{
+    Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use common::auth::TenantContextExtractor;
+use common::flight::transport::ServiceCapability;
+use datafusion::arrow::array::{
+    Array, Float64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+};
+use futures::StreamExt;
+use prometheus_api::{
+    InstantVector, LabelsResponse, QueryResponse, QueryResult, RangeVector, Sample, SeriesResponse,
+};
+use serde::Deserialize;
+
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new()
+        .route("/api/v1/query", get(query::<S>).post(query::<S>))
+        .route(
+            "/api/v1/query_range",
+            get(query_range::<S>).post(query_range::<S>),
+        )
+        .route("/api/v1/labels", get(labels::<S>))
+        .route("/api/v1/label/{name}/values", get(label_values::<S>))
+        .route("/api/v1/series", get(series::<S>))
+}
+
+/// One hour in nanoseconds, the default range-query lookback.
+const HOUR_NS: i64 = 3_600_000_000_000;
+
+/// Parameters for `/api/v1/query` (instant queries).
+#[derive(Debug, Deserialize)]
+pub struct InstantParams {
+    pub query: Option<String>,
+    /// Evaluation timestamp (unix seconds or RFC3339).
+    pub time: Option<String>,
+}
+
+/// Parameters for `/api/v1/query_range`.
+#[derive(Debug, Deserialize)]
+pub struct RangeParams {
+    pub query: Option<String>,
+    pub start: Option<String>,
+    pub end: Option<String>,
+    /// Resolution step (Go duration or seconds).
+    pub step: Option<String>,
+}
+
+/// Parameters for the metadata endpoints.
+#[derive(Debug, Default, Deserialize)]
+pub struct MetadataParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    #[serde(rename = "match[]")]
+    pub matcher: Option<String>,
+}
+
+/// GET|POST /prometheus/api/v1/query_range.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(tenant_id = %tenant_ctx.0.tenant_id, dataset_id = %tenant_ctx.0.dataset_id)
+)]
+pub async fn query_range<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RangeParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let Some(promql) = non_empty(&params.query) else {
+        return Ok(axum::Json(QueryResponse::error(
+            "bad_data",
+            "missing or empty 'query'",
+        )));
+    };
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    let step = parse_step_ns(params.step.as_deref()).unwrap_or_else(|| default_step_ns(start, end));
+
+    match run_promql(&state, &tenant_ctx, &promql, start, end, step).await {
+        Ok(batches) => Ok(axum::Json(QueryResponse::success(QueryResult::Matrix(
+            batches_to_matrix(&batches),
+        )))),
+        Err(status) => Err(status),
+    }
+}
+
+/// GET|POST /prometheus/api/v1/query — instant query.
+///
+/// Evaluated as a one-bucket range at `time`, returning the latest sample
+/// per series as a vector.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(tenant_id = %tenant_ctx.0.tenant_id, dataset_id = %tenant_ctx.0.dataset_id)
+)]
+pub async fn query<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<InstantParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let Some(promql) = non_empty(&params.query) else {
+        return Ok(axum::Json(QueryResponse::error(
+            "bad_data",
+            "missing or empty 'query'",
+        )));
+    };
+    let at = parse_timestamp_ns(params.time.as_deref()).unwrap_or_else(now_ns);
+    let start = at - HOUR_NS;
+    // One bucket spanning the lookback so each series yields one sample.
+    let step = HOUR_NS;
+
+    match run_promql(&state, &tenant_ctx, &promql, start, at, step).await {
+        Ok(batches) => {
+            let vector = matrix_to_vector(batches_to_matrix(&batches));
+            Ok(axum::Json(QueryResponse::success(QueryResult::Vector(
+                vector,
+            ))))
+        }
+        Err(status) => Err(status),
+    }
+}
+
+/// GET /prometheus/api/v1/labels — metric label names.
+pub async fn labels<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_metric_labels:{}:{}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "label",
+    ))))
+}
+
+/// GET /prometheus/api/v1/label/{name}/values — distinct values of a label.
+pub async fn label_values<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Path(name): Path<String>,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    if name.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_metric_label_values:{}:{}:{name}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "value",
+    ))))
+}
+
+/// GET /prometheus/api/v1/series — series matching a selector.
+pub async fn series<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<SeriesResponse>, StatusCode> {
+    let selector = params
+        .matcher
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let (start, end) = metadata_window(&params);
+    let payload = serde_json::json!({ "selector": selector, "start": start, "end": end });
+    let ticket = format!(
+        "query_metric_series:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(SeriesResponse::success(series_from_batches(
+        &batches,
+    ))))
+}
+
+// ---- execution + conversion ----
+
+/// Build and execute a `query_promql` ticket.
+async fn run_promql<S: RouterState>(
+    state: &S,
+    tenant_ctx: &TenantContextExtractor,
+    promql: &str,
+    start: i64,
+    end: i64,
+    step: i64,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let payload = serde_json::json!({
+        "query": promql,
+        "start": start,
+        "end": end,
+        "step": step,
+    });
+    let ticket = format!(
+        "query_promql:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    execute_ticket(state, ticket).await
+}
+
+/// Send a Flight ticket to a querier and collect the result batches.
+async fn execute_ticket<S: RouterState>(
+    state: &S,
+    ticket_content: String,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let mut client = state
+        .service_registry()
+        .get_flight_client_for_capability(ServiceCapability::QueryExecution)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to get Flight client for PromQL query");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    let ticket = Ticket::new(ticket_content);
+    let mut flight_request = tonic::Request::new(ticket);
+    common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
+
+    let mut stream = client
+        .do_get(flight_request)
+        .await
+        .map_err(|e| flight_status_to_http(&e))?
+        .into_inner();
+
+    let mut data = Vec::new();
+    while let Some(flight_data) = stream.next().await {
+        data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
+    }
+
+    // An empty result is a well-formed empty stream (no schema frame). Return
+    // no batches rather than letting `flight_data_to_batches` error on it — a
+    // query whose window contains no data must yield an empty vector/matrix.
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    flight_data_to_batches(&data).map_err(|e| {
+        tracing::error!(error = %e, "Failed to decode PromQL Flight data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+fn flight_status_to_http(status: &tonic::Status) -> StatusCode {
+    match status.code() {
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+        _ => {
+            tracing::error!(error = %status, "PromQL Flight query failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// Group matrix rows (`bucket`, `metric_name`, label columns, `value`)
+/// into Prometheus range vectors. `bucket` is nanoseconds; Prometheus
+/// samples use unix seconds.
+fn batches_to_matrix(batches: &[RecordBatch]) -> Vec<RangeVector> {
+    let mut order: Vec<String> = Vec::new();
+    let mut series: HashMap<String, RangeVector> = HashMap::new();
+
+    for batch in batches {
+        let Some(buckets) = timestamps_ns(batch, "bucket") else {
+            continue;
+        };
+        let value = batch
+            .column_by_name("value")
+            .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+        let schema = batch.schema();
+        let label_cols: Vec<(String, &StringArray)> = schema
+            .fields()
+            .iter()
+            .filter_map(|f| {
+                let name = f.name();
+                if name == "bucket" || name == "value" {
+                    return None;
+                }
+                str_col(batch, name).map(|c| (name.clone(), c))
+            })
+            .collect();
+
+        for i in 0..batch.num_rows() {
+            let mut metric: HashMap<String, String> = HashMap::new();
+            for (name, col) in &label_cols {
+                if col.is_null(i) || col.value(i).is_empty() {
+                    continue;
+                }
+                // `metric_name` is Prometheus's `__name__`.
+                let key = if name == "metric_name" {
+                    "__name__"
+                } else {
+                    name.as_str()
+                };
+                metric.insert(key.to_string(), col.value(i).to_string());
+            }
+            let key = label_key(&metric);
+            let seconds = if buckets.is_null(i) {
+                0.0
+            } else {
+                buckets.value(i) as f64 / 1_000_000_000.0
+            };
+            let v = value
+                .map(|c| if c.is_null(i) { f64::NAN } else { c.value(i) })
+                .unwrap_or(f64::NAN);
+            series
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    order.push(key.clone());
+                    RangeVector {
+                        metric,
+                        values: Vec::new(),
+                    }
+                })
+                .values
+                .push(Sample::new(seconds, format_value(v)));
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| series.remove(&k))
+        .collect()
+}
+
+/// Reduce a matrix to an instant vector: each series' last sample.
+fn matrix_to_vector(matrix: Vec<RangeVector>) -> Vec<InstantVector> {
+    matrix
+        .into_iter()
+        .filter_map(|series| {
+            series.values.into_iter().last().map(|value| InstantVector {
+                metric: series.metric,
+                value,
+            })
+        })
+        .collect()
+}
+
+fn format_value(v: f64) -> String {
+    if v.is_nan() {
+        "NaN".to_string()
+    } else if v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+fn label_key(labels: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = labels.iter().collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+}
+
+/// Collect the values of a single-string-column result batch.
+fn string_column(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        if let Some(col) = str_col(batch, column) {
+            for i in 0..col.len() {
+                if !col.is_null(i) {
+                    out.push(col.value(i).to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Decode a `series` JSON batch into label maps.
+fn series_from_batches(batches: &[RecordBatch]) -> Vec<HashMap<String, String>> {
+    let mut out = Vec::new();
+    for value in string_column(batches, "series") {
+        if let Ok(series) = serde_json::from_str::<Vec<HashMap<String, String>>>(&value) {
+            out.extend(series);
+        }
+    }
+    out
+}
+
+/// Resolve a metadata endpoint's `[start, end]` window in nanoseconds,
+/// defaulting to the last hour.
+fn metadata_window(params: &MetadataParams) -> (i64, i64) {
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    (start, end)
+}
+
+/// Read a timestamp column as nanoseconds, casting from the storage unit.
+fn timestamps_ns(batch: &RecordBatch, name: &str) -> Option<TimestampNanosecondArray> {
+    use datafusion::arrow::compute::cast;
+    use datafusion::arrow::datatypes::{DataType, TimeUnit};
+    let column = batch.column_by_name(name)?;
+    let nanos = cast(column, &DataType::Timestamp(TimeUnit::Nanosecond, None)).ok()?;
+    nanos
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()
+        .cloned()
+}
+
+fn non_empty(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn now_ns() -> i64 {
+    chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() * 1_000_000)
+}
+
+/// Parse a Prometheus timestamp (unix seconds float, or RFC3339) → ns.
+fn parse_timestamp_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(seconds) = value.parse::<f64>() {
+        return Some((seconds * 1_000_000_000.0) as i64);
+    }
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .and_then(|dt| dt.timestamp_nanos_opt())
+}
+
+/// Parse `step` (Go duration or seconds) → nanoseconds.
+fn parse_step_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(seconds) = value.parse::<f64>() {
+        return Some((seconds * 1_000_000_000.0) as i64);
+    }
+    // Reuse the LogQL lexer for durations like `30s`, `5m`.
+    let tokens = logql::tokenize(value).ok()?;
+    match tokens.first().map(|t| &t.token) {
+        Some(logql::Token::Duration(d)) => Some(d.as_nanos() as i64),
+        _ => None,
+    }
+}
+
+fn default_step_ns(start: i64, end: i64) -> i64 {
+    let span = (end - start).max(1);
+    (span / 250).max(1_000_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use std::sync::Arc;
+
+    fn matrix_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, true),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    1_000_000_000,
+                    2_000_000_000,
+                    1_000_000_000,
+                ])),
+                Arc::new(StringArray::from(vec!["reqs", "reqs", "reqs"])),
+                Arc::new(StringArray::from(vec!["api", "api", "web"])),
+                Arc::new(Float64Array::from(vec![2.0, 3.0, 5.5])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn matrix_groups_rows_and_maps_name() {
+        let matrix = batches_to_matrix(&[matrix_batch()]);
+        assert_eq!(matrix.len(), 2);
+        let api = matrix
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"api".to_string()))
+            .unwrap();
+        assert_eq!(api.metric.get("__name__"), Some(&"reqs".to_string()));
+        assert_eq!(
+            api.values,
+            vec![Sample::new(1.0, "2"), Sample::new(2.0, "3")]
+        );
+        let web = matrix
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"web".to_string()))
+            .unwrap();
+        assert_eq!(web.values, vec![Sample::new(1.0, "5.5")]);
+    }
+
+    #[test]
+    fn instant_vector_takes_last_sample() {
+        let vector = matrix_to_vector(batches_to_matrix(&[matrix_batch()]));
+        let api = vector
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"api".to_string()))
+            .unwrap();
+        assert_eq!(api.value, Sample::new(2.0, "3"));
+    }
+
+    #[test]
+    fn value_formatting() {
+        assert_eq!(format_value(3.0), "3");
+        assert_eq!(format_value(2.5), "2.5");
+        assert_eq!(format_value(f64::NAN), "NaN");
+    }
+
+    #[test]
+    fn step_and_timestamp_parsing() {
+        assert_eq!(parse_step_ns(Some("30")), Some(30_000_000_000));
+        assert_eq!(parse_step_ns(Some("5m")), Some(300_000_000_000));
+        assert_eq!(
+            parse_timestamp_ns(Some("1700000000")),
+            Some(1_700_000_000_000_000_000)
+        );
+        assert_eq!(
+            parse_timestamp_ns(Some("2023-11-14T22:13:20Z")),
+            Some(1_700_000_000_000_000_000)
+        );
+        assert_eq!(parse_timestamp_ns(None), None);
+    }
+}

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -215,6 +215,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Prometheus-compatible metrics query API (PromQL)
+        .nest(
+            "/prometheus",
+            endpoints::promql::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Trace-to-profile correlation
         .nest(
             "/api/profiles",

--- a/tests-integration/tests/promql_queries.rs
+++ b/tests-integration/tests/promql_queries.rs
@@ -1,0 +1,504 @@
+//! End-to-end integration tests for the PromQL query interface.
+//!
+//! Boots the full ingest→store→query stack (acceptor metrics handler →
+//! WAL → writer → Iceberg → querier → router), ingests gauge metrics,
+//! waits for persistence, then drives the `/prometheus` HTTP endpoints:
+//! range/instant queries, an aggregation, and label/series discovery.
+
+use acceptor::handler::WalManager;
+use acceptor::handler::otlp_metrics_handler::MetricsHandler;
+use arrow_flight::flight_service_server::FlightServiceServer;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    middleware,
+};
+use common::CatalogManager;
+use common::auth::{TenantContext, TenantSource, auth_middleware};
+use common::catalog::Catalog;
+use common::config::Configuration;
+use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+use common::wal::{Wal, WalConfig};
+use opentelemetry_proto::tonic::{
+    collector::metrics::v1::ExportMetricsServiceRequest,
+    common::v1::{AnyValue, KeyValue, any_value::Value},
+    metrics::v1::{
+        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data,
+        number_data_point,
+    },
+    resource::v1::Resource,
+};
+use querier::flight::QuerierFlightService;
+use router::{RouterState, discovery::ServiceRegistry, endpoints::promql};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use tonic::transport::Server;
+use tower::ServiceExt;
+use writer::IcebergWriterFlightService;
+
+const BASE_NS: u64 = 1_700_000_000_000_000_000;
+
+struct TestServices {
+    object_store: Arc<dyn object_store::ObjectStore>,
+    flight_transport: Arc<InMemoryFlightTransport>,
+    metrics_handler: MetricsHandler,
+    config: Configuration,
+    _temp_dir: TempDir,
+}
+
+fn test_tenant_context() -> TenantContext {
+    TenantContext {
+        tenant_id: "test-tenant".to_string(),
+        dataset_id: "test-dataset".to_string(),
+        tenant_slug: "test-tenant".to_string(),
+        dataset_slug: "test-dataset".to_string(),
+        api_key_name: Some("test-key".to_string()),
+        source: TenantSource::Config,
+    }
+}
+
+async fn setup() -> TestServices {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_path = temp_dir.path().join("storage");
+    std::fs::create_dir_all(&storage_path).unwrap();
+    let storage_dsn = format!("file://{}", storage_path.display());
+    let object_store =
+        common::storage::create_object_store_from_dsn(&storage_dsn).expect("object store");
+
+    let catalog_dsn = format!("sqlite://{}", temp_dir.path().join("catalog.db").display());
+    let mut config = Configuration::default();
+    config.discovery = Some(common::config::DiscoveryConfig {
+        dsn: catalog_dsn,
+        heartbeat_interval: Duration::from_secs(5),
+        poll_interval: Duration::from_secs(60),
+        ttl: Duration::from_secs(30),
+    });
+    config.storage.dsn = storage_dsn;
+    config.schema.catalog_uri = format!(
+        "sqlite://{}",
+        temp_dir.path().join("iceberg_catalog.db").display()
+    );
+    config.auth = common::config::AuthConfig {
+        tenants: vec![common::config::TenantConfig {
+            id: "test-tenant".to_string(),
+            slug: "test-tenant".to_string(),
+            name: "Test Tenant".to_string(),
+            default_dataset: Some("test-dataset".to_string()),
+            datasets: vec![],
+            api_keys: vec![common::config::ApiKeyConfig {
+                key: "test-key-123".to_string(),
+                name: Some("test-key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }],
+        admin_api_key: None,
+        internal_service_key: None,
+        ..Default::default()
+    };
+
+    let wal_config = WalConfig {
+        wal_dir: PathBuf::from(temp_dir.path()),
+        max_segment_size: 1024 * 1024,
+        max_buffer_entries: 1,
+        flush_interval_secs: 1,
+        tenant_id: "test-tenant".to_string(),
+        dataset_id: "test-dataset".to_string(),
+        retention_secs: 3600,
+        cleanup_interval_secs: 300,
+        compaction_threshold: 0.5,
+    };
+
+    let acceptor_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Acceptor,
+        "127.0.0.1:50168".to_string(),
+    )
+    .await
+    .unwrap();
+    let flight_transport = Arc::new(InMemoryFlightTransport::new(acceptor_bootstrap));
+
+    let writer_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let writer_addr = writer_listener.local_addr().unwrap();
+    drop(writer_listener);
+    let writer_wal = Arc::new(Wal::new(wal_config.clone()).await.unwrap());
+    let catalog_manager = Arc::new(
+        CatalogManager::new(config.clone())
+            .await
+            .expect("catalog mgr"),
+    );
+    let writer_service = IcebergWriterFlightService::new(
+        catalog_manager.clone(),
+        object_store.clone(),
+        writer_wal.clone(),
+    );
+    let _writer_bg = writer_service.start_background_processing();
+    tokio::spawn(
+        Server::builder()
+            .add_service(FlightServiceServer::new(writer_service))
+            .serve(writer_addr),
+    );
+    let writer_bootstrap =
+        ServiceBootstrap::new(config.clone(), ServiceType::Writer, writer_addr.to_string())
+            .await
+            .unwrap();
+    let _writer_id = writer_bootstrap.service_id();
+
+    {
+        use iceberg_rust::catalog::namespace::Namespace;
+        let namespace =
+            Namespace::try_new(&["test-tenant".to_string(), "test-dataset".to_string()]).unwrap();
+        catalog_manager
+            .catalog()
+            .create_namespace(&namespace, None)
+            .await
+            .expect("pre-create namespace");
+    }
+
+    let querier_service = QuerierFlightService::new_with_catalog_manager(
+        flight_transport.clone(),
+        catalog_manager,
+        common::config::QuerierConfig::default(),
+    )
+    .await
+    .expect("querier service");
+    let querier_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let querier_addr = querier_listener.local_addr().unwrap();
+    drop(querier_listener);
+    tokio::spawn(
+        Server::builder()
+            .add_service(FlightServiceServer::new(querier_service))
+            .serve(querier_addr),
+    );
+    let querier_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Querier,
+        querier_addr.to_string(),
+    )
+    .await
+    .unwrap();
+    let _querier_id = querier_bootstrap.service_id();
+
+    let wal_manager = Arc::new(WalManager::new(
+        wal_config.clone(),
+        wal_config.clone(),
+        wal_config.clone(),
+        wal_config,
+    ));
+    let metrics_handler = MetricsHandler::new(flight_transport.clone(), wal_manager);
+
+    for attempt in 0..50 {
+        let has_query = !flight_transport
+            .discover_services_by_capability(ServiceCapability::QueryExecution)
+            .await
+            .is_empty();
+        let has_storage = !flight_transport
+            .discover_services_by_capability(ServiceCapability::Storage)
+            .await
+            .is_empty();
+        if has_query && has_storage {
+            break;
+        }
+        assert!(attempt < 49, "services failed to register");
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    TestServices {
+        object_store,
+        flight_transport,
+        metrics_handler,
+        config,
+        _temp_dir: temp_dir,
+    }
+}
+
+fn string_value(s: &str) -> AnyValue {
+    AnyValue {
+        value: Some(Value::StringValue(s.to_string())),
+    }
+}
+
+/// One gauge metric `requests` for a service, with a `code` attribute.
+fn gauge_metrics(service: &str, value: f64, code: &str) -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(string_value(service)),
+                    ..Default::default()
+                }],
+                dropped_attributes_count: 0,
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                scope: None,
+                metrics: vec![Metric {
+                    name: "requests".to_string(),
+                    description: String::new(),
+                    unit: "1".to_string(),
+                    data: Some(Data::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            attributes: vec![KeyValue {
+                                key: "code".to_string(),
+                                value: Some(string_value(code)),
+                                ..Default::default()
+                            }],
+                            start_time_unix_nano: BASE_NS,
+                            time_unix_nano: BASE_NS,
+                            value: Some(number_data_point::Value::AsDouble(value)),
+                            exemplars: vec![],
+                            flags: 0,
+                        }],
+                    })),
+                    metadata: vec![],
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
+async fn build_router(services: &TestServices) -> Router {
+    let catalog = Catalog::new(services.config.discovery.as_ref().unwrap().dsn.as_str())
+        .await
+        .unwrap();
+    let service_registry = ServiceRegistry::with_flight_transport(
+        catalog.clone(),
+        (*services.flight_transport).clone(),
+    );
+    let authenticator = Arc::new(common::auth::Authenticator::new(
+        services.config.auth.clone(),
+        Arc::new(catalog.clone()),
+    ));
+
+    #[derive(Clone)]
+    struct State {
+        catalog: Catalog,
+        service_registry: ServiceRegistry,
+        config: Configuration,
+        authenticator: Arc<common::auth::Authenticator>,
+    }
+    impl std::fmt::Debug for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("State")
+        }
+    }
+    impl RouterState for State {
+        fn catalog(&self) -> &Catalog {
+            &self.catalog
+        }
+        fn service_registry(&self) -> &ServiceRegistry {
+            &self.service_registry
+        }
+        fn config(&self) -> &Configuration {
+            &self.config
+        }
+        fn authenticator(&self) -> &Arc<common::auth::Authenticator> {
+            &self.authenticator
+        }
+    }
+
+    let state = State {
+        catalog,
+        service_registry,
+        config: services.config.clone(),
+        authenticator: authenticator.clone(),
+    };
+    Router::new()
+        .nest("/prometheus", promql::router().with_state(state))
+        .layer(middleware::from_fn(move |req, next| {
+            auth_middleware(authenticator.clone(), req, next)
+        }))
+}
+
+async fn get(app: &Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let request = Request::builder()
+        .uri(uri)
+        .header("Authorization", "Bearer test-key-123")
+        .header("X-Tenant-ID", "test-tenant")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    if !status.is_success() {
+        eprintln!(
+            "GET {uri} -> {status}: {}",
+            std::str::from_utf8(&body).unwrap_or("<non-utf8>")
+        );
+    }
+    (
+        status,
+        serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// The window bracketing the ingested metrics.
+fn window() -> String {
+    // Prometheus params are unix seconds; step 1h covers the point.
+    let start = (BASE_NS / 1_000_000_000) as i64 - 60;
+    let end = (BASE_NS / 1_000_000_000) as i64 + 60;
+    format!("start={start}&end={end}&step=1h")
+}
+
+#[tokio::test]
+async fn promql_end_to_end() {
+    let services = setup().await;
+    let ctx = test_tenant_context();
+
+    // Ingest: requests{job=api}=10, requests{job=web}=20.
+    services
+        .metrics_handler
+        .handle_grpc_otlp_metrics(&ctx, gauge_metrics("api", 10.0, "200"))
+        .await
+        .expect("ingest api gauge");
+    services
+        .metrics_handler
+        .handle_grpc_otlp_metrics(&ctx, gauge_metrics("web", 20.0, "500"))
+        .await
+        .expect("ingest web gauge");
+
+    // Wait for persistence.
+    sleep(Duration::from_secs(15)).await;
+    let objects: Vec<_> = {
+        use futures::TryStreamExt;
+        services
+            .object_store
+            .list(None)
+            .try_collect()
+            .await
+            .unwrap()
+    };
+    assert!(
+        objects
+            .iter()
+            .any(|o| o.location.as_ref().contains("metrics")),
+        "expected persisted metrics objects, found: {:?}",
+        objects
+            .iter()
+            .map(|o| o.location.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    let app = build_router(&services).await;
+    let w = window();
+
+    // 1. Range query: matrix with the two series.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query_range?query=requests&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "query_range: {body}");
+    assert_eq!(body["data"]["resultType"], "matrix");
+    let values = matrix_value_sum(&body);
+    assert!(
+        (values - 30.0).abs() < 1e-9,
+        "api+web should total 30: {body}"
+    );
+
+    // 2. Aggregation: sum(requests) = 30.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query_range?query=sum(requests)&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let series = body["data"]["result"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(series.len(), 1, "sum collapses to one series: {body}");
+    assert!((matrix_value_sum(&body) - 30.0).abs() < 1e-9);
+
+    // 3. Instant query evaluated at the data's timestamp returns a vector
+    //    carrying the last sample of each series (10 + 20 = 30).
+    let at = BASE_NS / 1_000_000_000;
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query?query=requests&time={at}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["resultType"], "vector");
+    let vector = body["data"]["result"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(vector.len(), 2, "one instant sample per series: {body}");
+    let vsum: f64 = vector
+        .iter()
+        .filter_map(|s| s["value"][1].as_str().and_then(|v| v.parse::<f64>().ok()))
+        .sum();
+    assert!(
+        (vsum - 30.0).abs() < 1e-9,
+        "instant values total 30: {body}"
+    );
+
+    // A query whose window contains no data returns an empty vector, not 500.
+    let (status, body) = get(&app, "/prometheus/api/v1/query?query=requests&time=100").await;
+    assert_eq!(status, StatusCode::OK, "empty-window instant query: {body}");
+    assert_eq!(body["data"]["resultType"], "vector");
+    assert!(
+        body["data"]["result"]
+            .as_array()
+            .is_none_or(|a| a.is_empty()),
+        "empty window yields no series: {body}"
+    );
+
+    // 4. Labels include __name__, job, and the code attribute.
+    let (status, body) = get(&app, &format!("/prometheus/api/v1/labels?{w}")).await;
+    assert_eq!(status, StatusCode::OK);
+    let labels: Vec<String> = serde_json::from_value(body["data"].clone()).unwrap_or_default();
+    assert!(labels.contains(&"__name__".to_string()), "{labels:?}");
+    assert!(labels.contains(&"job".to_string()), "{labels:?}");
+    assert!(labels.contains(&"code".to_string()), "{labels:?}");
+
+    // 5. __name__ values include the metric.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/label/__name__/values?{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let names: Vec<String> = serde_json::from_value(body["data"].clone()).unwrap_or_default();
+    assert!(names.contains(&"requests".to_string()), "{names:?}");
+
+    // 6. Series matching the selector.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/series?match%5B%5D=requests&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let series = body["data"].as_array().cloned().unwrap_or_default();
+    assert!(
+        series.iter().all(|s| s["__name__"] == "requests"),
+        "series should all be requests: {body}"
+    );
+    assert_eq!(series.len(), 2, "one series per job: {body}");
+}
+
+/// Sum all sample values across all series in a matrix response.
+fn matrix_value_sum(body: &serde_json::Value) -> f64 {
+    body["data"]["result"]
+        .as_array()
+        .map(|series| {
+            series
+                .iter()
+                .flat_map(|s| s["values"].as_array().cloned().unwrap_or_default())
+                .filter_map(|sample| sample[1].as_str().and_then(|v| v.parse::<f64>().ok()))
+                .sum()
+        })
+        .unwrap_or(0.0)
+}


### PR DESCRIPTION
Implements PromQL query support end to end (epic #328), landing the querier
translation/execution, the router HTTP API, and an integration test in one
CI-gated PR. Builds on the `prometheus-api` types crate (#670).

Folds in the stacked work from #672 (router endpoints) and #673 (integration
test) — GitHub auto-merged those into this branch because the intermediate
feature branches were unprotected.

## Querier (#332, #340)
- `query/promql.rs` — `plan_promql` lowers the promql-parser AST to a
  `MetricPlan` (metric name, label matchers, aggregate, grouping, optional
  range function). No SQL strings — produces a DataFusion `Expr`/aggregate
  plan, matching the LogQL/trace query paths.
- `query/metrics.rs` — `MetricsService`: range queries (`date_bin`
  step-bucketed matrix), `sum/avg/min/max/count [by]`, `rate`/`increase`
  (two-stage counter delta), and metadata (`labels`, `label_values`,
  `series`) over `metrics_gauge`/`metrics_sum`. Casts the microsecond storage
  timestamp to nanoseconds before bucketing/filtering.
- Flight tickets: `query_promql`, `query_metric_labels`,
  `query_metric_label_values`, `query_metric_series`.

## Router (#337, #338, #339)
- `/prometheus/api/v1/query` (instant → vector), `query_range` (range →
  matrix), `labels`, `label/{name}/values`, `series`.
- `batches_to_matrix`/`matrix_to_vector` convert Arrow results to Prometheus
  JSON; ns timestamps → unix seconds.
- Returns an empty vector/matrix (not 500) when a window contains no data:
  the querier streams an empty Flight response with no schema frame, which
  `flight_data_to_batches` rejects, so an empty stream is short-circuited.

## Tests (#341)
- Unit: translator (11), metrics service (13), router conversions, ticket
  parsing.
- Integration (`tests-integration/tests/promql_queries.rs`): boots the full
  ingest→store→query stack, ingests gauge metrics, and drives the
  `/prometheus` endpoints — range/instant/`sum`, empty-window, and metadata.

Closes #332, #337, #338, #339, #340, #341.