### PR TITLE
feat(querier): PromQL without(...) grouping

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -38,7 +38,7 @@ wrong result.
 | `sum`, `avg`, `min`, `max`, `count` (with/without `by (…)`) | ✅ |
 | `topk(k, …)`, `bottomk(k, …)` (no `by`/`without`) | ✅ |
 | `stddev`, `stdvar` (population), `group` (with/without `by (…)`) | ✅ |
-| `without (…)` grouping | ❌ |
+| `without (…)` grouping | ✅ (over `job`/`service`; attribute labels aren't materialized) |
 | `count_values` | ❌ |
 | `quantile` (parameterized) | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -348,6 +348,20 @@ impl MetricsService {
                     })
                 })
                 .collect(),
+            // `without (labels)` keeps every materialized dimension except
+            // the excluded ones. `service_name` (job/service) is the only
+            // groupable column, so drop it when it is excluded, otherwise
+            // keep it — matching `by` semantics over the supported labels.
+            Grouping::Without(labels) => {
+                let drops_service = labels
+                    .iter()
+                    .any(|l| column_for_label(l) == Some("service_name"));
+                if drops_service {
+                    Ok(vec![])
+                } else {
+                    Ok(vec!["service_name"])
+                }
+            }
         }
     }
 

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -65,6 +65,8 @@ pub enum Grouping {
     Collapse,
     /// Group by the given labels (`sum by (a, b) (metric)`).
     By(Vec<String>),
+    /// Group by every label except the given ones (`sum without (a) (metric)`).
+    Without(Vec<String>),
 }
 
 /// A label matcher on a selector (excluding `__name__`).
@@ -526,9 +528,7 @@ fn grouping_from(modifier: Option<&LabelModifier>) -> Result<Grouping, QuerierEr
         None => Ok(Grouping::Collapse),
         Some(LabelModifier::Include(labels)) => Ok(Grouping::By(labels.labels.clone())),
         Some(LabelModifier::Exclude(labels)) if labels.is_empty() => Ok(Grouping::Collapse),
-        Some(LabelModifier::Exclude(_)) => Err(QuerierError::Unsupported(
-            "'without (labels)' grouping".to_string(),
-        )),
+        Some(LabelModifier::Exclude(labels)) => Ok(Grouping::Without(labels.labels.clone())),
     }
 }
 
@@ -661,6 +661,18 @@ mod tests {
     fn without_empty_collapses() {
         // `sum without () (x)` collapses like a bare `sum`.
         assert_eq!(plan(r#"sum without () (x)"#).grouping, Grouping::Collapse);
+    }
+
+    #[test]
+    fn without_labels_grouping() {
+        assert_eq!(
+            plan(r#"sum without (job) (x)"#).grouping,
+            Grouping::Without(vec!["job".into()])
+        );
+        assert_eq!(
+            plan(r#"avg without (instance, code) (x)"#).grouping,
+            Grouping::Without(vec!["instance".into(), "code".into()])
+        );
     }
 
     #[test]
@@ -826,10 +838,6 @@ mod tests {
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
-        assert!(matches!(
-            err(r#"sum without (job) (x)"#),
-            QuerierError::Unsupported(_)
-        ));
         // histogram_quantile over an inner rate() is not lowered yet.
         assert!(matches!(
             err(r#"histogram_quantile(0.9, rate(x[5m]))"#),


### PR DESCRIPTION
## What

Lowers `<agg> without (labels) (metric)` (previously returned `Unsupported`).

## How

- `promql.rs`: new `Grouping::Without(labels)`; `grouping_from` maps a non-empty `Exclude` modifier to it (empty `without ()` still collapses).
- `metrics.rs`: `group_columns` keeps the materialized `service_name` dimension unless an excluded label (`job`/`service`) maps to it — matching `by (…)` semantics over the supported label surface. Attribute labels remain unmaterialized (same limit as `by`).
- Docs function inventory updated.

## Test

`without_labels_grouping` covers lowering; the stale "unsupported" assertion was removed. Querier lib suite green.

Refs #336