### PR TITLE
fix(deps): scope brace-expansion override to preserve CJS lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "overrides": {
       "serialize-javascript@<=7.0.2": ">=7.0.3",
       "serialize-javascript@>=5.0.0 <7.0.5": ">=7.0.5",
-      "brace-expansion@<=5.0.7": ">=5.0.8"
+      "brace-expansion@>=1.0.0 <1.1.16": "1.1.16",
+      "brace-expansion@>=2.0.0 <2.0.2": "2.0.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,8 @@ settings:
 overrides:
   serialize-javascript@<=7.0.2: '>=7.0.3'
   serialize-javascript@>=5.0.0 <7.0.5: '>=7.0.5'
-  brace-expansion@<=5.0.7: '>=5.0.8'
+  brace-expansion@>=1.0.0 <1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.0.2: 2.0.2
 
 importers:
 
@@ -1969,6 +1970,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1980,6 +1984,12 @@ packages:
 
   body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
+
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -2108,6 +2118,9 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   continuable-cache@0.3.1:
     resolution: {integrity: sha512-TF30kpKhTH8AGCG3dut0rdd/19B7Z+qCnrMoBLpyQu/2drZdNrrpcjPEoJeSVsQM+8KmWG5O56oPDjSSUsuTyA==}
@@ -7190,6 +7203,8 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.11.1: {}
@@ -7200,6 +7215,15 @@ snapshots:
       error: 7.2.1
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
+
+  brace-expansion@1.1.16:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -7318,6 +7342,8 @@ snapshots:
   comment-parser@1.4.7: {}
 
   compute-scroll-into-view@3.1.1: {}
+
+  concat-map@0.0.1: {}
 
   continuable-cache@0.3.1: {}
 
@@ -8958,11 +8984,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 2.1.2
 
   minimizer-webpack-plugin@5.6.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack@5.109.0):
     dependencies:


### PR DESCRIPTION
## Regression
#684 added `brace-expansion@<=5.0.7 -> >=5.0.8`, which force-upgraded **every** brace-expansion in the tree — including eslint's CommonJS chain (`eslint -> minimatch@3 -> brace-expansion@1.x`) — to the ESM-only 5.x. That changed its export shape and broke the plugin lint on `main`:
```
TypeError: expand is not a function   (@eslint/config-array)
```
(surfaced on #586 and reproduced locally against main).

## Fix
Replace the broad override with major-line-scoped ones that apply the patched version *within each CJS line*:
- `brace-expansion@>=1.0.0 <1.1.16` -> `1.1.16`
- `brace-expansion@>=2.0.0 <2.0.2` -> `2.0.2`

eslint's 1.x consumer stays CommonJS and works again.

## Residual advisory
The brace-expansion advisory reachable via `eslint -> minimatch@3 -> brace-expansion@1.x` is not fully fixable on the 1.x line (only 2.x+/5.x carry the patch, and 5.x is ESM-incompatible with eslint's CJS chain). It remains until eslint bumps minimatch upstream — same class as the residual react-router/thrift advisories.

## Verification
- `pnpm lint` ✅ (0 errors)
- `pnpm typecheck` ✅
- `pnpm install --frozen-lockfile` ✅