### PR TITLE
feat(querier): PromQL delta() range function

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -48,6 +48,7 @@ wrong result.
 |----------|--------|
 | `rate` | ✅ (counter delta ÷ range seconds) |
 | `increase` | ✅ (counter delta) |
+| `delta` | ✅ (gauge delta: last − first, no reset correction) |
 | `avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time` | ✅ |
 | `count_over_time`, `last_over_time` | ✅ |
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -189,7 +189,7 @@ impl MetricsService {
 
         let delta = col("last") - col("first");
         let per_series = match range.function {
-            RangeFn::Increase => delta,
+            RangeFn::Increase | RangeFn::Delta => delta,
             RangeFn::Rate => delta / lit(range.seconds),
         };
         let df = df

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -91,6 +91,9 @@ pub enum RangeFn {
     Rate,
     /// `increase(metric[range])` — total increase over the window.
     Increase,
+    /// `delta(metric[range])` — difference between the last and first sample
+    /// in the window (gauge delta; no counter-reset correction).
+    Delta,
 }
 
 /// A range-vector spec: the function and its window in seconds.
@@ -260,9 +263,10 @@ fn build_plan(
             let function = match call.func.name {
                 "rate" => RangeFn::Rate,
                 "increase" => RangeFn::Increase,
+                "delta" => RangeFn::Delta,
                 other => {
                     return Err(QuerierError::Unsupported(format!(
-                        "function '{other}' (supported: rate, increase, *_over_time)"
+                        "function '{other}' (supported: rate, increase, delta, *_over_time)"
                     )));
                 }
             };
@@ -685,6 +689,24 @@ mod tests {
                 seconds: 60.0
             })
         );
+    }
+
+    #[test]
+    fn delta_is_a_range_function() {
+        let d = plan(r#"delta(temperature{room="lab"}[10m])"#);
+        assert_eq!(d.metric_name, "temperature");
+        assert_eq!(
+            d.range,
+            Some(RangeSpec {
+                function: RangeFn::Delta,
+                seconds: 600.0
+            })
+        );
+        assert_eq!(d.grouping, Grouping::Natural);
+        // Composes under an outer aggregation like rate/increase.
+        let p = plan(r#"sum(delta(x[5m]))"#);
+        assert_eq!(p.aggregate, MetricAgg::Sum);
+        assert_eq!(p.range.unwrap().function, RangeFn::Delta);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `delta(metric[range])` = last − first sample in the window (the gauge counterpart to `increase`; no counter-reset correction, matching the existing simplified range model). Composes under an outer aggregation like `rate`/`increase`.

## How

- `promql.rs`: `RangeFn::Delta`; `build_plan` maps `delta`.
- `metrics.rs`: `range_query` treats `Delta` like `Increase` (raw last−first).
- Docs function inventory updated.

## Test

`delta_is_a_range_function` covers bare + `sum(delta(...))`. Querier lib suite green.

Refs #336