### PR TITLE
test(promql): end-to-end integration test for /prometheus (#341)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,6 +6165,7 @@ dependencies = [
  "log",
  "logql",
  "loki-api",
+ "prometheus-api",
  "pyroscope-api",
  "serde",
  "serde_json",

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -223,6 +223,15 @@ flowchart LR
 | `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
 | LogQL metric queries (`rate`, `count_over_time`, `sum by (...)`) | Implemented via `query_range` -- `date_bin(step)` bucketed matrix (no binary ops / `topk` / `quantile` yet) |
 
+**Prometheus API Endpoints** (metrics, nested at `/prometheus`; see epic #328):
+
+| Endpoint | Status |
+|----------|--------|
+| `GET\|POST /prometheus/api/v1/query_range` | Implemented -- PromQL over `metrics_gauge`+`metrics_sum`, `date_bin(step)` matrix |
+| `GET\|POST /prometheus/api/v1/query` | Implemented -- instant vector (latest sample per series) |
+| `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Stub -- metadata discovery pending (#339) |
+| PromQL `rate`/`increase`, `histogram_quantile`, binary ops | Not implemented yet (#334/#335) |
+
 **Admin API Endpoints** (requires `admin_api_key`):
 
 | Endpoint | Description |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -229,8 +229,9 @@ flowchart LR
 |----------|--------|
 | `GET\|POST /prometheus/api/v1/query_range` | Implemented -- PromQL over `metrics_gauge`+`metrics_sum`, `date_bin(step)` matrix |
 | `GET\|POST /prometheus/api/v1/query` | Implemented -- instant vector (latest sample per series) |
-| `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Stub -- metadata discovery pending (#339) |
-| PromQL `rate`/`increase`, `histogram_quantile`, binary ops | Not implemented yet (#334/#335) |
+| `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Implemented -- metric label names/values and `{__name__, job}` series via Querier |
+| PromQL `rate`/`increase` | Implemented -- counter delta over `date_bin` buckets |
+| PromQL `histogram_quantile`, binary ops, `topk` | Not implemented yet (#335) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -10,6 +10,7 @@ common.workspace = true
 signaldb-api.workspace = true
 logql.workspace = true
 loki-api.workspace = true
+prometheus-api.workspace = true
 pyroscope-api.workspace = true
 tempo-api.workspace = true
 arrow-flight.workspace = true

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod flight;
 pub mod logql;
+pub mod promql;
 pub mod pyroscope;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/endpoints/promql.rs
+++ b/src/router/src/endpoints/promql.rs
@@ -9,7 +9,7 @@
 //!
 //! Handlers build a `query_promql` Flight ticket, execute it against a
 //! querier, and convert the returned matrix RecordBatches into Prometheus
-//! JSON. Metadata endpoints are minimal stubs for now (#339).
+//! JSON. Metadata endpoints (labels/values/series) query the metrics tables via the querier.
 
 use std::collections::HashMap;
 
@@ -137,32 +137,66 @@ pub async fn query<S: RouterState>(
     }
 }
 
-/// GET /prometheus/api/v1/labels — stub (metadata discovery lands in #339).
+/// GET /prometheus/api/v1/labels — metric label names.
 pub async fn labels<S: RouterState>(
-    State(_state): State<S>,
-    _tenant_ctx: TenantContextExtractor,
-    Query(_params): Query<MetadataParams>,
-) -> axum::Json<LabelsResponse> {
-    axum::Json(LabelsResponse::success(vec![]))
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_metric_labels:{}:{}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "label",
+    ))))
 }
 
-/// GET /prometheus/api/v1/label/{name}/values — stub (#339).
+/// GET /prometheus/api/v1/label/{name}/values — distinct values of a label.
 pub async fn label_values<S: RouterState>(
-    State(_state): State<S>,
-    _tenant_ctx: TenantContextExtractor,
-    Path(_name): Path<String>,
-    Query(_params): Query<MetadataParams>,
-) -> axum::Json<LabelsResponse> {
-    axum::Json(LabelsResponse::success(vec![]))
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Path(name): Path<String>,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+    if name.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let (start, end) = metadata_window(&params);
+    let ticket = format!(
+        "query_metric_label_values:{}:{}:{name}:{start}:{end}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(LabelsResponse::success(string_column(
+        &batches, "value",
+    ))))
 }
 
-/// GET /prometheus/api/v1/series — stub (#339).
+/// GET /prometheus/api/v1/series — series matching a selector.
 pub async fn series<S: RouterState>(
-    State(_state): State<S>,
-    _tenant_ctx: TenantContextExtractor,
-    Query(_params): Query<MetadataParams>,
-) -> axum::Json<SeriesResponse> {
-    axum::Json(SeriesResponse::success(vec![]))
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<MetadataParams>,
+) -> Result<axum::Json<SeriesResponse>, StatusCode> {
+    let selector = params
+        .matcher
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let (start, end) = metadata_window(&params);
+    let payload = serde_json::json!({ "selector": selector, "start": start, "end": end });
+    let ticket = format!(
+        "query_metric_series:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    Ok(axum::Json(SeriesResponse::success(series_from_batches(
+        &batches,
+    ))))
 }
 
 // ---- execution + conversion ----
@@ -349,6 +383,40 @@ fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a StringArray> {
     batch
         .column_by_name(name)
         .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+}
+
+/// Collect the values of a single-string-column result batch.
+fn string_column(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for batch in batches {
+        if let Some(col) = str_col(batch, column) {
+            for i in 0..col.len() {
+                if !col.is_null(i) {
+                    out.push(col.value(i).to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Decode a `series` JSON batch into label maps.
+fn series_from_batches(batches: &[RecordBatch]) -> Vec<HashMap<String, String>> {
+    let mut out = Vec::new();
+    for value in string_column(batches, "series") {
+        if let Ok(series) = serde_json::from_str::<Vec<HashMap<String, String>>>(&value) {
+            out.extend(series);
+        }
+    }
+    out
+}
+
+/// Resolve a metadata endpoint's `[start, end]` window in nanoseconds,
+/// defaulting to the last hour.
+fn metadata_window(params: &MetadataParams) -> (i64, i64) {
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    (start, end)
 }
 
 /// Read a timestamp column as nanoseconds, casting from the storage unit.

--- a/src/router/src/endpoints/promql.rs
+++ b/src/router/src/endpoints/promql.rs
@@ -1,0 +1,494 @@
+//! # Prometheus-Compatible HTTP API (PromQL)
+//!
+//! Query endpoints for the metrics signal in the format Grafana's
+//! Prometheus datasource expects, nested under `/prometheus`:
+//!
+//! - `GET|POST /api/v1/query_range` — range query → matrix
+//! - `GET|POST /api/v1/query` — instant query → vector
+//! - `GET /api/v1/labels`, `/api/v1/label/{name}/values`, `/api/v1/series`
+//!
+//! Handlers build a `query_promql` Flight ticket, execute it against a
+//! querier, and convert the returned matrix RecordBatches into Prometheus
+//! JSON. Metadata endpoints are minimal stubs for now (#339).
+
+use std::collections::HashMap;
+
+use crate::RouterState;
+use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use axum::{
+    Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use common::auth::TenantContextExtractor;
+use common::flight::transport::ServiceCapability;
+use datafusion::arrow::array::{
+    Array, Float64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+};
+use futures::StreamExt;
+use prometheus_api::{
+    InstantVector, LabelsResponse, QueryResponse, QueryResult, RangeVector, Sample, SeriesResponse,
+};
+use serde::Deserialize;
+
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new()
+        .route("/api/v1/query", get(query::<S>).post(query::<S>))
+        .route(
+            "/api/v1/query_range",
+            get(query_range::<S>).post(query_range::<S>),
+        )
+        .route("/api/v1/labels", get(labels::<S>))
+        .route("/api/v1/label/{name}/values", get(label_values::<S>))
+        .route("/api/v1/series", get(series::<S>))
+}
+
+/// One hour in nanoseconds, the default range-query lookback.
+const HOUR_NS: i64 = 3_600_000_000_000;
+
+/// Parameters for `/api/v1/query` (instant queries).
+#[derive(Debug, Deserialize)]
+pub struct InstantParams {
+    pub query: Option<String>,
+    /// Evaluation timestamp (unix seconds or RFC3339).
+    pub time: Option<String>,
+}
+
+/// Parameters for `/api/v1/query_range`.
+#[derive(Debug, Deserialize)]
+pub struct RangeParams {
+    pub query: Option<String>,
+    pub start: Option<String>,
+    pub end: Option<String>,
+    /// Resolution step (Go duration or seconds).
+    pub step: Option<String>,
+}
+
+/// Parameters for the metadata endpoints.
+#[derive(Debug, Default, Deserialize)]
+pub struct MetadataParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    #[serde(rename = "match[]")]
+    pub matcher: Option<String>,
+}
+
+/// GET|POST /prometheus/api/v1/query_range.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(tenant_id = %tenant_ctx.0.tenant_id, dataset_id = %tenant_ctx.0.dataset_id)
+)]
+pub async fn query_range<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<RangeParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let Some(promql) = non_empty(&params.query) else {
+        return Ok(axum::Json(QueryResponse::error(
+            "bad_data",
+            "missing or empty 'query'",
+        )));
+    };
+    let end = parse_timestamp_ns(params.end.as_deref()).unwrap_or_else(now_ns);
+    let start = parse_timestamp_ns(params.start.as_deref()).unwrap_or(end - HOUR_NS);
+    let step = parse_step_ns(params.step.as_deref()).unwrap_or_else(|| default_step_ns(start, end));
+
+    match run_promql(&state, &tenant_ctx, &promql, start, end, step).await {
+        Ok(batches) => Ok(axum::Json(QueryResponse::success(QueryResult::Matrix(
+            batches_to_matrix(&batches),
+        )))),
+        Err(status) => Err(status),
+    }
+}
+
+/// GET|POST /prometheus/api/v1/query — instant query.
+///
+/// Evaluated as a one-bucket range at `time`, returning the latest sample
+/// per series as a vector.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(tenant_id = %tenant_ctx.0.tenant_id, dataset_id = %tenant_ctx.0.dataset_id)
+)]
+pub async fn query<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<InstantParams>,
+) -> Result<axum::Json<QueryResponse>, StatusCode> {
+    let Some(promql) = non_empty(&params.query) else {
+        return Ok(axum::Json(QueryResponse::error(
+            "bad_data",
+            "missing or empty 'query'",
+        )));
+    };
+    let at = parse_timestamp_ns(params.time.as_deref()).unwrap_or_else(now_ns);
+    let start = at - HOUR_NS;
+    // One bucket spanning the lookback so each series yields one sample.
+    let step = HOUR_NS;
+
+    match run_promql(&state, &tenant_ctx, &promql, start, at, step).await {
+        Ok(batches) => {
+            let vector = matrix_to_vector(batches_to_matrix(&batches));
+            Ok(axum::Json(QueryResponse::success(QueryResult::Vector(
+                vector,
+            ))))
+        }
+        Err(status) => Err(status),
+    }
+}
+
+/// GET /prometheus/api/v1/labels — stub (metadata discovery lands in #339).
+pub async fn labels<S: RouterState>(
+    State(_state): State<S>,
+    _tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> axum::Json<LabelsResponse> {
+    axum::Json(LabelsResponse::success(vec![]))
+}
+
+/// GET /prometheus/api/v1/label/{name}/values — stub (#339).
+pub async fn label_values<S: RouterState>(
+    State(_state): State<S>,
+    _tenant_ctx: TenantContextExtractor,
+    Path(_name): Path<String>,
+    Query(_params): Query<MetadataParams>,
+) -> axum::Json<LabelsResponse> {
+    axum::Json(LabelsResponse::success(vec![]))
+}
+
+/// GET /prometheus/api/v1/series — stub (#339).
+pub async fn series<S: RouterState>(
+    State(_state): State<S>,
+    _tenant_ctx: TenantContextExtractor,
+    Query(_params): Query<MetadataParams>,
+) -> axum::Json<SeriesResponse> {
+    axum::Json(SeriesResponse::success(vec![]))
+}
+
+// ---- execution + conversion ----
+
+/// Build and execute a `query_promql` ticket.
+async fn run_promql<S: RouterState>(
+    state: &S,
+    tenant_ctx: &TenantContextExtractor,
+    promql: &str,
+    start: i64,
+    end: i64,
+    step: i64,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let payload = serde_json::json!({
+        "query": promql,
+        "start": start,
+        "end": end,
+        "step": step,
+    });
+    let ticket = format!(
+        "query_promql:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    execute_ticket(state, ticket).await
+}
+
+/// Send a Flight ticket to a querier and collect the result batches.
+async fn execute_ticket<S: RouterState>(
+    state: &S,
+    ticket_content: String,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    let mut client = state
+        .service_registry()
+        .get_flight_client_for_capability(ServiceCapability::QueryExecution)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to get Flight client for PromQL query");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    let ticket = Ticket::new(ticket_content);
+    let mut flight_request = tonic::Request::new(ticket);
+    common::flight::trace_context::inject_context_into_request(&mut flight_request);
+    if let Some(key) = &state.config().auth.internal_service_key {
+        common::flight::auth::attach_internal_auth(&mut flight_request, key);
+    }
+
+    let mut stream = client
+        .do_get(flight_request)
+        .await
+        .map_err(|e| flight_status_to_http(&e))?
+        .into_inner();
+
+    let mut data = Vec::new();
+    while let Some(flight_data) = stream.next().await {
+        data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
+    }
+
+    flight_data_to_batches(&data).map_err(|e| {
+        tracing::error!(error = %e, "Failed to decode PromQL Flight data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+fn flight_status_to_http(status: &tonic::Status) -> StatusCode {
+    match status.code() {
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+        _ => {
+            tracing::error!(error = %status, "PromQL Flight query failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// Group matrix rows (`bucket`, `metric_name`, label columns, `value`)
+/// into Prometheus range vectors. `bucket` is nanoseconds; Prometheus
+/// samples use unix seconds.
+fn batches_to_matrix(batches: &[RecordBatch]) -> Vec<RangeVector> {
+    let mut order: Vec<String> = Vec::new();
+    let mut series: HashMap<String, RangeVector> = HashMap::new();
+
+    for batch in batches {
+        let Some(buckets) = timestamps_ns(batch, "bucket") else {
+            continue;
+        };
+        let value = batch
+            .column_by_name("value")
+            .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+        let schema = batch.schema();
+        let label_cols: Vec<(String, &StringArray)> = schema
+            .fields()
+            .iter()
+            .filter_map(|f| {
+                let name = f.name();
+                if name == "bucket" || name == "value" {
+                    return None;
+                }
+                str_col(batch, name).map(|c| (name.clone(), c))
+            })
+            .collect();
+
+        for i in 0..batch.num_rows() {
+            let mut metric: HashMap<String, String> = HashMap::new();
+            for (name, col) in &label_cols {
+                if col.is_null(i) || col.value(i).is_empty() {
+                    continue;
+                }
+                // `metric_name` is Prometheus's `__name__`.
+                let key = if name == "metric_name" {
+                    "__name__"
+                } else {
+                    name.as_str()
+                };
+                metric.insert(key.to_string(), col.value(i).to_string());
+            }
+            let key = label_key(&metric);
+            let seconds = if buckets.is_null(i) {
+                0.0
+            } else {
+                buckets.value(i) as f64 / 1_000_000_000.0
+            };
+            let v = value
+                .map(|c| if c.is_null(i) { f64::NAN } else { c.value(i) })
+                .unwrap_or(f64::NAN);
+            series
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    order.push(key.clone());
+                    RangeVector {
+                        metric,
+                        values: Vec::new(),
+                    }
+                })
+                .values
+                .push(Sample::new(seconds, format_value(v)));
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| series.remove(&k))
+        .collect()
+}
+
+/// Reduce a matrix to an instant vector: each series' last sample.
+fn matrix_to_vector(matrix: Vec<RangeVector>) -> Vec<InstantVector> {
+    matrix
+        .into_iter()
+        .filter_map(|series| {
+            series.values.into_iter().last().map(|value| InstantVector {
+                metric: series.metric,
+                value,
+            })
+        })
+        .collect()
+}
+
+fn format_value(v: f64) -> String {
+    if v.is_nan() {
+        "NaN".to_string()
+    } else if v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+fn label_key(labels: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = labels.iter().collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+}
+
+/// Read a timestamp column as nanoseconds, casting from the storage unit.
+fn timestamps_ns(batch: &RecordBatch, name: &str) -> Option<TimestampNanosecondArray> {
+    use datafusion::arrow::compute::cast;
+    use datafusion::arrow::datatypes::{DataType, TimeUnit};
+    let column = batch.column_by_name(name)?;
+    let nanos = cast(column, &DataType::Timestamp(TimeUnit::Nanosecond, None)).ok()?;
+    nanos
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()
+        .cloned()
+}
+
+fn non_empty(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn now_ns() -> i64 {
+    chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() * 1_000_000)
+}
+
+/// Parse a Prometheus timestamp (unix seconds float, or RFC3339) → ns.
+fn parse_timestamp_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(seconds) = value.parse::<f64>() {
+        return Some((seconds * 1_000_000_000.0) as i64);
+    }
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .and_then(|dt| dt.timestamp_nanos_opt())
+}
+
+/// Parse `step` (Go duration or seconds) → nanoseconds.
+fn parse_step_ns(value: Option<&str>) -> Option<i64> {
+    let value = value.map(str::trim).filter(|s| !s.is_empty())?;
+    if let Ok(seconds) = value.parse::<f64>() {
+        return Some((seconds * 1_000_000_000.0) as i64);
+    }
+    // Reuse the LogQL lexer for durations like `30s`, `5m`.
+    let tokens = logql::tokenize(value).ok()?;
+    match tokens.first().map(|t| &t.token) {
+        Some(logql::Token::Duration(d)) => Some(d.as_nanos() as i64),
+        _ => None,
+    }
+}
+
+fn default_step_ns(start: i64, end: i64) -> i64 {
+    let span = (end - start).max(1);
+    (span / 250).max(1_000_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use std::sync::Arc;
+
+    fn matrix_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, true),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    1_000_000_000,
+                    2_000_000_000,
+                    1_000_000_000,
+                ])),
+                Arc::new(StringArray::from(vec!["reqs", "reqs", "reqs"])),
+                Arc::new(StringArray::from(vec!["api", "api", "web"])),
+                Arc::new(Float64Array::from(vec![2.0, 3.0, 5.5])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn matrix_groups_rows_and_maps_name() {
+        let matrix = batches_to_matrix(&[matrix_batch()]);
+        assert_eq!(matrix.len(), 2);
+        let api = matrix
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"api".to_string()))
+            .unwrap();
+        assert_eq!(api.metric.get("__name__"), Some(&"reqs".to_string()));
+        assert_eq!(
+            api.values,
+            vec![Sample::new(1.0, "2"), Sample::new(2.0, "3")]
+        );
+        let web = matrix
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"web".to_string()))
+            .unwrap();
+        assert_eq!(web.values, vec![Sample::new(1.0, "5.5")]);
+    }
+
+    #[test]
+    fn instant_vector_takes_last_sample() {
+        let vector = matrix_to_vector(batches_to_matrix(&[matrix_batch()]));
+        let api = vector
+            .iter()
+            .find(|s| s.metric.get("service_name") == Some(&"api".to_string()))
+            .unwrap();
+        assert_eq!(api.value, Sample::new(2.0, "3"));
+    }
+
+    #[test]
+    fn value_formatting() {
+        assert_eq!(format_value(3.0), "3");
+        assert_eq!(format_value(2.5), "2.5");
+        assert_eq!(format_value(f64::NAN), "NaN");
+    }
+
+    #[test]
+    fn step_and_timestamp_parsing() {
+        assert_eq!(parse_step_ns(Some("30")), Some(30_000_000_000));
+        assert_eq!(parse_step_ns(Some("5m")), Some(300_000_000_000));
+        assert_eq!(
+            parse_timestamp_ns(Some("1700000000")),
+            Some(1_700_000_000_000_000_000)
+        );
+        assert_eq!(
+            parse_timestamp_ns(Some("2023-11-14T22:13:20Z")),
+            Some(1_700_000_000_000_000_000)
+        );
+        assert_eq!(parse_timestamp_ns(None), None);
+    }
+}

--- a/src/router/src/endpoints/promql.rs
+++ b/src/router/src/endpoints/promql.rs
@@ -255,6 +255,13 @@ async fn execute_ticket<S: RouterState>(
         data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
     }
 
+    // An empty result is a well-formed empty stream (no schema frame). Return
+    // no batches rather than letting `flight_data_to_batches` error on it — a
+    // query whose window contains no data must yield an empty vector/matrix.
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+
     flight_data_to_batches(&data).map_err(|e| {
         tracing::error!(error = %e, "Failed to decode PromQL Flight data");
         StatusCode::INTERNAL_SERVER_ERROR

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -215,6 +215,13 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Prometheus-compatible metrics query API (PromQL)
+        .nest(
+            "/prometheus",
+            endpoints::promql::router()
+                .layer(query_rate_layer.clone())
+                .layer(auth_layer.clone()),
+        )
         // Trace-to-profile correlation
         .nest(
             "/api/profiles",

--- a/tests-integration/tests/promql_queries.rs
+++ b/tests-integration/tests/promql_queries.rs
@@ -1,0 +1,504 @@
+//! End-to-end integration tests for the PromQL query interface.
+//!
+//! Boots the full ingest→store→query stack (acceptor metrics handler →
+//! WAL → writer → Iceberg → querier → router), ingests gauge metrics,
+//! waits for persistence, then drives the `/prometheus` HTTP endpoints:
+//! range/instant queries, an aggregation, and label/series discovery.
+
+use acceptor::handler::WalManager;
+use acceptor::handler::otlp_metrics_handler::MetricsHandler;
+use arrow_flight::flight_service_server::FlightServiceServer;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    middleware,
+};
+use common::CatalogManager;
+use common::auth::{TenantContext, TenantSource, auth_middleware};
+use common::catalog::Catalog;
+use common::config::Configuration;
+use common::flight::transport::{InMemoryFlightTransport, ServiceCapability};
+use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+use common::wal::{Wal, WalConfig};
+use opentelemetry_proto::tonic::{
+    collector::metrics::v1::ExportMetricsServiceRequest,
+    common::v1::{AnyValue, KeyValue, any_value::Value},
+    metrics::v1::{
+        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data,
+        number_data_point,
+    },
+    resource::v1::Resource,
+};
+use querier::flight::QuerierFlightService;
+use router::{RouterState, discovery::ServiceRegistry, endpoints::promql};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use tonic::transport::Server;
+use tower::ServiceExt;
+use writer::IcebergWriterFlightService;
+
+const BASE_NS: u64 = 1_700_000_000_000_000_000;
+
+struct TestServices {
+    object_store: Arc<dyn object_store::ObjectStore>,
+    flight_transport: Arc<InMemoryFlightTransport>,
+    metrics_handler: MetricsHandler,
+    config: Configuration,
+    _temp_dir: TempDir,
+}
+
+fn test_tenant_context() -> TenantContext {
+    TenantContext {
+        tenant_id: "test-tenant".to_string(),
+        dataset_id: "test-dataset".to_string(),
+        tenant_slug: "test-tenant".to_string(),
+        dataset_slug: "test-dataset".to_string(),
+        api_key_name: Some("test-key".to_string()),
+        source: TenantSource::Config,
+    }
+}
+
+async fn setup() -> TestServices {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_path = temp_dir.path().join("storage");
+    std::fs::create_dir_all(&storage_path).unwrap();
+    let storage_dsn = format!("file://{}", storage_path.display());
+    let object_store =
+        common::storage::create_object_store_from_dsn(&storage_dsn).expect("object store");
+
+    let catalog_dsn = format!("sqlite://{}", temp_dir.path().join("catalog.db").display());
+    let mut config = Configuration::default();
+    config.discovery = Some(common::config::DiscoveryConfig {
+        dsn: catalog_dsn,
+        heartbeat_interval: Duration::from_secs(5),
+        poll_interval: Duration::from_secs(60),
+        ttl: Duration::from_secs(30),
+    });
+    config.storage.dsn = storage_dsn;
+    config.schema.catalog_uri = format!(
+        "sqlite://{}",
+        temp_dir.path().join("iceberg_catalog.db").display()
+    );
+    config.auth = common::config::AuthConfig {
+        tenants: vec![common::config::TenantConfig {
+            id: "test-tenant".to_string(),
+            slug: "test-tenant".to_string(),
+            name: "Test Tenant".to_string(),
+            default_dataset: Some("test-dataset".to_string()),
+            datasets: vec![],
+            api_keys: vec![common::config::ApiKeyConfig {
+                key: "test-key-123".to_string(),
+                name: Some("test-key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }],
+        admin_api_key: None,
+        internal_service_key: None,
+        ..Default::default()
+    };
+
+    let wal_config = WalConfig {
+        wal_dir: PathBuf::from(temp_dir.path()),
+        max_segment_size: 1024 * 1024,
+        max_buffer_entries: 1,
+        flush_interval_secs: 1,
+        tenant_id: "test-tenant".to_string(),
+        dataset_id: "test-dataset".to_string(),
+        retention_secs: 3600,
+        cleanup_interval_secs: 300,
+        compaction_threshold: 0.5,
+    };
+
+    let acceptor_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Acceptor,
+        "127.0.0.1:50168".to_string(),
+    )
+    .await
+    .unwrap();
+    let flight_transport = Arc::new(InMemoryFlightTransport::new(acceptor_bootstrap));
+
+    let writer_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let writer_addr = writer_listener.local_addr().unwrap();
+    drop(writer_listener);
+    let writer_wal = Arc::new(Wal::new(wal_config.clone()).await.unwrap());
+    let catalog_manager = Arc::new(
+        CatalogManager::new(config.clone())
+            .await
+            .expect("catalog mgr"),
+    );
+    let writer_service = IcebergWriterFlightService::new(
+        catalog_manager.clone(),
+        object_store.clone(),
+        writer_wal.clone(),
+    );
+    let _writer_bg = writer_service.start_background_processing();
+    tokio::spawn(
+        Server::builder()
+            .add_service(FlightServiceServer::new(writer_service))
+            .serve(writer_addr),
+    );
+    let writer_bootstrap =
+        ServiceBootstrap::new(config.clone(), ServiceType::Writer, writer_addr.to_string())
+            .await
+            .unwrap();
+    let _writer_id = writer_bootstrap.service_id();
+
+    {
+        use iceberg_rust::catalog::namespace::Namespace;
+        let namespace =
+            Namespace::try_new(&["test-tenant".to_string(), "test-dataset".to_string()]).unwrap();
+        catalog_manager
+            .catalog()
+            .create_namespace(&namespace, None)
+            .await
+            .expect("pre-create namespace");
+    }
+
+    let querier_service = QuerierFlightService::new_with_catalog_manager(
+        flight_transport.clone(),
+        catalog_manager,
+        common::config::QuerierConfig::default(),
+    )
+    .await
+    .expect("querier service");
+    let querier_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let querier_addr = querier_listener.local_addr().unwrap();
+    drop(querier_listener);
+    tokio::spawn(
+        Server::builder()
+            .add_service(FlightServiceServer::new(querier_service))
+            .serve(querier_addr),
+    );
+    let querier_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Querier,
+        querier_addr.to_string(),
+    )
+    .await
+    .unwrap();
+    let _querier_id = querier_bootstrap.service_id();
+
+    let wal_manager = Arc::new(WalManager::new(
+        wal_config.clone(),
+        wal_config.clone(),
+        wal_config.clone(),
+        wal_config,
+    ));
+    let metrics_handler = MetricsHandler::new(flight_transport.clone(), wal_manager);
+
+    for attempt in 0..50 {
+        let has_query = !flight_transport
+            .discover_services_by_capability(ServiceCapability::QueryExecution)
+            .await
+            .is_empty();
+        let has_storage = !flight_transport
+            .discover_services_by_capability(ServiceCapability::Storage)
+            .await
+            .is_empty();
+        if has_query && has_storage {
+            break;
+        }
+        assert!(attempt < 49, "services failed to register");
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    TestServices {
+        object_store,
+        flight_transport,
+        metrics_handler,
+        config,
+        _temp_dir: temp_dir,
+    }
+}
+
+fn string_value(s: &str) -> AnyValue {
+    AnyValue {
+        value: Some(Value::StringValue(s.to_string())),
+    }
+}
+
+/// One gauge metric `requests` for a service, with a `code` attribute.
+fn gauge_metrics(service: &str, value: f64, code: &str) -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(string_value(service)),
+                    ..Default::default()
+                }],
+                dropped_attributes_count: 0,
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                scope: None,
+                metrics: vec![Metric {
+                    name: "requests".to_string(),
+                    description: String::new(),
+                    unit: "1".to_string(),
+                    data: Some(Data::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            attributes: vec![KeyValue {
+                                key: "code".to_string(),
+                                value: Some(string_value(code)),
+                                ..Default::default()
+                            }],
+                            start_time_unix_nano: BASE_NS,
+                            time_unix_nano: BASE_NS,
+                            value: Some(number_data_point::Value::AsDouble(value)),
+                            exemplars: vec![],
+                            flags: 0,
+                        }],
+                    })),
+                    metadata: vec![],
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
+async fn build_router(services: &TestServices) -> Router {
+    let catalog = Catalog::new(services.config.discovery.as_ref().unwrap().dsn.as_str())
+        .await
+        .unwrap();
+    let service_registry = ServiceRegistry::with_flight_transport(
+        catalog.clone(),
+        (*services.flight_transport).clone(),
+    );
+    let authenticator = Arc::new(common::auth::Authenticator::new(
+        services.config.auth.clone(),
+        Arc::new(catalog.clone()),
+    ));
+
+    #[derive(Clone)]
+    struct State {
+        catalog: Catalog,
+        service_registry: ServiceRegistry,
+        config: Configuration,
+        authenticator: Arc<common::auth::Authenticator>,
+    }
+    impl std::fmt::Debug for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("State")
+        }
+    }
+    impl RouterState for State {
+        fn catalog(&self) -> &Catalog {
+            &self.catalog
+        }
+        fn service_registry(&self) -> &ServiceRegistry {
+            &self.service_registry
+        }
+        fn config(&self) -> &Configuration {
+            &self.config
+        }
+        fn authenticator(&self) -> &Arc<common::auth::Authenticator> {
+            &self.authenticator
+        }
+    }
+
+    let state = State {
+        catalog,
+        service_registry,
+        config: services.config.clone(),
+        authenticator: authenticator.clone(),
+    };
+    Router::new()
+        .nest("/prometheus", promql::router().with_state(state))
+        .layer(middleware::from_fn(move |req, next| {
+            auth_middleware(authenticator.clone(), req, next)
+        }))
+}
+
+async fn get(app: &Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let request = Request::builder()
+        .uri(uri)
+        .header("Authorization", "Bearer test-key-123")
+        .header("X-Tenant-ID", "test-tenant")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    if !status.is_success() {
+        eprintln!(
+            "GET {uri} -> {status}: {}",
+            std::str::from_utf8(&body).unwrap_or("<non-utf8>")
+        );
+    }
+    (
+        status,
+        serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// The window bracketing the ingested metrics.
+fn window() -> String {
+    // Prometheus params are unix seconds; step 1h covers the point.
+    let start = (BASE_NS / 1_000_000_000) as i64 - 60;
+    let end = (BASE_NS / 1_000_000_000) as i64 + 60;
+    format!("start={start}&end={end}&step=1h")
+}
+
+#[tokio::test]
+async fn promql_end_to_end() {
+    let services = setup().await;
+    let ctx = test_tenant_context();
+
+    // Ingest: requests{job=api}=10, requests{job=web}=20.
+    services
+        .metrics_handler
+        .handle_grpc_otlp_metrics(&ctx, gauge_metrics("api", 10.0, "200"))
+        .await
+        .expect("ingest api gauge");
+    services
+        .metrics_handler
+        .handle_grpc_otlp_metrics(&ctx, gauge_metrics("web", 20.0, "500"))
+        .await
+        .expect("ingest web gauge");
+
+    // Wait for persistence.
+    sleep(Duration::from_secs(15)).await;
+    let objects: Vec<_> = {
+        use futures::TryStreamExt;
+        services
+            .object_store
+            .list(None)
+            .try_collect()
+            .await
+            .unwrap()
+    };
+    assert!(
+        objects
+            .iter()
+            .any(|o| o.location.as_ref().contains("metrics")),
+        "expected persisted metrics objects, found: {:?}",
+        objects
+            .iter()
+            .map(|o| o.location.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    let app = build_router(&services).await;
+    let w = window();
+
+    // 1. Range query: matrix with the two series.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query_range?query=requests&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "query_range: {body}");
+    assert_eq!(body["data"]["resultType"], "matrix");
+    let values = matrix_value_sum(&body);
+    assert!(
+        (values - 30.0).abs() < 1e-9,
+        "api+web should total 30: {body}"
+    );
+
+    // 2. Aggregation: sum(requests) = 30.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query_range?query=sum(requests)&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let series = body["data"]["result"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(series.len(), 1, "sum collapses to one series: {body}");
+    assert!((matrix_value_sum(&body) - 30.0).abs() < 1e-9);
+
+    // 3. Instant query evaluated at the data's timestamp returns a vector
+    //    carrying the last sample of each series (10 + 20 = 30).
+    let at = BASE_NS / 1_000_000_000;
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query?query=requests&time={at}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["resultType"], "vector");
+    let vector = body["data"]["result"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(vector.len(), 2, "one instant sample per series: {body}");
+    let vsum: f64 = vector
+        .iter()
+        .filter_map(|s| s["value"][1].as_str().and_then(|v| v.parse::<f64>().ok()))
+        .sum();
+    assert!(
+        (vsum - 30.0).abs() < 1e-9,
+        "instant values total 30: {body}"
+    );
+
+    // A query whose window contains no data returns an empty vector, not 500.
+    let (status, body) = get(&app, "/prometheus/api/v1/query?query=requests&time=100").await;
+    assert_eq!(status, StatusCode::OK, "empty-window instant query: {body}");
+    assert_eq!(body["data"]["resultType"], "vector");
+    assert!(
+        body["data"]["result"]
+            .as_array()
+            .is_none_or(|a| a.is_empty()),
+        "empty window yields no series: {body}"
+    );
+
+    // 4. Labels include __name__, job, and the code attribute.
+    let (status, body) = get(&app, &format!("/prometheus/api/v1/labels?{w}")).await;
+    assert_eq!(status, StatusCode::OK);
+    let labels: Vec<String> = serde_json::from_value(body["data"].clone()).unwrap_or_default();
+    assert!(labels.contains(&"__name__".to_string()), "{labels:?}");
+    assert!(labels.contains(&"job".to_string()), "{labels:?}");
+    assert!(labels.contains(&"code".to_string()), "{labels:?}");
+
+    // 5. __name__ values include the metric.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/label/__name__/values?{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let names: Vec<String> = serde_json::from_value(body["data"].clone()).unwrap_or_default();
+    assert!(names.contains(&"requests".to_string()), "{names:?}");
+
+    // 6. Series matching the selector.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/series?match%5B%5D=requests&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let series = body["data"].as_array().cloned().unwrap_or_default();
+    assert!(
+        series.iter().all(|s| s["__name__"] == "requests"),
+        "series should all be requests: {body}"
+    );
+    assert_eq!(series.len(), 2, "one series per job: {body}");
+}
+
+/// Sum all sample values across all series in a matrix response.
+fn matrix_value_sum(body: &serde_json::Value) -> f64 {
+    body["data"]["result"]
+        .as_array()
+        .map(|series| {
+            series
+                .iter()
+                .flat_map(|s| s["values"].as_array().cloned().unwrap_or_default())
+                .filter_map(|sample| sample[1].as_str().and_then(|v| v.parse::<f64>().ok()))
+                .sum()
+        })
+        .unwrap_or(0.0)
+}


### PR DESCRIPTION
Part 3 of the PromQL query stack (epic #328). Stacked on the router PR.

Boots the full ingest→store→query stack (OTLP metrics handler → WAL → writer →
Iceberg → querier → router), ingests gauge metrics, waits for persistence, then
drives the `/prometheus` endpoints end to end:

- range query (matrix) and `sum(...)` aggregation
- instant query (vector) at a fixed eval time and over an empty window
- `labels`, `label/{name}/values`, and `series` metadata

Mirrors the LogQL integration test. Closes #341.