### PR TITLE
docs(skills): mark PromQL metadata + histogram_quantile implemented

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -65,7 +65,7 @@ Key details:
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
 6. Router also nests query APIs for every signal, each lowering a parsed query to a DataFusion `Expr`/aggregate over the signal's Iceberg tables (never a SQL string, matching the trace path):
    - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series.
-   - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix); metadata endpoints and `histogram_quantile` are pending (#339/#335).
+   - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix), plus `histogram_quantile(phi, metric)` interpolated from `metrics_histogram` OTLP buckets; `MetricsService` also backs `/prometheus` labels/values/series. `histogram_quantile` over an inner `rate()`, binary ops, and `topk` remain pending (#335).
    - `/pyroscope` (profiles) via `ProfileService`.
 
 ## Service Components


### PR DESCRIPTION
Refreshes the architecture skill's query-path note now that /prometheus metadata endpoints (#671) and histogram_quantile (#674) have landed. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that PromQL labels, values, and series endpoints are backed by `MetricsService`.
  * Updated the documented status of `histogram_quantile`, noting remaining limitations for queries involving `rate()`, binary operations, and `topk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->