### PR TITLE
feat(querier): PromQL <agg>_over_time functions + support inventory (#328)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -1,0 +1,89 @@
+---
+audience: user
+type: reference
+status: living
+sources:
+  - src/querier/src/query/promql.rs
+  - src/querier/src/query/metrics.rs
+---
+
+# PromQL function & operator support
+
+What SignalDB's `/prometheus` query API supports today, and what it doesn't
+yet. See [Query metrics with PromQL](querying-promql.md) for usage.
+
+SignalDB lowers a parsed PromQL expression to a DataFusion plan over the
+metrics Iceberg tables (`metrics_gauge`, `metrics_sum`, `metrics_histogram`).
+Range aggregations bucket samples with `date_bin(step)` rather than a sliding
+window — exact when the query `step` equals the range, an approximation
+otherwise. Anything listed as unsupported returns a clear error rather than a
+wrong result.
+
+## Selectors
+
+| Feature | Status |
+|---------|--------|
+| Instant vector selector `metric{…}` | ✅ |
+| Label matchers `=`, `!=`, `=~`, `!~` | ✅ (regex on attribute labels: `=`/`!=` only) |
+| `__name__` matcher | ✅ |
+| Range vector selector `metric[5m]` (as a function argument) | ✅ |
+| `offset` modifier | ❌ |
+| `@` modifier | ❌ |
+| Subqueries `expr[5m:1m]` | ❌ |
+
+## Aggregation operators
+
+| Operator | Status |
+|----------|--------|
+| `sum`, `avg`, `min`, `max`, `count` (with/without `by (…)`) | ✅ |
+| `without (…)` grouping | ❌ |
+| `stddev`, `stdvar`, `group`, `count_values` | ❌ |
+| `topk`, `bottomk`, `quantile` (parameterized) | ❌ |
+
+## Range (`[range]`) functions
+
+| Function | Status |
+|----------|--------|
+| `rate` | ✅ (counter delta ÷ range seconds) |
+| `increase` | ✅ (counter delta) |
+| `avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time` | ✅ |
+| `count_over_time`, `last_over_time` | ✅ |
+| `stddev_over_time`, `stdvar_over_time` | ✅ (population) |
+| `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
+| `irate`, `idelta`, `delta`, `deriv`, `resets`, `changes` | ❌ |
+| `present_over_time`, `absent_over_time`, `quantile_over_time` | ❌ |
+
+## Histograms
+
+| Function | Status |
+|----------|--------|
+| `histogram_quantile(phi, metric)` | ✅ (interpolated from OTLP buckets; the argument is the histogram metric name, not `le`-keyed `_bucket` series) |
+| `histogram_quantile(phi, rate(metric[5m]))` | ❌ |
+| `histogram_count`, `histogram_sum`, `histogram_fraction` | ❌ |
+
+## Binary operators
+
+| Operator | Status |
+|----------|--------|
+| Arithmetic `+ - * / % ^` | ❌ |
+| Comparison `== != > < >= <=` | ❌ |
+| Logical/set `and`, `or`, `unless` | ❌ |
+| `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |
+
+## Math & label functions
+
+| Function | Status |
+|----------|--------|
+| `abs`, `ceil`, `floor`, `round`, `clamp`, `clamp_min`, `clamp_max` | ❌ |
+| `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ❌ |
+| `sort`, `sort_desc` | ❌ |
+| `label_replace`, `label_join` | ❌ |
+| `vector`, `scalar`, `absent` | ❌ |
+| `time`, `timestamp`, `day_of_week`, `hour`, … | ❌ |
+
+## Roadmap
+
+Tracked under epic #328 and #335. Unsupported items above are being added
+incrementally; scalar arithmetic/comparison, the common math functions, and
+`topk`/`bottomk` are the next planned increments. Full vector-to-vector binary
+matching (`on`/`ignoring`/`group_left`) and subqueries are larger efforts.

--- a/docs/users/querying-promql.md
+++ b/docs/users/querying-promql.md
@@ -46,9 +46,10 @@ curl -sG http://localhost:3000/prometheus/api/v1/query_range \
 
 Supported so far: instant/range selectors with label matchers
 (`=`, `!=`, `=~`, `!~`); the aggregations `sum`, `avg`, `min`, `max`, `count`,
-optionally with `by (label)`; the range functions `rate` and `increase`; and
-`histogram_quantile(phi, metric)` (see below). `histogram_quantile` over an
-inner `rate()`, binary operators, and `topk` are not implemented yet (#335).
+optionally with `by (label)`; the range functions `rate`, `increase`, and the
+`<agg>_over_time` family; and `histogram_quantile(phi, metric)` (see below).
+For the full list of what is and isn't supported, see the
+[PromQL function support reference](promql-functions.md).
 
 ## Quantiles from histograms
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -22,7 +22,7 @@ use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
 use datafusion::functions_aggregate::expr_fn::{
-    avg, count, first_value, last_value, max, min, sum,
+    avg, count, first_value, last_value, max, min, stddev_pop, sum, var_pop,
 };
 use datafusion::logical_expr::{Expr, SortExpr, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
@@ -652,6 +652,8 @@ fn aggregate_expr(agg: MetricAgg) -> Expr {
         MetricAgg::Min => min(value),
         MetricAgg::Max => max(value),
         MetricAgg::Count => count(value),
+        MetricAgg::Stddev => stddev_pop(value),
+        MetricAgg::StdVar => var_pop(value),
         // Last value in the bucket, ordered by timestamp.
         MetricAgg::Last => last_value(value, vec![SortExpr::new(col("timestamp"), true, true)]),
     }
@@ -1010,6 +1012,43 @@ mod tests {
             .filter_map(|s| s.get("job").cloned())
             .collect();
         assert_eq!(jobs, BTreeSet::from(["api".to_string(), "web".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn over_time_reduces_samples_per_bucket() {
+        let service = service_with_data();
+        // api has samples [1,3] in one bucket, web has [5].
+        let avg = matrix(&service, "avg_over_time(reqs[1m])", 1000).await;
+        let api = avg
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 2.0); // (1+3)/2
+        assert_eq!(
+            matrix(&service, "sum_over_time(reqs[1m])", 1000)
+                .await
+                .iter()
+                .find(|(_, s, _)| s.as_deref() == Some("api"))
+                .unwrap()
+                .2,
+            4.0
+        );
+        assert_eq!(
+            matrix(&service, "count_over_time(reqs[1m])", 1000)
+                .await
+                .iter()
+                .find(|(_, s, _)| s.as_deref() == Some("api"))
+                .unwrap()
+                .2,
+            2.0
+        );
+        // Population stddev of [1,3] is 1.0.
+        let sd = matrix(&service, "stddev_over_time(reqs[1m])", 1000).await;
+        let api_sd = sd
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert!((api_sd.2 - 1.0).abs() < 1e-9, "got {}", api_sd.2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -15,6 +15,8 @@
 //!
 //! - Range-vector functions `rate(metric[range])` and
 //!   `increase(metric[range])`, optionally under an outer aggregation.
+//! - The `<agg>_over_time(metric[range])` family (avg/sum/min/max/count/
+//!   last/stddev/stdvar) — a per-bucket reducer over the raw samples.
 //! - `histogram_quantile(phi, metric)` over a stored OTLP histogram — the
 //!   quantile is interpolated per series from the metric's buckets.
 //!
@@ -40,6 +42,10 @@ pub enum MetricAgg {
     Min,
     Max,
     Count,
+    /// Population standard deviation (`stddev_over_time`).
+    Stddev,
+    /// Population variance (`stdvar_over_time`).
+    StdVar,
 }
 
 /// How series are grouped.
@@ -163,15 +169,6 @@ fn build_plan(
         Expr::Paren(p) => build_plan(&p.expr, aggregate, grouping),
         Expr::VectorSelector(vs) => lower_selector(vs, aggregate, grouping, None),
         Expr::Call(call) => {
-            let function = match call.func.name {
-                "rate" => RangeFn::Rate,
-                "increase" => RangeFn::Increase,
-                other => {
-                    return Err(QuerierError::Unsupported(format!(
-                        "function '{other}' (only rate/increase are supported)"
-                    )));
-                }
-            };
             let arg = call.args.first().ok_or_else(|| {
                 QuerierError::InvalidInput(format!("{} expects one argument", call.func.name))
             })?;
@@ -180,6 +177,29 @@ fn build_plan(
                     "{} requires a range-vector selector like metric[5m]",
                     call.func.name
                 )));
+            };
+
+            // `<agg>_over_time(metric[range])` reduces the raw samples in each
+            // bucket. Only the bare form is supported; an outer aggregation
+            // would need a second reduce stage (#335).
+            if let Some(reducer) = over_time_agg(call.func.name) {
+                if grouping != Grouping::Natural || aggregate != MetricAgg::Last {
+                    return Err(QuerierError::Unsupported(format!(
+                        "{} under an outer aggregation is not supported yet (#335)",
+                        call.func.name
+                    )));
+                }
+                return lower_selector(&ms.vs, reducer, Grouping::Natural, None);
+            }
+
+            let function = match call.func.name {
+                "rate" => RangeFn::Rate,
+                "increase" => RangeFn::Increase,
+                other => {
+                    return Err(QuerierError::Unsupported(format!(
+                        "function '{other}' (supported: rate, increase, *_over_time)"
+                    )));
+                }
             };
             let seconds = ms.range.as_secs_f64();
             lower_selector(
@@ -277,6 +297,21 @@ fn aggregate_op(op: &str) -> Result<MetricAgg, QuerierError> {
                 "aggregation operator '{other}'"
             )));
         }
+    })
+}
+
+/// Map an `<agg>_over_time` function name to its per-bucket reducer.
+fn over_time_agg(name: &str) -> Option<MetricAgg> {
+    Some(match name {
+        "avg_over_time" => MetricAgg::Avg,
+        "sum_over_time" => MetricAgg::Sum,
+        "min_over_time" => MetricAgg::Min,
+        "max_over_time" => MetricAgg::Max,
+        "count_over_time" => MetricAgg::Count,
+        "last_over_time" => MetricAgg::Last,
+        "stddev_over_time" => MetricAgg::Stddev,
+        "stdvar_over_time" => MetricAgg::StdVar,
+        _ => return None,
     })
 }
 
@@ -435,6 +470,33 @@ mod tests {
         assert_eq!(p.aggregate, MetricAgg::Sum);
         assert_eq!(p.grouping, Grouping::Collapse);
         assert_eq!(p.range.unwrap().function, RangeFn::Rate);
+    }
+
+    #[test]
+    fn over_time_maps_to_reducer() {
+        for (q, a) in [
+            ("avg_over_time(x[5m])", MetricAgg::Avg),
+            ("sum_over_time(x[5m])", MetricAgg::Sum),
+            ("min_over_time(x[5m])", MetricAgg::Min),
+            ("max_over_time(x[5m])", MetricAgg::Max),
+            ("count_over_time(x[5m])", MetricAgg::Count),
+            ("last_over_time(x[5m])", MetricAgg::Last),
+            ("stddev_over_time(x[5m])", MetricAgg::Stddev),
+            ("stdvar_over_time(x[5m])", MetricAgg::StdVar),
+        ] {
+            let p = plan(q);
+            assert_eq!(p.aggregate, a, "{q}");
+            assert_eq!(p.grouping, Grouping::Natural, "{q}");
+            assert!(p.range.is_none(), "{q}");
+        }
+    }
+
+    #[test]
+    fn over_time_under_aggregation_unsupported() {
+        assert!(matches!(
+            err(r#"sum(avg_over_time(x[5m]))"#),
+            QuerierError::Unsupported(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Continues PromQL coverage (epic #328). Adds the `<agg>_over_time` range
functions and a function-support reference doc.

## Functions
`avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time`,
`count_over_time`, `last_over_time`, `stddev_over_time`, `stdvar_over_time` —
each a per-bucket reducer over the raw samples in the range, reusing the
existing `date_bin(step)` bucketing (bare form; an outer aggregation over them,
e.g. `sum(avg_over_time(…))`, remains unsupported — #335).

## Inventory
New `docs/users/promql-functions.md` documents the full PromQL surface —
selectors, aggregations, range functions, histograms, binary operators, math —
with a ✅/❌ status for each, so users can see exactly what the `/prometheus`
API supports today and what's on the roadmap.

## Tests
Translator (function→reducer mapping, outer-aggregation rejection) and service
(per-bucket avg/sum/count/stddev) unit tests.