### PR TITLE
docs(grafana): use pnpm for plugin build commands

### DIFF
--- a/docs/users/grafana-datasource.md
+++ b/docs/users/grafana-datasource.md
@@ -68,9 +68,9 @@ metric results.
 From the repository root:
 
 ```bash
-npm install               # install workspace dependencies
-npm run grafana:build     # build the frontend
-cd src/grafana-plugin && npm run build:backend   # build the Rust backend
+pnpm install                # install workspace dependencies
+pnpm run grafana:build      # build the frontend
+cd src/grafana-plugin && pnpm run build:backend   # build the Rust backend
 ```
 
 Copy the resulting `src/grafana-plugin/dist/` directory into Grafana's


### PR DESCRIPTION
The datasource how-to (`docs/users/grafana-datasource.md`) told users to run `npm install` / `npm run ...`, but the repo is pnpm-only:

- `packageManager: pnpm@9.15.4` in root `package.json`
- only `pnpm-lock.yaml` exists (no `package-lock.json`)
- `grafana:build` is a `pnpm --filter signaldb-datasource build` workspace script, and CI installs with `pnpm install --frozen-lockfile`

Running `npm install` at the root would ignore the pnpm workspace. Aligns the build steps with the actual toolchain.

Found while checking user-facing docs for accuracy alongside #680. The rest of the doc (config-fields table, "backend only supports flight" — confirmed at `backend/src/main.rs:21`) is accurate.