### PR TITLE
ci(docker): fix image publishing (packages:write + cache-export resilience)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,9 @@ jobs:
     name: Build Docker Image (amd64)
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v7
 
@@ -281,6 +284,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: check
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v7
 
@@ -324,6 +330,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker-build-amd64, docker-build-arm64]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64,ignore-error=true
 
   # Docker build for arm64 (only on main branch, not PRs)
   docker-build-arm64:
@@ -322,7 +322,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=arm64
-          cache-to: type=gha,mode=max,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64,ignore-error=true
 
   # Merge architecture-specific images into multi-arch manifest (main only)
   docker-manifest:


### PR DESCRIPTION
Two independent problems block the Docker publish job on `main`, both pre-existing and surfaced once the Dockerfile build fix (49bf16a) let the build reach these later steps.

## 1. Push denied — missing `packages: write`
```
denied: installation not allowed to Create organization package
```
The workflow has no `permissions:` block, so `GITHUB_TOKEN` is `packages: read`. Added scoped job-level `permissions: { contents: read, packages: write }` to the three GHCR-push jobs (amd64, arm64, manifest).

## 2. Cache export fails the build — `ERROR: not_found`
```
#43 exporting to GitHub Actions Cache
#43 ERROR: not_found
ERROR: failed to solve: not_found
```
The image compiles successfully, then `cache-to: type=gha,mode=max` fails against the GHA cache backend and sinks the whole job. Added `ignore-error=true` so a cache-export hiccup is a warning, not a failure.

## Verification caveats
- The **push** step only runs on `main`, so this PR's Docker job builds but does not push — the permissions fix is only truly exercised after merge. I'll watch the post-merge run.
- The cache `not_found` is a backend/perf issue; `ignore-error=true` stops it failing CI but the underlying cache miss means Docker builds stay slow (full recompile) until the cache backend is sorted. Follow-up worth filing.

## Alternative for #1
Repo Settings → Actions → Workflow permissions → *Read and write*. The workflow fix is version-controlled and scoped, so preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build and multi-architecture manifest workflows to use explicit job permissions required for successful container publishing.
  * Improved build caching resilience by allowing cache export to fail without breaking the workflow for amd64 and arm64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->