### PR TITLE
test(compactor): fix top-of-hour flake in grace-period retention test

### DIFF
--- a/tests-integration/tests/compactor/partition_drop.rs
+++ b/tests-integration/tests/compactor/partition_drop.rs
@@ -210,7 +210,7 @@ async fn test_partition_drop_respects_grace_period() -> Result<()> {
         .await?;
 
     let now = Utc::now().timestamp_millis();
-    // Create data at exactly the retention boundary (3 hours + 1 minute ago)
+    // Create data just past the 3-hour retention boundary (3h 1min ago).
     let boundary_time = now - (3 * 60 * 60 * 1000) - (60 * 1000);
 
     let config = DataGeneratorConfig {
@@ -233,7 +233,15 @@ async fn test_partition_drop_respects_grace_period() -> Result<()> {
         logs: std::time::Duration::from_secs(24 * 3600),
         metrics: std::time::Duration::from_secs(24 * 3600),
         tenant_overrides: HashMap::new(),
-        grace_period: std::time::Duration::from_secs(3600), // 1 hour grace period
+        // Partitions are dated by their Hour-transform bucket start
+        // (`PartitionInfo.timestamp` = floor-to-hour), so a data point at
+        // 3h 1min ago can floor to a bucket up to ~1h older when the test
+        // runs near the top of a wall-clock hour. A 2-hour grace period
+        // (effective cutoff = retention 3h + grace 2h = 5h) keeps that
+        // worst-case bucket (~4h 1min old) safely inside the window,
+        // removing a top-of-hour boundary flake while still exercising that
+        // grace protects a partition past retention.
+        grace_period: std::time::Duration::from_secs(2 * 3600),
         timezone: "UTC".to_string(),
         dry_run: false,
         snapshots_to_keep: Some(10),
@@ -262,15 +270,16 @@ async fn test_partition_drop_respects_grace_period() -> Result<()> {
         "Grace period must protect the boundary partition from being dropped"
     );
 
-    // The partition at 3h 1min ago should be protected by the grace period
-    // Effective cutoff = retention (3h) + grace (1h) = 4h ago
-    // Our partition at 3h 1min ago is within the grace period, so should NOT be dropped
+    // The partition at 3h 1min ago should be protected by the grace period.
+    // Effective cutoff = retention (3h) + grace (2h) = 5h ago.
+    // Our partition at 3h 1min ago is well within the grace period, so should
+    // NOT be dropped even after the Hour-transform floors its bucket start.
 
     // Note: Since the retention enforcer computes cutoff with grace period applied,
     // we verify the grace period is working by checking that data just past the
     // retention boundary (but within grace) is preserved
 
-    let retention_cutoff_with_grace = now - (4 * 60 * 60 * 1000); // 4 hours (3h retention + 1h grace)
+    let retention_cutoff_with_grace = now - (5 * 60 * 60 * 1000); // 5 hours (3h retention + 2h grace)
 
     let partition_timestamp = partitions[0].timestamp_range.1;
     assert!(


### PR DESCRIPTION
Fixes a ~1.7%/run flake in `test_partition_drop_respects_grace_period`
(surfaced on unrelated CI runs).

## Root cause
`PartitionInfo.timestamp` is the Iceberg Hour-transform bucket start
(`hours_since_epoch * 3600`, `src/compactor/src/iceberg/partition.rs`), i.e.
floored to the hour. The test places data at `now - 3h 1min` and expects the
1-hour grace period (effective cutoff `now - 4h`) to protect it. But when the
test runs in the **first 60 seconds of a wall-clock hour**, `now - 3h 1min`
floors into the *previous* hour bucket — `now - 4h` — which is `< cutoff`, so
the partition is dropped and the `dropped == 0` assertion fails.

## Fix
Widen the grace period to 2h (effective cutoff `now - 5h`). The worst-case
floored bucket is ~4h 1min old, comfortably inside the 5h window regardless of
where in the hour the test runs. The test still exercises exactly what it
claims — that grace protects a partition already past its retention.

Verified locally. No production code changes.