### PR TITLE
feat(querier): PromQL deriv() range function

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -49,6 +49,7 @@ wrong result.
 | `rate` | ✅ (counter delta ÷ range seconds) |
 | `increase` | ✅ (counter delta) |
 | `delta` | ✅ (gauge delta: last − first, no reset correction) |
+| `deriv` | ✅ (per-second slope via linear regression; needs ≥2 samples) |
 | `avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time` | ✅ |
 | `count_over_time`, `last_over_time` | ✅ |
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -22,9 +22,9 @@ use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
 use datafusion::functions_aggregate::expr_fn::{
-    avg, count, first_value, last_value, max, min, stddev_pop, sum, var_pop,
+    avg, count, first_value, last_value, max, min, regr_slope, stddev_pop, sum, var_pop,
 };
-use datafusion::logical_expr::{Expr, SortExpr, col, lit, not};
+use datafusion::logical_expr::{Expr, SortExpr, cast, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
@@ -175,31 +175,54 @@ impl MetricsService {
     ) -> Result<DataFrame, QuerierError> {
         use super::promql::RangeFn;
 
-        // Stage 1: (last - first)[/seconds] per (bucket, metric_name, service).
-        let order = vec![SortExpr::new(col("timestamp"), true, true)];
-        let df = df
-            .aggregate(
-                vec![bucket, col("metric_name"), col("service_name")],
-                vec![
-                    first_value(col("value"), order.clone()).alias("first"),
-                    last_value(col("value"), order).alias("last"),
-                ],
-            )
-            .map_err(QuerierError::QueryFailed)?;
-
-        let delta = col("last") - col("first");
-        let per_series = match range.function {
-            RangeFn::Increase | RangeFn::Delta => delta,
-            RangeFn::Rate => delta / lit(range.seconds),
+        // Stage 1: reduce each (bucket, metric_name, service) to one `value`.
+        let df = match range.function {
+            // `deriv`: per-second slope from a linear regression of the
+            // samples against time (nanoseconds → seconds).
+            RangeFn::Deriv => {
+                let secs = cast_value_f64(cast(cast_ns(col("timestamp")), DataType::Int64))
+                    / lit(1_000_000_000.0);
+                df.aggregate(
+                    vec![bucket, col("metric_name"), col("service_name")],
+                    vec![regr_slope(col("value"), secs).alias("value")],
+                )
+                .map_err(QuerierError::QueryFailed)?
+                .select(vec![
+                    col("bucket"),
+                    col("metric_name"),
+                    col("service_name"),
+                    cast_value_f64(col("value")).alias("value"),
+                ])
+                .map_err(QuerierError::QueryFailed)?
+            }
+            // rate/increase/delta: (last - first)[/seconds].
+            _ => {
+                let order = vec![SortExpr::new(col("timestamp"), true, true)];
+                let reduced = df
+                    .aggregate(
+                        vec![bucket, col("metric_name"), col("service_name")],
+                        vec![
+                            first_value(col("value"), order.clone()).alias("first"),
+                            last_value(col("value"), order).alias("last"),
+                        ],
+                    )
+                    .map_err(QuerierError::QueryFailed)?;
+                let delta = col("last") - col("first");
+                let per_series = match range.function {
+                    RangeFn::Increase | RangeFn::Delta => delta,
+                    RangeFn::Rate => delta / lit(range.seconds),
+                    RangeFn::Deriv => unreachable!("deriv handled above"),
+                };
+                reduced
+                    .select(vec![
+                        col("bucket"),
+                        col("metric_name"),
+                        col("service_name"),
+                        cast_value_f64(per_series).alias("value"),
+                    ])
+                    .map_err(QuerierError::QueryFailed)?
+            }
         };
-        let df = df
-            .select(vec![
-                col("bucket"),
-                col("metric_name"),
-                col("service_name"),
-                cast_value_f64(per_series).alias("value"),
-            ])
-            .map_err(QuerierError::QueryFailed)?;
 
         // Stage 2: an outer aggregation folds the per-series rates. A bare
         // `rate(...)` (Natural grouping over `service_name`) is already the
@@ -1171,6 +1194,19 @@ mod tests {
             .find(|(_, s, _)| s.as_deref() == Some("api"))
             .unwrap();
         assert!((api.2 - 2.0 / 60.0).abs() < 1e-9, "got {}", api.2);
+    }
+
+    #[tokio::test]
+    async fn deriv_is_regression_slope_per_second() {
+        let service = service_with_data();
+        // api samples: (t=100ns, 1), (t=200ns, 3). Slope over Δt=100ns is
+        // 2 / 100e-9 = 2e7 values/second.
+        let out = matrix(&service, "deriv(reqs[1m])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert!((api.2 - 2.0e7).abs() < 1.0, "got {}", api.2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -96,6 +96,9 @@ pub enum RangeFn {
     /// `delta(metric[range])` — difference between the last and first sample
     /// in the window (gauge delta; no counter-reset correction).
     Delta,
+    /// `deriv(metric[range])` — per-second derivative estimated by simple
+    /// linear regression of the samples against time.
+    Deriv,
 }
 
 /// A range-vector spec: the function and its window in seconds.
@@ -266,9 +269,10 @@ fn build_plan(
                 "rate" => RangeFn::Rate,
                 "increase" => RangeFn::Increase,
                 "delta" => RangeFn::Delta,
+                "deriv" => RangeFn::Deriv,
                 other => {
                     return Err(QuerierError::Unsupported(format!(
-                        "function '{other}' (supported: rate, increase, delta, *_over_time)"
+                        "function '{other}' (supported: rate, increase, delta, deriv, *_over_time)"
                     )));
                 }
             };
@@ -719,6 +723,24 @@ mod tests {
         let p = plan(r#"sum(delta(x[5m]))"#);
         assert_eq!(p.aggregate, MetricAgg::Sum);
         assert_eq!(p.range.unwrap().function, RangeFn::Delta);
+    }
+
+    #[test]
+    fn deriv_is_a_range_function() {
+        let d = plan(r#"deriv(disk_usage_bytes[1h])"#);
+        assert_eq!(d.metric_name, "disk_usage_bytes");
+        assert_eq!(
+            d.range,
+            Some(RangeSpec {
+                function: RangeFn::Deriv,
+                seconds: 3600.0
+            })
+        );
+        assert_eq!(d.grouping, Grouping::Natural);
+        // Composes under an outer aggregation.
+        let p = plan(r#"max(deriv(x[5m]))"#);
+        assert_eq!(p.aggregate, MetricAgg::Max);
+        assert_eq!(p.range.unwrap().function, RangeFn::Deriv);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `deriv(metric[range])` — the per-second derivative estimated by simple linear regression of the window's samples against time (Prometheus `deriv`).

## How

- `promql.rs`: `RangeFn::Deriv`; `build_plan` maps `deriv`.
- `metrics.rs`: `range_query` gains a per-function stage-1 reducer so `deriv` computes `regr_slope(value, time_seconds)` alongside the rate/increase/delta (last − first) path; the outer-aggregation stage is shared. Needs ≥2 samples in a bucket.

## Test

- Lowering: `deriv_is_a_range_function` (bare + under aggregation).
- Execution: `deriv_is_regression_slope_per_second` verifies the slope end-to-end against an in-memory table.

Refs #336