### PR TITLE
feat(querier): PromQL math functions & scalar arithmetic (#328)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -65,7 +65,8 @@ wrong result.
 
 | Operator | Status |
 |----------|--------|
-| Arithmetic `+ - * / % ^` | ❌ |
+| Arithmetic `+ - * / % ^` with a scalar (`metric * 8`, `1024 / metric`) | ✅ |
+| Arithmetic between two vectors | ❌ |
 | Comparison `== != > < >= <=` | ❌ |
 | Logical/set `and`, `or`, `unless` | ❌ |
 | `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |
@@ -74,8 +75,8 @@ wrong result.
 
 | Function | Status |
 |----------|--------|
-| `abs`, `ceil`, `floor`, `round`, `clamp`, `clamp_min`, `clamp_max` | ❌ |
-| `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ❌ |
+| `abs`, `ceil`, `floor`, `round`, `clamp`, `clamp_min`, `clamp_max` | ✅ |
+| `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ✅ |
 | `sort`, `sort_desc` | ❌ |
 | `label_replace`, `label_join` | ❌ |
 | `vector`, `scalar`, `absent` | ❌ |
@@ -84,6 +85,6 @@ wrong result.
 ## Roadmap
 
 Tracked under epic #328 and #335. Unsupported items above are being added
-incrementally; scalar arithmetic/comparison, the common math functions, and
-`topk`/`bottomk` are the next planned increments. Full vector-to-vector binary
-matching (`on`/`ignoring`/`group_left`) and subqueries are larger efforts.
+incrementally; `topk`/`bottomk`, `irate`, and comparison operators are the next
+planned increments. Full vector-to-vector binary matching
+(`on`/`ignoring`/`group_left`) and subqueries are larger efforts.

--- a/docs/users/querying-promql.md
+++ b/docs/users/querying-promql.md
@@ -47,8 +47,10 @@ curl -sG http://localhost:3000/prometheus/api/v1/query_range \
 Supported so far: instant/range selectors with label matchers
 (`=`, `!=`, `=~`, `!~`); the aggregations `sum`, `avg`, `min`, `max`, `count`,
 optionally with `by (label)`; the range functions `rate`, `increase`, and the
-`<agg>_over_time` family; and `histogram_quantile(phi, metric)` (see below).
-For the full list of what is and isn't supported, see the
+`<agg>_over_time` family; `histogram_quantile(phi, metric)` (see below); the
+unary math functions (`abs`, `ceil`, `floor`, `round`, `sqrt`, `clamp*`, …);
+and scalar arithmetic (`metric * 8`, `1024 / metric`). For the full list of
+what is and isn't supported, see the
 [PromQL function support reference](promql-functions.md).
 
 ## Quantiles from histograms

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -28,7 +28,9 @@ use datafusion::logical_expr::{Expr, SortExpr, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
-use super::promql::{Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, plan_promql};
+use super::promql::{
+    ArithOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, ValueOp, plan_promql,
+};
 use super::{error::QuerierError, table_ref::build_table_reference};
 
 /// The metrics tables a PromQL query scans (gauge + sum cover counters
@@ -120,6 +122,9 @@ impl MetricsService {
         } else {
             self.simple_query(df, bucket, plan.aggregate, &group_cols)?
         };
+
+        // Apply math / scalar-arithmetic transforms to the result value.
+        let df = apply_transforms_df(df, &plan.transforms, &group_cols)?;
 
         df.sort(vec![SortExpr::new(col("bucket"), true, true)])
             .map_err(QuerierError::QueryFailed)?
@@ -295,7 +300,8 @@ impl MetricsService {
             ts.push(bucket_ns);
             names.push(metric);
             services.push(service);
-            values.push(histogram_quantile(phi, &acc.bounds, &acc.counts));
+            let q = histogram_quantile(phi, &acc.bounds, &acc.counts);
+            values.push(apply_transforms_f64(q, &plan.transforms));
         }
 
         let schema = Arc::new(Schema::new(vec![
@@ -750,6 +756,114 @@ fn histogram_quantile(phi: f64, bounds: &[f64], counts: &[f64]) -> f64 {
     bucket_start + (bucket_end - bucket_start) * (rank_in_bucket / count_in_bucket)
 }
 
+/// Re-project a matrix DataFrame with the `value` column transformed by
+/// `ops`, preserving `bucket`, `metric_name`, and the grouping columns.
+fn apply_transforms_df(
+    df: DataFrame,
+    ops: &[ValueOp],
+    group_cols: &[&str],
+) -> Result<DataFrame, QuerierError> {
+    if ops.is_empty() {
+        return Ok(df);
+    }
+    let mut proj = vec![col("bucket"), col("metric_name")];
+    proj.extend(group_cols.iter().map(|c| col(*c)));
+    proj.push(apply_value_ops_expr(col("value"), ops).alias("value"));
+    df.select(proj).map_err(QuerierError::QueryFailed)
+}
+
+/// Compose the value transforms into a DataFusion expression.
+fn apply_value_ops_expr(mut value: Expr, ops: &[ValueOp]) -> Expr {
+    use datafusion::functions::math::expr_fn as math;
+    use datafusion::logical_expr::when;
+    for op in ops {
+        value = match op {
+            ValueOp::Abs => math::abs(value),
+            ValueOp::Ceil => math::ceil(value),
+            ValueOp::Floor => math::floor(value),
+            ValueOp::Round => math::round(vec![value]),
+            ValueOp::Sqrt => math::sqrt(value),
+            ValueOp::Exp => math::exp(value),
+            ValueOp::Ln => math::ln(value),
+            ValueOp::Log2 => math::log2(value),
+            ValueOp::Log10 => math::log10(value),
+            ValueOp::Sgn => math::signum(value),
+            ValueOp::ClampMin(m) => when(value.clone().lt(lit(*m)), lit(*m))
+                .otherwise(value)
+                .unwrap(),
+            ValueOp::ClampMax(m) => when(value.clone().gt(lit(*m)), lit(*m))
+                .otherwise(value)
+                .unwrap(),
+            ValueOp::Clamp(lo, hi) => {
+                let clamped_low = when(value.clone().lt(lit(*lo)), lit(*lo))
+                    .otherwise(value)
+                    .unwrap();
+                when(clamped_low.clone().gt(lit(*hi)), lit(*hi))
+                    .otherwise(clamped_low)
+                    .unwrap()
+            }
+            ValueOp::Arith(arith, s, scalar_left) => arith_expr(*arith, value, *s, *scalar_left),
+        };
+    }
+    value
+}
+
+/// Build `value OP scalar` (or `scalar OP value`) as an expression.
+fn arith_expr(op: ArithOp, value: Expr, scalar: f64, scalar_left: bool) -> Expr {
+    use datafusion::functions::math::expr_fn::power;
+    let s = lit(scalar);
+    match (op, scalar_left) {
+        (ArithOp::Add, _) => value + s,
+        (ArithOp::Mul, _) => value * s,
+        (ArithOp::Sub, false) => value - s,
+        (ArithOp::Sub, true) => s - value,
+        (ArithOp::Div, false) => value / s,
+        (ArithOp::Div, true) => s / value,
+        (ArithOp::Mod, false) => value % s,
+        (ArithOp::Mod, true) => s % value,
+        (ArithOp::Pow, false) => power(value, s),
+        (ArithOp::Pow, true) => power(s, value),
+    }
+}
+
+/// Apply the value transforms to a scalar (histogram path).
+fn apply_transforms_f64(mut v: f64, ops: &[ValueOp]) -> f64 {
+    for op in ops {
+        v = match op {
+            ValueOp::Abs => v.abs(),
+            ValueOp::Ceil => v.ceil(),
+            ValueOp::Floor => v.floor(),
+            ValueOp::Round => v.round(),
+            ValueOp::Sqrt => v.sqrt(),
+            ValueOp::Exp => v.exp(),
+            ValueOp::Ln => v.ln(),
+            ValueOp::Log2 => v.log2(),
+            ValueOp::Log10 => v.log10(),
+            ValueOp::Sgn => v.signum(),
+            ValueOp::ClampMin(m) => v.max(*m),
+            ValueOp::ClampMax(m) => v.min(*m),
+            ValueOp::Clamp(lo, hi) => v.clamp(*lo, *hi),
+            ValueOp::Arith(arith, s, scalar_left) => arith_f64(*arith, v, *s, *scalar_left),
+        };
+    }
+    v
+}
+
+fn arith_f64(op: ArithOp, v: f64, s: f64, scalar_left: bool) -> f64 {
+    match (op, scalar_left) {
+        (ArithOp::Add, _) => v + s,
+        (ArithOp::Mul, _) => v * s,
+        (ArithOp::Sub, false) => v - s,
+        (ArithOp::Sub, true) => s - v,
+        (ArithOp::Div, false) => v / s,
+        (ArithOp::Div, true) => s / v,
+        (ArithOp::Mod, false) => v % s,
+        (ArithOp::Mod, true) => s % v,
+        (ArithOp::Pow, false) => v.powf(s),
+        (ArithOp::Pow, true) => s.powf(v),
+    }
+}
+
 fn cast_ns(expr: Expr) -> Expr {
     datafusion::logical_expr::cast(expr, DataType::Timestamp(TimeUnit::Nanosecond, None))
 }
@@ -1049,6 +1163,34 @@ mod tests {
             .find(|(_, s, _)| s.as_deref() == Some("api"))
             .unwrap();
         assert!((api_sd.2 - 1.0).abs() < 1e-9, "got {}", api_sd.2);
+    }
+
+    #[tokio::test]
+    async fn scalar_arithmetic_and_math_transform_value() {
+        let service = service_with_data();
+        // Bare selector → last value per series: api=3, web=5.
+        let by = |out: Vec<(String, Option<String>, f64)>, svc: &str| {
+            out.into_iter()
+                .find(|(_, s, _)| s.as_deref() == Some(svc))
+                .unwrap()
+                .2
+        };
+        assert_eq!(by(matrix(&service, "reqs * 2", 1000).await, "api"), 6.0);
+        assert_eq!(by(matrix(&service, "reqs + 10", 1000).await, "web"), 15.0);
+        // clamp_max caps web's 5 at 4; api's 3 stays.
+        assert_eq!(
+            by(matrix(&service, "clamp_max(reqs, 4)", 1000).await, "web"),
+            4.0
+        );
+        assert_eq!(
+            by(matrix(&service, "clamp_max(reqs, 4)", 1000).await, "api"),
+            3.0
+        );
+        // 10 / reqs → api 10/3.
+        assert!((by(matrix(&service, "10 / reqs", 1000).await, "api") - 10.0 / 3.0).abs() < 1e-9);
+        // abs over a rate that is negative is not exercised here; abs of a
+        // positive last value is a no-op.
+        assert_eq!(by(matrix(&service, "abs(reqs)", 1000).await, "api"), 3.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -19,10 +19,13 @@
 //!   last/stddev/stdvar) — a per-bucket reducer over the raw samples.
 //! - `histogram_quantile(phi, metric)` over a stored OTLP histogram — the
 //!   quantile is interpolated per series from the metric's buckets.
+//! - Unary math functions (`abs`, `ceil`, `floor`, `round`, `sqrt`, `exp`,
+//!   `ln`, `log2`, `log10`, `sgn`, `clamp*`) and scalar arithmetic
+//!   (`metric * 8`, `1024 / metric`) as value transforms on the result.
 //!
-//! `irate`, binary operators, subqueries, and `histogram_quantile` over an
-//! inner `rate()`/aggregation are not lowered yet and return
-//! [`QuerierError::Unsupported`] (#335).
+//! `irate`, comparison/logical/vector-to-vector operators, subqueries, and
+//! `histogram_quantile` over an inner `rate()`/aggregation are not lowered yet
+//! and return [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -94,6 +97,42 @@ pub struct RangeSpec {
 
 impl Eq for RangeSpec {}
 
+/// A scalar arithmetic operator in a `vector OP scalar` expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Pow,
+}
+
+/// A transform applied to the result `value` column, in order. Covers the
+/// unary math functions and scalar arithmetic (`metric * 8`, `metric / 1024`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ValueOp {
+    Abs,
+    Ceil,
+    Floor,
+    Round,
+    Sqrt,
+    Exp,
+    Ln,
+    Log2,
+    Log10,
+    /// `sgn` — sign of the value (-1, 0, 1).
+    Sgn,
+    ClampMin(f64),
+    ClampMax(f64),
+    Clamp(f64, f64),
+    /// Scalar arithmetic; the bool is true when the scalar is on the left
+    /// (`scalar OP vector`), false for `vector OP scalar`.
+    Arith(ArithOp, f64, bool),
+}
+
+impl Eq for ValueOp {}
+
 /// A lowered PromQL query.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricPlan {
@@ -113,6 +152,9 @@ pub struct MetricPlan {
     /// the `metrics_histogram` table and interpolates the phi-quantile from
     /// each series' stored buckets instead of aggregating a scalar `value`.
     pub quantile: Option<f64>,
+    /// Math/scalar-arithmetic transforms applied to the result `value`, in
+    /// order (e.g. `abs`, `metric * 8`). Empty for a plain query.
+    pub transforms: Vec<ValueOp>,
 }
 
 impl Eq for MetricPlan {}
@@ -131,6 +173,8 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
         Expr::Call(call) if call.func.name == "histogram_quantile" => {
             lower_histogram_quantile(call)
         }
+        // A math function wrapping a vector: `abs(...)`, `clamp_min(..., 0)`.
+        Expr::Call(call) if is_math_fn(call.func.name) => lower_math_call(call),
         // Bare selector or bare range function.
         Expr::VectorSelector(_) | Expr::Call(_) => {
             build_plan(expr, MetricAgg::Last, Grouping::Natural)
@@ -145,9 +189,9 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             let grouping = grouping_from(agg.modifier.as_ref())?;
             build_plan(unwrap_paren(&agg.expr), aggregate, grouping)
         }
-        Expr::Binary(_) => Err(QuerierError::Unsupported(
-            "binary operations between metric queries".to_string(),
-        )),
+        // Scalar arithmetic: `metric * 8`, `1024 / metric`. Applied to the
+        // result value. Vector-to-vector operations remain unsupported.
+        Expr::Binary(bin) => lower_binary(bin),
         Expr::MatrixSelector(_) | Expr::Subquery(_) => Err(QuerierError::Unsupported(
             "range-vector selector without a function".to_string(),
         )),
@@ -245,6 +289,7 @@ fn lower_selector(
         grouping,
         range,
         quantile: None,
+        transforms: Vec::new(),
     })
 }
 
@@ -276,6 +321,118 @@ fn lower_histogram_quantile(call: &parser::Call) -> Result<MetricPlan, QuerierEr
     let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
     plan.quantile = Some(phi);
     Ok(plan)
+}
+
+/// Whether a function name is a supported unary math / clamp function.
+fn is_math_fn(name: &str) -> bool {
+    matches!(
+        name,
+        "abs"
+            | "ceil"
+            | "floor"
+            | "round"
+            | "sqrt"
+            | "exp"
+            | "ln"
+            | "log2"
+            | "log10"
+            | "sgn"
+            | "clamp_min"
+            | "clamp_max"
+            | "clamp"
+    )
+}
+
+/// Lower a math function `f(vector, [scalars…])` by lowering the vector
+/// argument and appending the corresponding value transform.
+fn lower_math_call(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let inner = call.args.args.first().ok_or_else(|| {
+        QuerierError::InvalidInput(format!("{} expects an argument", call.func.name))
+    })?;
+    let op = match call.func.name {
+        "abs" => ValueOp::Abs,
+        "ceil" => ValueOp::Ceil,
+        "floor" => ValueOp::Floor,
+        "round" => ValueOp::Round,
+        "sqrt" => ValueOp::Sqrt,
+        "exp" => ValueOp::Exp,
+        "ln" => ValueOp::Ln,
+        "log2" => ValueOp::Log2,
+        "log10" => ValueOp::Log10,
+        "sgn" => ValueOp::Sgn,
+        "clamp_min" => ValueOp::ClampMin(scalar_arg(call, 1)?),
+        "clamp_max" => ValueOp::ClampMax(scalar_arg(call, 1)?),
+        "clamp" => ValueOp::Clamp(scalar_arg(call, 1)?, scalar_arg(call, 2)?),
+        other => {
+            return Err(QuerierError::Unsupported(format!("function '{other}'")));
+        }
+    };
+    let mut plan = lower(unwrap_paren(inner))?;
+    plan.transforms.push(op);
+    Ok(plan)
+}
+
+/// Lower a binary expression. Only `vector OP scalar` / `scalar OP vector`
+/// arithmetic is supported; comparison, logical, and vector-to-vector
+/// operations are not (#335).
+fn lower_binary(bin: &parser::BinaryExpr) -> Result<MetricPlan, QuerierError> {
+    if bin.op.is_comparison_operator() {
+        return Err(QuerierError::Unsupported(
+            "comparison operators".to_string(),
+        ));
+    }
+    let arith = match format!("{}", bin.op).as_str() {
+        "+" => ArithOp::Add,
+        "-" => ArithOp::Sub,
+        "*" => ArithOp::Mul,
+        "/" => ArithOp::Div,
+        "%" => ArithOp::Mod,
+        "^" => ArithOp::Pow,
+        other => {
+            return Err(QuerierError::Unsupported(format!(
+                "binary operator '{other}'"
+            )));
+        }
+    };
+    match (as_scalar(&bin.lhs), as_scalar(&bin.rhs)) {
+        (Some(_), Some(_)) => Err(QuerierError::Unsupported(
+            "constant-only arithmetic".to_string(),
+        )),
+        (None, None) => Err(QuerierError::Unsupported(
+            "vector-to-vector binary operations".to_string(),
+        )),
+        // scalar OP vector
+        (Some(s), None) => {
+            let mut plan = lower(unwrap_paren(&bin.rhs))?;
+            plan.transforms.push(ValueOp::Arith(arith, s, true));
+            Ok(plan)
+        }
+        // vector OP scalar
+        (None, Some(s)) => {
+            let mut plan = lower(unwrap_paren(&bin.lhs))?;
+            plan.transforms.push(ValueOp::Arith(arith, s, false));
+            Ok(plan)
+        }
+    }
+}
+
+/// The `i`-th call argument as a numeric literal.
+fn scalar_arg(call: &parser::Call, i: usize) -> Result<f64, QuerierError> {
+    match call.args.args.get(i).map(|a| unwrap_paren(a)) {
+        Some(Expr::NumberLiteral(n)) => Ok(n.val),
+        _ => Err(QuerierError::Unsupported(format!(
+            "{} requires a numeric literal argument",
+            call.func.name
+        ))),
+    }
+}
+
+/// A parenthesized number literal, if the expression is one.
+fn as_scalar(expr: &Expr) -> Option<f64> {
+    match unwrap_paren(expr) {
+        Expr::NumberLiteral(n) => Some(n.val),
+        _ => None,
+    }
 }
 
 fn unwrap_paren(expr: &Expr) -> &Expr {
@@ -497,6 +654,65 @@ mod tests {
             err(r#"sum(avg_over_time(x[5m]))"#),
             QuerierError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn math_functions_append_transforms() {
+        assert_eq!(plan("abs(x)").transforms, vec![ValueOp::Abs]);
+        assert_eq!(plan("ceil(x)").transforms, vec![ValueOp::Ceil]);
+        assert_eq!(plan("sqrt(x)").transforms, vec![ValueOp::Sqrt]);
+        assert_eq!(plan("sgn(x)").transforms, vec![ValueOp::Sgn]);
+        assert_eq!(
+            plan("clamp_min(x, 0)").transforms,
+            vec![ValueOp::ClampMin(0.0)]
+        );
+        assert_eq!(
+            plan("clamp_max(x, 5)").transforms,
+            vec![ValueOp::ClampMax(5.0)]
+        );
+        assert_eq!(
+            plan("clamp(x, 1, 9)").transforms,
+            vec![ValueOp::Clamp(1.0, 9.0)]
+        );
+    }
+
+    #[test]
+    fn scalar_arithmetic_appends_transform() {
+        assert_eq!(
+            plan("x * 8").transforms,
+            vec![ValueOp::Arith(ArithOp::Mul, 8.0, false)]
+        );
+        assert_eq!(
+            plan("1024 / x").transforms,
+            vec![ValueOp::Arith(ArithOp::Div, 1024.0, true)]
+        );
+        assert_eq!(
+            plan("x + 1").transforms,
+            vec![ValueOp::Arith(ArithOp::Add, 1.0, false)]
+        );
+    }
+
+    #[test]
+    fn math_over_rate_keeps_range_and_transform() {
+        let p = plan("abs(rate(x[5m]))");
+        assert_eq!(p.range.unwrap().function, RangeFn::Rate);
+        assert_eq!(p.transforms, vec![ValueOp::Abs]);
+    }
+
+    #[test]
+    fn nested_transforms_order_inner_to_outer() {
+        // abs(x) * 2 → abs first, then *2.
+        let p = plan("abs(x) * 2");
+        assert_eq!(
+            p.transforms,
+            vec![ValueOp::Abs, ValueOp::Arith(ArithOp::Mul, 2.0, false)]
+        );
+    }
+
+    #[test]
+    fn vector_binary_and_comparison_unsupported() {
+        assert!(matches!(err("x + y"), QuerierError::Unsupported(_)));
+        assert!(matches!(err("x > 5"), QuerierError::Unsupported(_)));
     }
 
     #[test]


### PR DESCRIPTION
Continues PromQL coverage (epic #328). Adds unary math functions and
scalar arithmetic as ordered value transforms on the result.

## Functions
- Math: `abs`, `ceil`, `floor`, `round`, `sqrt`, `exp`, `ln`, `log2`, `log10`,
  `sgn`, `clamp`, `clamp_min`, `clamp_max`.
- Scalar arithmetic: `metric OP scalar` and `scalar OP metric` for
  `+ - * / % ^` (e.g. `rate(bytes[5m]) * 8`, `1024 / node_memory`).

They compose with everything else — selectors, `rate`/`increase`,
`_over_time`, and `histogram_quantile` — applied in order to the output value
(`abs(x) * 2` → abs then ×2). Vector-to-vector and comparison operators remain
unsupported (documented, #335).

## Implementation
A `transforms: Vec<ValueOp>` on the plan, applied as a final DataFusion
projection for the DataFrame paths and in Rust for the histogram path.

## Tests
Translator (function/operator → transform, nesting order, vector-binary
rejection) and service-level (scalar mul/add/div, clamp) unit tests. Inventory
doc and query guide updated.