### PR TITLE
feat(querier): PromQL topk/bottomk selection (#328)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -36,9 +36,10 @@ wrong result.
 | Operator | Status |
 |----------|--------|
 | `sum`, `avg`, `min`, `max`, `count` (with/without `by (…)`) | ✅ |
+| `topk(k, …)`, `bottomk(k, …)` (no `by`/`without`) | ✅ |
 | `without (…)` grouping | ❌ |
 | `stddev`, `stdvar`, `group`, `count_values` | ❌ |
-| `topk`, `bottomk`, `quantile` (parameterized) | ❌ |
+| `quantile` (parameterized) | ❌ |
 
 ## Range (`[range]`) functions
 
@@ -85,6 +86,6 @@ wrong result.
 ## Roadmap
 
 Tracked under epic #328 and #335. Unsupported items above are being added
-incrementally; `topk`/`bottomk`, `irate`, and comparison operators are the next
-planned increments. Full vector-to-vector binary matching
+incrementally; comparison operators and `irate` are the next planned
+increments. Full vector-to-vector binary matching
 (`on`/`ignoring`/`group_left`) and subqueries are larger efforts.

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,7 +29,7 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, ValueOp, plan_promql,
+    ArithOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec, ValueOp, plan_promql,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -126,11 +126,18 @@ impl MetricsService {
         // Apply math / scalar-arithmetic transforms to the result value.
         let df = apply_transforms_df(df, &plan.transforms, &group_cols)?;
 
-        df.sort(vec![SortExpr::new(col("bucket"), true, true)])
+        let batches = df
+            .sort(vec![SortExpr::new(col("bucket"), true, true)])
             .map_err(QuerierError::QueryFailed)?
             .collect()
             .await
-            .map_err(QuerierError::QueryFailed)
+            .map_err(QuerierError::QueryFailed)?;
+
+        // `topk`/`bottomk`: keep the k highest/lowest series per bucket.
+        if let Some(spec) = plan.topk {
+            return apply_topk(batches, spec);
+        }
+        Ok(batches)
     }
 
     /// Aggregate `value` per (bucket, metric_name, group) directly.
@@ -864,6 +871,89 @@ fn arith_f64(op: ArithOp, v: f64, s: f64, scalar_left: bool) -> f64 {
     }
 }
 
+/// Keep the k highest (or lowest, for `bottomk`) series per bucket. The input
+/// matrix has columns `bucket`, `metric_name`, `service_name`, `value`.
+fn apply_topk(batches: Vec<RecordBatch>, spec: TopKSpec) -> Result<Vec<RecordBatch>, QuerierError> {
+    use std::cmp::Ordering;
+
+    if batches.is_empty() {
+        return Ok(batches);
+    }
+    let schema = batches[0].schema();
+
+    struct Row {
+        bucket: i64,
+        name: String,
+        service: String,
+        value: f64,
+    }
+    let mut rows: Vec<Row> = Vec::new();
+    for batch in &batches {
+        let bucket = batch
+            .column_by_name("bucket")
+            .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+            .ok_or_else(|| QuerierError::InvalidInput("bucket column missing".to_string()))?;
+        let name = string_column(batch, "metric_name")?;
+        let service = string_column(batch, "service_name")?;
+        let value = batch
+            .column_by_name("value")
+            .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+            .ok_or_else(|| QuerierError::InvalidInput("value column missing".to_string()))?;
+        for i in 0..batch.num_rows() {
+            rows.push(Row {
+                bucket: bucket.value(i),
+                name: name.value(i).to_string(),
+                service: if service.is_null(i) {
+                    String::new()
+                } else {
+                    service.value(i).to_string()
+                },
+                value: if value.is_null(i) {
+                    f64::NAN
+                } else {
+                    value.value(i)
+                },
+            });
+        }
+    }
+
+    // Rank within each bucket; BTreeMap keeps buckets in ascending order.
+    let mut by_bucket: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for (i, r) in rows.iter().enumerate() {
+        by_bucket.entry(r.bucket).or_default().push(i);
+    }
+    let mut keep: Vec<usize> = Vec::new();
+    for (_bucket, mut idxs) in by_bucket {
+        idxs.sort_by(|&a, &b| {
+            let (va, vb) = (rows[a].value, rows[b].value);
+            let ord = va.partial_cmp(&vb).unwrap_or(Ordering::Equal);
+            if spec.bottom { ord } else { ord.reverse() }
+        });
+        idxs.truncate(spec.k);
+        keep.extend(idxs);
+    }
+
+    let mut ts = Vec::with_capacity(keep.len());
+    let mut names = Vec::with_capacity(keep.len());
+    let mut services = Vec::with_capacity(keep.len());
+    let mut values = Vec::with_capacity(keep.len());
+    for &i in &keep {
+        ts.push(rows[i].bucket);
+        names.push(rows[i].name.clone());
+        services.push(rows[i].service.clone());
+        values.push(rows[i].value);
+    }
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(TimestampNanosecondArray::from(ts)),
+        Arc::new(StringArray::from(names)),
+        Arc::new(StringArray::from(services)),
+        Arc::new(Float64Array::from(values)),
+    ];
+    let out = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![out])
+}
+
 fn cast_ns(expr: Expr) -> Expr {
     datafusion::logical_expr::cast(expr, DataType::Timestamp(TimeUnit::Nanosecond, None))
 }
@@ -1191,6 +1281,24 @@ mod tests {
         // abs over a rate that is negative is not exercised here; abs of a
         // positive last value is a no-op.
         assert_eq!(by(matrix(&service, "abs(reqs)", 1000).await, "api"), 3.0);
+    }
+
+    #[tokio::test]
+    async fn topk_and_bottomk_select_series_per_bucket() {
+        let service = service_with_data();
+        // One bucket, series api=3 and web=5.
+        let top = matrix(&service, "topk(1, reqs)", 1000).await;
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].1.as_deref(), Some("web"));
+        assert_eq!(top[0].2, 5.0);
+
+        let bottom = matrix(&service, "bottomk(1, reqs)", 1000).await;
+        assert_eq!(bottom.len(), 1);
+        assert_eq!(bottom[0].1.as_deref(), Some("api"));
+        assert_eq!(bottom[0].2, 3.0);
+
+        // k larger than the series count keeps all.
+        assert_eq!(matrix(&service, "topk(5, reqs)", 1000).await.len(), 2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -17,6 +17,8 @@
 //!   `increase(metric[range])`, optionally under an outer aggregation.
 //! - The `<agg>_over_time(metric[range])` family (avg/sum/min/max/count/
 //!   last/stddev/stdvar) — a per-bucket reducer over the raw samples.
+//! - `topk(k, …)` / `bottomk(k, …)` — keep the k highest/lowest series per
+//!   bucket (no `by`/`without` grouping yet).
 //! - `histogram_quantile(phi, metric)` over a stored OTLP histogram — the
 //!   quantile is interpolated per series from the metric's buckets.
 //! - Unary math functions (`abs`, `ceil`, `floor`, `round`, `sqrt`, `exp`,
@@ -155,6 +157,17 @@ pub struct MetricPlan {
     /// Math/scalar-arithmetic transforms applied to the result `value`, in
     /// order (e.g. `abs`, `metric * 8`). Empty for a plain query.
     pub transforms: Vec<ValueOp>,
+    /// Set for `topk(k, …)` / `bottomk(k, …)` — after computing per-series
+    /// values, keep the k highest (or lowest) series per bucket.
+    pub topk: Option<TopKSpec>,
+}
+
+/// A `topk`/`bottomk` selection: keep `k` series per bucket, ranked by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TopKSpec {
+    pub k: usize,
+    /// `true` for `bottomk` (keep the lowest), `false` for `topk`.
+    pub bottom: bool,
 }
 
 impl Eq for MetricPlan {}
@@ -180,10 +193,15 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             build_plan(expr, MetricAgg::Last, Grouping::Natural)
         }
         Expr::Aggregate(agg) => {
-            let aggregate = aggregate_op(&format!("{}", agg.op))?;
+            let op = format!("{}", agg.op);
+            // `topk(k, expr)` / `bottomk(k, expr)`: rank series per bucket.
+            if op == "topk" || op == "bottomk" {
+                return lower_topk(agg, op == "bottomk");
+            }
+            let aggregate = aggregate_op(&op)?;
             if agg.param.is_some() {
                 return Err(QuerierError::Unsupported(
-                    "parameterized aggregation (topk/quantile/count_values)".to_string(),
+                    "parameterized aggregation (quantile/count_values)".to_string(),
                 ));
             }
             let grouping = grouping_from(agg.modifier.as_ref())?;
@@ -290,7 +308,32 @@ fn lower_selector(
         range,
         quantile: None,
         transforms: Vec::new(),
+        topk: None,
     })
+}
+
+/// Lower `topk(k, expr)` / `bottomk(k, expr)`. `k` must be a numeric literal;
+/// the inner expression is lowered with its natural per-series grouping and a
+/// [`TopKSpec`] selects the k highest/lowest series per bucket. `by`/`without`
+/// grouping on the selection itself is not supported yet (#335).
+fn lower_topk(agg: &parser::AggregateExpr, bottom: bool) -> Result<MetricPlan, QuerierError> {
+    let name = if bottom { "bottomk" } else { "topk" };
+    let k = match agg.param.as_deref().map(unwrap_paren) {
+        Some(Expr::NumberLiteral(n)) if n.val >= 0.0 => n.val as usize,
+        _ => {
+            return Err(QuerierError::Unsupported(format!(
+                "{name} requires a non-negative numeric literal k"
+            )));
+        }
+    };
+    if agg.modifier.is_some() {
+        return Err(QuerierError::Unsupported(format!(
+            "{name} with by/without grouping is not supported yet (#335)"
+        )));
+    }
+    let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Last, Grouping::Natural)?;
+    plan.topk = Some(TopKSpec { k, bottom });
+    Ok(plan)
 }
 
 /// Lower `histogram_quantile(phi, <selector>)`. The phi must be a numeric
@@ -716,12 +759,49 @@ mod tests {
     }
 
     #[test]
+    fn topk_and_bottomk() {
+        let t = plan("topk(2, x)");
+        assert_eq!(
+            t.topk,
+            Some(TopKSpec {
+                k: 2,
+                bottom: false
+            })
+        );
+        assert_eq!(t.grouping, Grouping::Natural);
+
+        let b = plan("bottomk(1, http_requests_total)");
+        assert_eq!(b.topk, Some(TopKSpec { k: 1, bottom: true }));
+
+        // Composes with a range function.
+        let r = plan("topk(3, rate(x[5m]))");
+        assert_eq!(
+            r.topk,
+            Some(TopKSpec {
+                k: 3,
+                bottom: false
+            })
+        );
+        assert_eq!(r.range.unwrap().function, RangeFn::Rate);
+    }
+
+    #[test]
+    fn topk_requires_literal_k_and_no_grouping() {
+        // The parser itself requires a scalar first argument.
+        assert!(plan_promql("topk(x, y)").is_err());
+        // by/without grouping on the selection is not supported yet.
+        assert!(matches!(
+            err("topk by (job) (2, x)"),
+            QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
     fn unsupported_shapes() {
         assert!(matches!(
             err(r#"irate(x[5m])"#),
             QuerierError::Unsupported(_)
         ));
-        assert!(matches!(err(r#"topk(5, x)"#), QuerierError::Unsupported(_)));
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
         assert!(matches!(
             err(r#"sum without (job) (x)"#),


### PR DESCRIPTION
Continues PromQL coverage (epic #328). Adds `topk`/`bottomk`.

`topk(k, expr)` / `bottomk(k, expr)` compute the per-series values, then keep
the k highest (topk) or lowest (bottomk) series **per bucket**, implemented as
a post-collection ranking over the result matrix. Composes with selectors,
`rate`/`increase`, and `_over_time`. `by`/`without` grouping on the selection
itself is not supported yet (#335).

## Tests
Translator (k parsing, range composition, scalar-k requirement, grouping
rejection) and service-level (topk/bottomk pick the right series, k>count keeps
all). Inventory doc updated.