### PR TITLE
feat(querier): PromQL stddev, stdvar, and group aggregations

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -37,8 +37,9 @@ wrong result.
 |----------|--------|
 | `sum`, `avg`, `min`, `max`, `count` (with/without `by (…)`) | ✅ |
 | `topk(k, …)`, `bottomk(k, …)` (no `by`/`without`) | ✅ |
+| `stddev`, `stdvar` (population), `group` (with/without `by (…)`) | ✅ |
 | `without (…)` grouping | ❌ |
-| `stddev`, `stdvar`, `group`, `count_values` | ❌ |
+| `count_values` | ❌ |
 | `quantile` (parameterized) | ❌ |
 
 ## Range (`[range]`) functions

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -667,6 +667,8 @@ fn aggregate_expr(agg: MetricAgg) -> Expr {
         MetricAgg::Count => count(value),
         MetricAgg::Stddev => stddev_pop(value),
         MetricAgg::StdVar => var_pop(value),
+        // `group()` yields a constant 1 for every output series.
+        MetricAgg::Group => max(lit(1.0_f64)),
         // Last value in the bucket, ordered by timestamp.
         MetricAgg::Last => last_value(value, vec![SortExpr::new(col("timestamp"), true, true)]),
     }

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -11,7 +11,8 @@
 //!
 //! - A bare selector `metric{label="v"}` — the series' samples, bucketed
 //!   by step (last value per bucket).
-//! - A vector aggregation `sum|avg|min|max|count [by (labels)] (metric)`.
+//! - A vector aggregation
+//!   `sum|avg|min|max|count|stddev|stdvar|group [by (labels)] (metric)`.
 //!
 //! - Range-vector functions `rate(metric[range])` and
 //!   `increase(metric[range])`, optionally under an outer aggregation.
@@ -47,10 +48,12 @@ pub enum MetricAgg {
     Min,
     Max,
     Count,
-    /// Population standard deviation (`stddev_over_time`).
+    /// Population standard deviation (`stddev`, `stddev_over_time`).
     Stddev,
-    /// Population variance (`stdvar_over_time`).
+    /// Population variance (`stdvar`, `stdvar_over_time`).
     StdVar,
+    /// `group(...)` — a constant `1` per output series.
+    Group,
 }
 
 /// How series are grouped.
@@ -492,6 +495,9 @@ fn aggregate_op(op: &str) -> Result<MetricAgg, QuerierError> {
         "min" => MetricAgg::Min,
         "max" => MetricAgg::Max,
         "count" => MetricAgg::Count,
+        "stddev" => MetricAgg::Stddev,
+        "stdvar" => MetricAgg::StdVar,
+        "group" => MetricAgg::Group,
         other => {
             return Err(QuerierError::Unsupported(format!(
                 "aggregation operator '{other}'"
@@ -632,6 +638,23 @@ mod tests {
         ] {
             assert_eq!(plan(q).aggregate, a, "{q}");
         }
+    }
+
+    #[test]
+    fn stddev_stdvar_group_aggregates() {
+        for (q, a) in [
+            ("stddev(x)", MetricAgg::Stddev),
+            ("stdvar(x)", MetricAgg::StdVar),
+            ("group(x)", MetricAgg::Group),
+        ] {
+            let p = plan(q);
+            assert_eq!(p.aggregate, a, "{q}");
+            assert_eq!(p.grouping, Grouping::Collapse, "{q}");
+        }
+        // With `by (…)` grouping.
+        let p = plan(r#"stddev by (job) (x)"#);
+        assert_eq!(p.aggregate, MetricAgg::Stddev);
+        assert_eq!(p.grouping, Grouping::By(vec!["job".into()]));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds three instant vector-aggregation operators to the PromQL query path:

- `stddev(v)` / `stdvar(v)` — population standard deviation / variance (the same aggregates already used by `stddev_over_time`/`stdvar_over_time`, now wired into the instant path).
- `group(v)` — yields a constant `1` per output series.

All three support `by (…)` grouping like the existing `sum`/`avg`/`min`/`max`/`count`.

## How

- `promql.rs`: `aggregate_op` maps `stddev`/`stdvar`/`group`; new `MetricAgg::Group`.
- `metrics.rs`: `aggregate_expr` lowers `Group` to `max(lit(1.0))`.
- Docs function inventory updated.

## Test

Unit test `stddev_stdvar_group_aggregates` covers lowering + `by` grouping. Full querier lib suite green.

Refs #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the PromQL `group` aggregation operator, including grouping by labels.
  * Added support for `stddev` and `stdvar` aggregation operators.

* **Documentation**
  * Updated PromQL support documentation to reflect the newly supported aggregation operators.
  * Clarified that `without (…)` grouping and `count_values` remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->