### PR TITLE
docs(skills): scope tempo-api glob to plugin source dirs

### DIFF
--- a/.claude/skills/tempo-api/SKILL.md
+++ b/.claude/skills/tempo-api/SKILL.md
@@ -5,7 +5,8 @@ user-invocable: false
 sources:
   - src/router/src/endpoints/tempo.rs
   - src/router/src/endpoints/admin.rs
-  - src/grafana-plugin/**
+  - src/grafana-plugin/src/**
+  - src/grafana-plugin/backend/src/**
 ---
 
 # SignalDB Tempo API Compatibility


### PR DESCRIPTION
## Problem
The `tempo-api` knowledge skill declared `src/grafana-plugin/**` in its `sources:` frontmatter. The doc-freshness check (`scripts/check-doc-freshness.sh`) therefore fired on **any** change under the plugin dir — including `package.json`/lockfile dependency bumps — even though the skill only describes the plugin's *architecture*, not its dependency versions.

This false-failed unrelated Dependabot PRs. Example (#586, prettier bump):
```
.claude/skills/tempo-api/SKILL.md — sources changed: src/grafana-plugin/package.json
```

## Fix
Narrow the glob to the source dirs the skill's content actually derives from:
- `src/grafana-plugin/src/**` (TS frontend query/config editors)
- `src/grafana-plugin/backend/src/**` (Rust backend → Flight)

Manifests (`package.json`), lockfiles, and tooling config (`tsconfig`, `eslint`, `jest`, …) sit directly under `src/grafana-plugin/` and no longer match, so dependency/tooling bumps stop tripping the check while real frontend/backend code changes still do.

Follows the docs skill's own guidance: "Keep globs tight: overly broad sources cause false nags, which get ignored."