### PR TITLE
feat(querier): PromQL histogram_quantile (#335)

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -231,7 +231,8 @@ flowchart LR
 | `GET\|POST /prometheus/api/v1/query` | Implemented -- instant vector (latest sample per series) |
 | `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Implemented -- metric label names/values and `{__name__, job}` series via Querier |
 | PromQL `rate`/`increase` | Implemented -- counter delta over `date_bin` buckets |
-| PromQL `histogram_quantile`, binary ops, `topk` | Not implemented yet (#335) |
+| PromQL `histogram_quantile(phi, metric)` | Implemented -- interpolated per series from `metrics_histogram` OTLP buckets |
+| PromQL `histogram_quantile` over `rate()`, binary ops, `topk` | Not implemented yet (#335) |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 

--- a/docs/users/querying-promql.md
+++ b/docs/users/querying-promql.md
@@ -46,9 +46,31 @@ curl -sG http://localhost:3000/prometheus/api/v1/query_range \
 
 Supported so far: instant/range selectors with label matchers
 (`=`, `!=`, `=~`, `!~`); the aggregations `sum`, `avg`, `min`, `max`, `count`,
-optionally with `by (label)`; and the range functions `rate` and `increase`.
-`histogram_quantile`, binary operators, and `topk` are not implemented yet
-(#335).
+optionally with `by (label)`; the range functions `rate` and `increase`; and
+`histogram_quantile(phi, metric)` (see below). `histogram_quantile` over an
+inner `rate()`, binary operators, and `topk` are not implemented yet (#335).
+
+## Quantiles from histograms
+
+`histogram_quantile(phi, metric)` estimates the `phi`-quantile of a histogram
+metric — e.g. p95 latency:
+
+```bash
+curl -sG http://localhost:3000/prometheus/api/v1/query_range \
+  -H "Authorization: Bearer $SIGNALDB_API_KEY" \
+  -H "X-Tenant-ID: $SIGNALDB_TENANT" \
+  --data-urlencode 'query=histogram_quantile(0.95, http_request_duration_seconds)' \
+  --data-urlencode "start=$(date -d '-1 hour' +%s)" \
+  --data-urlencode "end=$(date +%s)" \
+  --data-urlencode 'step=60'
+```
+
+Unlike Prometheus text-format histograms (a fan of `_bucket` series keyed by
+`le`), SignalDB stores each OTLP histogram whole. So the argument is the
+**histogram metric name itself**, not a `sum by (le) (rate(..._bucket[5m]))`
+expression. The quantile is interpolated per series from the metric's stored
+buckets, assuming a uniform spread within the containing bucket — the same
+estimate Prometheus's `histogram_quantile` produces.
 
 ## Instant query (vector)
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -14,8 +14,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, IntervalMonthDayNano, TimeUnit};
+use datafusion::arrow::array::{
+    Array, ArrayRef, Float64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+};
+use datafusion::arrow::datatypes::{DataType, Field, IntervalMonthDayNano, Schema, TimeUnit};
 use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
@@ -95,6 +97,15 @@ impl MetricsService {
             ));
         }
         let plan = plan_promql(query)?;
+
+        // histogram_quantile targets the histogram table with a distinct
+        // (row-wise, interpolated) execution path.
+        if let Some(phi) = plan.quantile {
+            return self
+                .histogram_query(&plan, phi, start, end, step, tenant_slug, dataset_slug)
+                .await;
+        }
+
         let group_cols = self.group_columns(&plan)?;
 
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
@@ -193,6 +204,119 @@ impl MetricsService {
         proj.extend(group_cols.iter().map(|c| col(*c)));
         proj.push(cast_value_f64(col("value")).alias("value"));
         df.select(proj).map_err(QuerierError::QueryFailed)
+    }
+
+    /// `histogram_quantile(phi, metric)`: interpolate the phi-quantile per
+    /// (step bucket, series) from stored OTLP histogram buckets.
+    ///
+    /// SignalDB stores whole histograms per row — `bucket_counts` and
+    /// `explicit_bounds` as JSON arrays — rather than Prometheus `_bucket`
+    /// series keyed by `le`. Data points that fall in the same step bucket
+    /// are merged by summing their bucket counts element-wise (exact for a
+    /// single point per bucket and for delta temporality), then the quantile
+    /// is interpolated. Output matches the matrix shape: `bucket`,
+    /// `metric_name`, `service_name`, `value`.
+    #[allow(clippy::too_many_arguments)]
+    async fn histogram_query(
+        &self,
+        plan: &MetricPlan,
+        phi: f64,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let table_ref = build_table_reference(tenant_slug, dataset_slug, "metrics_histogram")
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        // No histogram table yet → empty result, not an error.
+        let Ok(df) = self.session_context.table(table_ref).await else {
+            return Ok(vec![]);
+        };
+        let df = apply_filters(df, plan, start, end)?;
+        let batches = df
+            .select(vec![
+                bucket_expr(step),
+                col("metric_name"),
+                col("service_name"),
+                col("bucket_counts"),
+                col("explicit_bounds"),
+            ])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Merge histogram data points per (bucket, metric_name, service_name).
+        // BTreeMap keeps the output sorted by bucket, then series.
+        let mut groups: BTreeMap<(i64, String, String), HistogramAcc> = BTreeMap::new();
+        for batch in &batches {
+            let bucket = batch
+                .column_by_name("bucket")
+                .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+                .ok_or_else(|| {
+                    QuerierError::InvalidInput("bucket column is not a timestamp".to_string())
+                })?;
+            let name = string_column(batch, "metric_name")?;
+            let service = string_column(batch, "service_name")?;
+            let counts = string_column(batch, "bucket_counts")?;
+            let bounds = string_column(batch, "explicit_bounds")?;
+            for i in 0..batch.num_rows() {
+                if bucket.is_null(i) || counts.is_null(i) || bounds.is_null(i) {
+                    continue;
+                }
+                let (Some(row_counts), Some(row_bounds)) = (
+                    parse_f64_array(counts.value(i)),
+                    parse_f64_array(bounds.value(i)),
+                ) else {
+                    continue;
+                };
+                // OTLP invariant: one more bucket count than bound.
+                if row_counts.len() != row_bounds.len() + 1 || row_bounds.is_empty() {
+                    continue;
+                }
+                let key = (
+                    bucket.value(i),
+                    name.value(i).to_string(),
+                    service.value(i).to_string(),
+                );
+                groups
+                    .entry(key)
+                    .or_insert_with(|| HistogramAcc::new(row_bounds, row_counts.len()))
+                    .merge(&row_counts);
+            }
+        }
+
+        let mut ts = Vec::with_capacity(groups.len());
+        let mut names = Vec::with_capacity(groups.len());
+        let mut services = Vec::with_capacity(groups.len());
+        let mut values = Vec::with_capacity(groups.len());
+        for ((bucket_ns, metric, service), acc) in groups {
+            ts.push(bucket_ns);
+            names.push(metric);
+            services.push(service);
+            values.push(histogram_quantile(phi, &acc.bounds, &acc.counts));
+        }
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
     }
 
     /// Resolve the grouping labels to physical columns. Only labels backed
@@ -533,6 +657,97 @@ fn aggregate_expr(agg: MetricAgg) -> Expr {
     }
 }
 
+/// Merges OTLP histogram data points that share a step bucket and series.
+struct HistogramAcc {
+    /// Upper bounds of the finite buckets (`explicit_bounds`).
+    bounds: Vec<f64>,
+    /// Running element-wise sum of `bucket_counts` (one more than `bounds`).
+    counts: Vec<f64>,
+}
+
+impl HistogramAcc {
+    fn new(bounds: Vec<f64>, count_len: usize) -> Self {
+        Self {
+            bounds,
+            counts: vec![0.0; count_len],
+        }
+    }
+
+    fn merge(&mut self, row_counts: &[f64]) {
+        if row_counts.len() == self.counts.len() {
+            for (acc, add) in self.counts.iter_mut().zip(row_counts) {
+                *acc += add;
+            }
+        }
+    }
+}
+
+/// Parse a JSON numeric array (`"[1,2,3]"`) into `f64`s.
+fn parse_f64_array(raw: &str) -> Option<Vec<f64>> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let array = value.as_array()?;
+    array.iter().map(|v| v.as_f64()).collect()
+}
+
+/// Interpolate the `phi`-quantile of a classic histogram, following
+/// Prometheus's `bucketQuantile`: locate the bucket the rank falls in and
+/// linearly interpolate within it, assuming a uniform spread.
+///
+/// `bounds` are the finite bucket upper bounds; `counts` are the
+/// non-cumulative per-bucket counts with one extra `+Inf` bucket
+/// (`counts.len() == bounds.len() + 1`).
+fn histogram_quantile(phi: f64, bounds: &[f64], counts: &[f64]) -> f64 {
+    if phi.is_nan() {
+        return f64::NAN;
+    }
+    if phi < 0.0 {
+        return f64::NEG_INFINITY;
+    }
+    if phi > 1.0 {
+        return f64::INFINITY;
+    }
+    if bounds.is_empty() || counts.len() != bounds.len() + 1 {
+        return f64::NAN;
+    }
+    let total: f64 = counts.iter().sum();
+    if total <= 0.0 {
+        return f64::NAN;
+    }
+
+    // Cumulative counts across buckets.
+    let mut cumulative = Vec::with_capacity(counts.len());
+    let mut running = 0.0;
+    for &c in counts {
+        running += c;
+        cumulative.push(running);
+    }
+
+    let rank = phi * total;
+    let last = counts.len() - 1;
+    let b = cumulative.iter().position(|&c| c >= rank).unwrap_or(last);
+
+    // Rank lands in the open-ended `+Inf` bucket: clamp to the top finite
+    // bound (we can't extrapolate beyond it).
+    if b == last {
+        return bounds[bounds.len() - 1];
+    }
+
+    let bucket_end = bounds[b];
+    let (bucket_start, rank_in_bucket, count_in_bucket) = if b == 0 {
+        // Prometheus: a non-positive first bound is returned as-is.
+        if bucket_end <= 0.0 {
+            return bucket_end;
+        }
+        (0.0, rank, cumulative[0])
+    } else {
+        (bounds[b - 1], rank - cumulative[b - 1], counts[b])
+    };
+    if count_in_bucket <= 0.0 {
+        return bucket_start;
+    }
+    bucket_start + (bucket_end - bucket_start) * (rank_in_bucket / count_in_bucket)
+}
+
 fn cast_ns(expr: Expr) -> Expr {
     datafusion::logical_expr::cast(expr, DataType::Timestamp(TimeUnit::Nanosecond, None))
 }
@@ -804,5 +1019,114 @@ mod tests {
             service.query_range("reqs", 0, 1000, 0, "t", "d").await,
             Err(QuerierError::InvalidInput(_))
         ));
+    }
+
+    // ---- histogram_quantile ----
+
+    #[test]
+    fn histogram_quantile_interpolates_within_bucket() {
+        // bounds [1,2,4], counts [1,2,3,4] (incl. +Inf), total 10.
+        // rank 5 lands in the (2,4] bucket: 2 + 2*(5-3)/3 = 3.333…
+        let bounds = [1.0, 2.0, 4.0];
+        let counts = [1.0, 2.0, 3.0, 4.0];
+        assert!((histogram_quantile(0.5, &bounds, &counts) - (2.0 + 2.0 * 2.0 / 3.0)).abs() < 1e-9);
+        // rank 1 lands at the top of the first bucket: exactly its bound.
+        assert!((histogram_quantile(0.1, &bounds, &counts) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn histogram_quantile_in_inf_bucket_clamps_to_top_bound() {
+        let bounds = [1.0, 2.0, 4.0];
+        let counts = [1.0, 2.0, 3.0, 4.0];
+        // rank 9.5 falls in the +Inf bucket → clamp to the highest bound.
+        assert_eq!(histogram_quantile(0.95, &bounds, &counts), 4.0);
+    }
+
+    #[test]
+    fn histogram_quantile_edge_cases() {
+        let bounds = [1.0, 2.0];
+        let counts = [1.0, 1.0, 1.0];
+        assert!(histogram_quantile(f64::NAN, &bounds, &counts).is_nan());
+        assert_eq!(
+            histogram_quantile(-0.1, &bounds, &counts),
+            f64::NEG_INFINITY
+        );
+        assert_eq!(histogram_quantile(1.5, &bounds, &counts), f64::INFINITY);
+        // No observations → NaN.
+        assert!(histogram_quantile(0.5, &bounds, &[0.0, 0.0, 0.0]).is_nan());
+        // Malformed (counts length != bounds+1) → NaN.
+        assert!(histogram_quantile(0.5, &bounds, &[1.0, 1.0]).is_nan());
+    }
+
+    #[test]
+    fn parse_f64_array_handles_json_and_junk() {
+        assert_eq!(parse_f64_array("[1, 2.5, 3]"), Some(vec![1.0, 2.5, 3.0]));
+        assert_eq!(parse_f64_array("[]"), Some(vec![]));
+        assert_eq!(parse_f64_array("not json"), None);
+        assert_eq!(parse_f64_array(r#"{"a":1}"#), None);
+    }
+
+    fn service_with_histogram() -> MetricsService {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("bucket_counts", DataType::Utf8, true),
+            Field::new("explicit_bounds", DataType::Utf8, true),
+            Field::new("attributes", DataType::Utf8, true),
+            Field::new("resource_attributes", DataType::Utf8, true),
+        ]));
+        // Two data points for the same series in one step bucket. Merging
+        // scales the counts (×2) without moving the quantile.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 100])),
+                Arc::new(StringArray::from(vec!["api", "api"])),
+                Arc::new(StringArray::from(vec!["latency", "latency"])),
+                Arc::new(StringArray::from(vec!["[1,2,3,4]", "[1,2,3,4]"])),
+                Arc::new(StringArray::from(vec!["[1,2,4]", "[1,2,4]"])),
+                Arc::new(StringArray::from(vec!["{}", "{}"])),
+                Arc::new(StringArray::from(vec!["{}", "{}"])),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("metrics_histogram".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+        MetricsService::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn histogram_quantile_query_interpolates_merged_series() {
+        let service = service_with_histogram();
+        let out = matrix(&service, "histogram_quantile(0.5, latency)", 1000).await;
+        assert_eq!(out.len(), 1);
+        let (name, svc, value) = &out[0];
+        assert_eq!(name, "latency");
+        assert_eq!(svc.as_deref(), Some("api"));
+        assert!(
+            (value - (2.0 + 2.0 * 2.0 / 3.0)).abs() < 1e-9,
+            "got {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn histogram_quantile_without_table_is_empty() {
+        // The gauge-only service has no metrics_histogram table.
+        let service = service_with_data();
+        let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
+        assert!(out.is_empty());
     }
 }

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -15,9 +15,12 @@
 //!
 //! - Range-vector functions `rate(metric[range])` and
 //!   `increase(metric[range])`, optionally under an outer aggregation.
+//! - `histogram_quantile(phi, metric)` over a stored OTLP histogram — the
+//!   quantile is interpolated per series from the metric's buckets.
 //!
-//! `irate`, binary operators, subqueries, and `histogram_quantile` are
-//! not lowered yet and return [`QuerierError::Unsupported`] (#335).
+//! `irate`, binary operators, subqueries, and `histogram_quantile` over an
+//! inner `rate()`/aggregation are not lowered yet and return
+//! [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -100,6 +103,10 @@ pub struct MetricPlan {
     /// Set for `rate`/`increase` — a per-series counter delta over the
     /// window is computed before any outer aggregation.
     pub range: Option<RangeSpec>,
+    /// Set for `histogram_quantile(phi, <selector>)` — the query targets
+    /// the `metrics_histogram` table and interpolates the phi-quantile from
+    /// each series' stored buckets instead of aggregating a scalar `value`.
+    pub quantile: Option<f64>,
 }
 
 impl Eq for MetricPlan {}
@@ -114,6 +121,10 @@ pub fn plan_promql(query: &str) -> Result<MetricPlan, QuerierError> {
 fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
     match expr {
         Expr::Paren(p) => lower(&p.expr),
+        // `histogram_quantile(phi, <selector>)` targets the histogram table.
+        Expr::Call(call) if call.func.name == "histogram_quantile" => {
+            lower_histogram_quantile(call)
+        }
         // Bare selector or bare range function.
         Expr::VectorSelector(_) | Expr::Call(_) => {
             build_plan(expr, MetricAgg::Last, Grouping::Natural)
@@ -213,7 +224,38 @@ fn lower_selector(
         aggregate,
         grouping,
         range,
+        quantile: None,
     })
+}
+
+/// Lower `histogram_quantile(phi, <selector>)`. The phi must be a numeric
+/// literal and the inner argument a plain vector selector — SignalDB stores
+/// whole OTLP histograms per series (bucket arrays), so the quantile is
+/// interpolated per series rather than from `le`-labelled bucket series.
+fn lower_histogram_quantile(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let phi = match unwrap_paren(call.args.args.first().ok_or_else(|| {
+        QuerierError::InvalidInput("histogram_quantile expects (phi, selector)".to_string())
+    })?) {
+        Expr::NumberLiteral(n) => n.val,
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "histogram_quantile requires a numeric literal quantile".to_string(),
+            ));
+        }
+    };
+    let inner = call.args.args.get(1).ok_or_else(|| {
+        QuerierError::InvalidInput("histogram_quantile expects (phi, selector)".to_string())
+    })?;
+    let Expr::VectorSelector(vs) = unwrap_paren(inner) else {
+        return Err(QuerierError::Unsupported(
+            "histogram_quantile over rate()/aggregations is not supported yet (#335); \
+             use histogram_quantile(phi, metric)"
+                .to_string(),
+        ));
+    };
+    let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
+    plan.quantile = Some(phi);
+    Ok(plan)
 }
 
 fn unwrap_paren(expr: &Expr) -> &Expr {
@@ -407,10 +449,27 @@ mod tests {
             err(r#"sum without (job) (x)"#),
             QuerierError::Unsupported(_)
         ));
+        // histogram_quantile over an inner rate() is not lowered yet.
         assert!(matches!(
-            err(r#"histogram_quantile(0.9, x)"#),
+            err(r#"histogram_quantile(0.9, rate(x[5m]))"#),
             QuerierError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn histogram_quantile_over_selector() {
+        let p = plan(r#"histogram_quantile(0.95, http_request_duration_seconds{job="api"})"#);
+        assert_eq!(p.metric_name, "http_request_duration_seconds");
+        assert_eq!(p.quantile, Some(0.95));
+        assert_eq!(p.matchers.len(), 1);
+        assert_eq!(p.grouping, Grouping::Natural);
+        assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn non_histogram_plan_has_no_quantile() {
+        assert_eq!(plan(r#"http_requests_total"#).quantile, None);
+        assert_eq!(plan(r#"sum(rate(x[5m]))"#).quantile, None);
     }
 
     #[test]

--- a/tests-integration/tests/promql_queries.rs
+++ b/tests-integration/tests/promql_queries.rs
@@ -25,8 +25,8 @@ use opentelemetry_proto::tonic::{
     collector::metrics::v1::ExportMetricsServiceRequest,
     common::v1::{AnyValue, KeyValue, any_value::Value},
     metrics::v1::{
-        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data,
-        number_data_point,
+        Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics,
+        ScopeMetrics, metric::Data, number_data_point,
     },
     resource::v1::Resource,
 };
@@ -266,6 +266,52 @@ fn gauge_metrics(service: &str, value: f64, code: &str) -> ExportMetricsServiceR
     }
 }
 
+/// A single `latency` histogram data point with bounds [1,2,4] and bucket
+/// counts [1,2,3,4] (incl. +Inf) — total 10. The 0.5-quantile interpolates
+/// to 2 + 2*(5-3)/3 = 3.333… within the (2,4] bucket.
+fn histogram_metrics(service: &str) -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(string_value(service)),
+                    ..Default::default()
+                }],
+                dropped_attributes_count: 0,
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                scope: None,
+                metrics: vec![Metric {
+                    name: "latency".to_string(),
+                    description: String::new(),
+                    unit: "s".to_string(),
+                    data: Some(Data::Histogram(Histogram {
+                        aggregation_temporality: 1, // delta
+                        data_points: vec![HistogramDataPoint {
+                            attributes: vec![],
+                            start_time_unix_nano: BASE_NS,
+                            time_unix_nano: BASE_NS,
+                            count: 10,
+                            sum: Some(20.0),
+                            bucket_counts: vec![1, 2, 3, 4],
+                            explicit_bounds: vec![1.0, 2.0, 4.0],
+                            exemplars: vec![],
+                            flags: 0,
+                            min: Some(0.5),
+                            max: Some(6.0),
+                        }],
+                    })),
+                    metadata: vec![],
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
 async fn build_router(services: &TestServices) -> Router {
     let catalog = Catalog::new(services.config.discovery.as_ref().unwrap().dsn.as_str())
         .await
@@ -367,6 +413,12 @@ async fn promql_end_to_end() {
         .handle_grpc_otlp_metrics(&ctx, gauge_metrics("web", 20.0, "500"))
         .await
         .expect("ingest web gauge");
+    // Ingest: latency histogram (buckets [1,2,4], counts [1,2,3,4]).
+    services
+        .metrics_handler
+        .handle_grpc_otlp_metrics(&ctx, histogram_metrics("api"))
+        .await
+        .expect("ingest api histogram");
 
     // Wait for persistence.
     sleep(Duration::from_secs(15)).await;
@@ -487,6 +539,21 @@ async fn promql_end_to_end() {
         "series should all be requests: {body}"
     );
     assert_eq!(series.len(), 2, "one series per job: {body}");
+
+    // 7. histogram_quantile over the stored latency histogram: the median
+    //    interpolates to 3.333… within the (2,4] bucket.
+    let (status, body) = get(
+        &app,
+        &format!("/prometheus/api/v1/query_range?query=histogram_quantile(0.5,latency)&{w}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "histogram_quantile: {body}");
+    assert_eq!(body["data"]["resultType"], "matrix");
+    let q = matrix_value_sum(&body);
+    assert!(
+        (q - (2.0 + 2.0 * 2.0 / 3.0)).abs() < 1e-6,
+        "median latency ≈ 3.333, got {q}: {body}"
+    );
 }
 
 /// Sum all sample values across all series in a matrix response.


### PR DESCRIPTION
Stacks on the PromQL query support merged in #671 (epic #328). Adds
`histogram_quantile(phi, metric)`.

## Approach
SignalDB stores OTLP histograms whole — `bucket_counts` and `explicit_bounds`
as JSON arrays in `metrics_histogram` — rather than as Prometheus `_bucket`
series keyed by `le`. So the argument is the **histogram metric name itself**,
and the quantile is interpolated per series:

- **Translator** (`promql.rs`): `histogram_quantile(phi, <selector>)` lowers to
  a `MetricPlan` carrying `quantile: Some(phi)`. A numeric-literal phi and a
  plain vector selector are required; `rate()`/aggregation inners return
  `Unsupported` (#335).
- **Execution** (`metrics.rs`): a dedicated path scans `metrics_histogram`,
  merges each (step bucket, series)'s bucket arrays element-wise (exact for a
  single point per bucket and for delta temporality), and interpolates the
  phi-quantile with Prometheus's `bucketQuantile` algorithm (locate the bucket
  the rank falls in, linear interpolation within it). Output matches the matrix
  shape, so the router needs no change.

## Tests
- Unit: the interpolation function (within-bucket, +Inf clamp, φ<0/φ>1/NaN,
  zero-observations, malformed), `parse_f64_array`, and the histogram query
  path (merge + empty-when-no-table).
- Integration (`promql_queries.rs`): ingests a `latency` histogram and asserts
  `histogram_quantile(0.5, latency)` interpolates to ≈3.333.

## Docs
User guide (`querying-promql.md`) gains a quantiles section explaining the
metric-name-not-`le` model; architecture overview marks it implemented.

Partially closes #335 (histogram_quantile over selectors; `rate()` inner and
binary ops/`topk` remain).