### PR TITLE
feat(querier): PromQL present_over_time()

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -54,7 +54,8 @@ wrong result.
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |
 | `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
 | `irate`, `idelta`, `delta`, `deriv`, `resets`, `changes` | ❌ |
-| `present_over_time`, `absent_over_time`, `quantile_over_time` | ❌ |
+| `present_over_time` | ✅ (1 per bucket with samples) |
+| `absent_over_time`, `quantile_over_time` | ❌ |
 
 ## Histograms
 

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -523,6 +523,9 @@ fn over_time_agg(name: &str) -> Option<MetricAgg> {
         "last_over_time" => MetricAgg::Last,
         "stddev_over_time" => MetricAgg::Stddev,
         "stdvar_over_time" => MetricAgg::StdVar,
+        // 1 for every bucket that has at least one sample (buckets with no
+        // sample produce no row, which is exactly `present_over_time`).
+        "present_over_time" => MetricAgg::Group,
         _ => return None,
     })
 }
@@ -740,6 +743,7 @@ mod tests {
             ("last_over_time(x[5m])", MetricAgg::Last),
             ("stddev_over_time(x[5m])", MetricAgg::Stddev),
             ("stdvar_over_time(x[5m])", MetricAgg::StdVar),
+            ("present_over_time(x[5m])", MetricAgg::Group),
         ] {
             let p = plan(q);
             assert_eq!(p.aggregate, a, "{q}");


### PR DESCRIPTION
## What

Adds `present_over_time(metric[range])`.

## How

Maps to the constant-`1` group reducer: every step bucket with ≥1 sample yields 1, and buckets with no sample produce no row — exactly `present_over_time`'s semantics. `promql.rs` `over_time_agg` maps the name to `MetricAgg::Group`.

## Test

`over_time_maps_to_reducer` covers the lowering; execution reuses the existing group-reducer path.

Refs #336