### PR TITLE
feat(querier): PromQL scalar comparison operators

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -69,8 +69,9 @@ wrong result.
 | Operator | Status |
 |----------|--------|
 | Arithmetic `+ - * / % ^` with a scalar (`metric * 8`, `1024 / metric`) | ✅ |
+| Comparison `== != > < >= <=` with a scalar (`metric > 5`, `5 < metric`) | ✅ (filters series; with `bool` maps to 1/0) |
 | Arithmetic between two vectors | ❌ |
-| Comparison `== != > < >= <=` | ❌ |
+| Comparison between two vectors | ❌ |
 | Logical/set `and`, `or`, `unless` | ❌ |
 | `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,7 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec, ValueOp, plan_promql,
+    ArithOp, CmpOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec, ValueOp,
+    plan_promql,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -125,6 +126,19 @@ impl MetricsService {
 
         // Apply math / scalar-arithmetic transforms to the result value.
         let df = apply_transforms_df(df, &plan.transforms, &group_cols)?;
+
+        // `vector CMP scalar` without `bool`: keep only matching samples.
+        let df = if let Some(cmp) = &plan.filter {
+            df.filter(cmp_bool_expr(
+                col("value"),
+                cmp.op,
+                cmp.scalar,
+                cmp.scalar_left,
+            ))
+            .map_err(QuerierError::QueryFailed)?
+        } else {
+            df
+        };
 
         let batches = df
             .sort(vec![SortExpr::new(col("bucket"), true, true)])
@@ -304,11 +318,18 @@ impl MetricsService {
         let mut services = Vec::with_capacity(groups.len());
         let mut values = Vec::with_capacity(groups.len());
         for ((bucket_ns, metric, service), acc) in groups {
+            let q = histogram_quantile(phi, &acc.bounds, &acc.counts);
+            let val = apply_transforms_f64(q, &plan.transforms);
+            // `vector CMP scalar` without `bool`: drop non-matching series.
+            if let Some(cmp) = &plan.filter
+                && !cmp_f64(val, cmp.op, cmp.scalar, cmp.scalar_left)
+            {
+                continue;
+            }
             ts.push(bucket_ns);
             names.push(metric);
             services.push(service);
-            let q = histogram_quantile(phi, &acc.bounds, &acc.counts);
-            values.push(apply_transforms_f64(q, &plan.transforms));
+            values.push(val);
         }
 
         let schema = Arc::new(Schema::new(vec![
@@ -826,9 +847,29 @@ fn apply_value_ops_expr(mut value: Expr, ops: &[ValueOp]) -> Expr {
                     .unwrap()
             }
             ValueOp::Arith(arith, s, scalar_left) => arith_expr(*arith, value, *s, *scalar_left),
+            ValueOp::CompareBool(op, s, scalar_left) => {
+                when(cmp_bool_expr(value, *op, *s, *scalar_left), lit(1.0_f64))
+                    .otherwise(lit(0.0_f64))
+                    .unwrap()
+            }
         };
     }
     value
+}
+
+/// Build a boolean `value CMP scalar` (or `scalar CMP value`) expression,
+/// used both for the `bool` value map and for comparison filtering.
+fn cmp_bool_expr(value: Expr, op: CmpOp, scalar: f64, scalar_left: bool) -> Expr {
+    let s = lit(scalar);
+    let (l, r) = if scalar_left { (s, value) } else { (value, s) };
+    match op {
+        CmpOp::Eq => l.eq(r),
+        CmpOp::Ne => l.not_eq(r),
+        CmpOp::Gt => l.gt(r),
+        CmpOp::Lt => l.lt(r),
+        CmpOp::Ge => l.gt_eq(r),
+        CmpOp::Le => l.lt_eq(r),
+    }
 }
 
 /// Build `value OP scalar` (or `scalar OP value`) as an expression.
@@ -867,9 +908,33 @@ fn apply_transforms_f64(mut v: f64, ops: &[ValueOp]) -> f64 {
             ValueOp::ClampMax(m) => v.min(*m),
             ValueOp::Clamp(lo, hi) => v.clamp(*lo, *hi),
             ValueOp::Arith(arith, s, scalar_left) => arith_f64(*arith, v, *s, *scalar_left),
+            ValueOp::CompareBool(op, s, scalar_left) => {
+                if cmp_f64(v, *op, *s, *scalar_left) {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
         };
     }
     v
+}
+
+/// Evaluate a scalar comparison for the histogram (row-wise) path.
+fn cmp_f64(v: f64, op: CmpOp, scalar: f64, scalar_left: bool) -> bool {
+    let (l, r) = if scalar_left {
+        (scalar, v)
+    } else {
+        (v, scalar)
+    };
+    match op {
+        CmpOp::Eq => l == r,
+        CmpOp::Ne => l != r,
+        CmpOp::Gt => l > r,
+        CmpOp::Lt => l < r,
+        CmpOp::Ge => l >= r,
+        CmpOp::Le => l <= r,
+    }
 }
 
 fn arith_f64(op: ArithOp, v: f64, s: f64, scalar_left: bool) -> f64 {
@@ -1297,6 +1362,40 @@ mod tests {
         // abs over a rate that is negative is not exercised here; abs of a
         // positive last value is a no-op.
         assert_eq!(by(matrix(&service, "abs(reqs)", 1000).await, "api"), 3.0);
+    }
+
+    #[tokio::test]
+    async fn scalar_comparison_filters_series() {
+        let service = service_with_data();
+        // Bare selector → api=3, web=5. `reqs > 4` keeps only web.
+        let out = matrix(&service, "reqs > 4", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].1.as_deref(), Some("web"));
+        assert_eq!(out[0].2, 5.0);
+
+        // `4 < reqs` is equivalent (scalar on the left).
+        let out = matrix(&service, "4 < reqs", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].1.as_deref(), Some("web"));
+
+        // No series match → empty result.
+        assert!(matrix(&service, "reqs > 100", 1000).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scalar_comparison_bool_maps_to_one_or_zero() {
+        let service = service_with_data();
+        // `reqs > bool 4`: api(3) → 0, web(5) → 1. Both series retained.
+        let out = matrix(&service, "reqs > bool 4", 1000).await;
+        let by = |svc: &str| {
+            out.iter()
+                .find(|(_, s, _)| s.as_deref() == Some(svc))
+                .unwrap()
+                .2
+        };
+        assert_eq!(out.len(), 2);
+        assert_eq!(by("api"), 0.0);
+        assert_eq!(by("web"), 1.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -26,9 +26,11 @@
 //!   `ln`, `log2`, `log10`, `sgn`, `clamp*`) and scalar arithmetic
 //!   (`metric * 8`, `1024 / metric`) as value transforms on the result.
 //!
-//! `irate`, comparison/logical/vector-to-vector operators, subqueries, and
-//! `histogram_quantile` over an inner `rate()`/aggregation are not lowered yet
-//! and return [`QuerierError::Unsupported`] (#335).
+//! Scalar comparisons (`metric > 5`, `5 < metric`, with an optional `bool`
+//! modifier) filter the result or map it to 1/0. `irate`, logical and
+//! vector-to-vector operators, subqueries, and `histogram_quantile` over an
+//! inner `rate()`/aggregation are not lowered yet and return
+//! [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -118,6 +120,29 @@ pub enum ArithOp {
     Pow,
 }
 
+/// A comparison operator in a `vector OP scalar` expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Gt,
+    Lt,
+    Ge,
+    Le,
+}
+
+/// A `vector CMP scalar` comparison used as a filter (Prometheus keeps the
+/// series where the comparison holds). `scalar_left` is true for
+/// `scalar CMP vector` (e.g. `5 < metric`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScalarCompare {
+    pub op: CmpOp,
+    pub scalar: f64,
+    pub scalar_left: bool,
+}
+
+impl Eq for ScalarCompare {}
+
 /// A transform applied to the result `value` column, in order. Covers the
 /// unary math functions and scalar arithmetic (`metric * 8`, `metric / 1024`).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -139,6 +164,9 @@ pub enum ValueOp {
     /// Scalar arithmetic; the bool is true when the scalar is on the left
     /// (`scalar OP vector`), false for `vector OP scalar`.
     Arith(ArithOp, f64, bool),
+    /// `vector CMP scalar bool` — map each value to 1 or 0 depending on the
+    /// comparison. The bool is true when the scalar is on the left.
+    CompareBool(CmpOp, f64, bool),
 }
 
 impl Eq for ValueOp {}
@@ -168,6 +196,9 @@ pub struct MetricPlan {
     /// Set for `topk(k, …)` / `bottomk(k, …)` — after computing per-series
     /// values, keep the k highest (or lowest) series per bucket.
     pub topk: Option<TopKSpec>,
+    /// Set for a `vector CMP scalar` comparison without `bool` — keep only
+    /// the samples where the comparison holds.
+    pub filter: Option<ScalarCompare>,
 }
 
 /// A `topk`/`bottomk` selection: keep `k` series per bucket, ranked by value.
@@ -318,6 +349,7 @@ fn lower_selector(
         quantile: None,
         transforms: Vec::new(),
         topk: None,
+        filter: None,
     })
 }
 
@@ -429,9 +461,7 @@ fn lower_math_call(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
 /// operations are not (#335).
 fn lower_binary(bin: &parser::BinaryExpr) -> Result<MetricPlan, QuerierError> {
     if bin.op.is_comparison_operator() {
-        return Err(QuerierError::Unsupported(
-            "comparison operators".to_string(),
-        ));
+        return lower_comparison(bin);
     }
     let arith = match format!("{}", bin.op).as_str() {
         "+" => ArithOp::Add,
@@ -466,6 +496,62 @@ fn lower_binary(bin: &parser::BinaryExpr) -> Result<MetricPlan, QuerierError> {
             Ok(plan)
         }
     }
+}
+
+/// Lower a `vector CMP scalar` (or `scalar CMP vector`) comparison. Without
+/// the `bool` modifier this filters the series to those where the comparison
+/// holds; with `bool` it maps each value to 1/0. Vector-to-vector comparison
+/// stays unsupported (#335).
+fn lower_comparison(bin: &parser::BinaryExpr) -> Result<MetricPlan, QuerierError> {
+    let op = match format!("{}", bin.op).as_str() {
+        "==" => CmpOp::Eq,
+        "!=" => CmpOp::Ne,
+        ">" => CmpOp::Gt,
+        "<" => CmpOp::Lt,
+        ">=" => CmpOp::Ge,
+        "<=" => CmpOp::Le,
+        other => {
+            return Err(QuerierError::Unsupported(format!(
+                "comparison operator '{other}'"
+            )));
+        }
+    };
+    let return_bool = bin
+        .modifier
+        .as_ref()
+        .map(|m| m.return_bool)
+        .unwrap_or(false);
+    let (mut plan, scalar, scalar_left) = match (as_scalar(&bin.lhs), as_scalar(&bin.rhs)) {
+        (Some(_), Some(_)) => {
+            return Err(QuerierError::Unsupported(
+                "constant-only comparison".to_string(),
+            ));
+        }
+        (None, None) => {
+            return Err(QuerierError::Unsupported(
+                "vector-to-vector comparison".to_string(),
+            ));
+        }
+        // scalar CMP vector
+        (Some(s), None) => (lower(unwrap_paren(&bin.rhs))?, s, true),
+        // vector CMP scalar
+        (None, Some(s)) => (lower(unwrap_paren(&bin.lhs))?, s, false),
+    };
+    if return_bool {
+        plan.transforms
+            .push(ValueOp::CompareBool(op, scalar, scalar_left));
+    } else if plan.filter.is_some() {
+        return Err(QuerierError::Unsupported(
+            "chained comparison filters".to_string(),
+        ));
+    } else {
+        plan.filter = Some(ScalarCompare {
+            op,
+            scalar,
+            scalar_left,
+        });
+    }
+    Ok(plan)
 }
 
 /// The `i`-th call argument as a numeric literal.
@@ -810,9 +896,58 @@ mod tests {
     }
 
     #[test]
-    fn vector_binary_and_comparison_unsupported() {
+    fn vector_binary_and_vector_comparison_unsupported() {
         assert!(matches!(err("x + y"), QuerierError::Unsupported(_)));
-        assert!(matches!(err("x > 5"), QuerierError::Unsupported(_)));
+        // Vector-to-vector comparison stays unsupported.
+        assert!(matches!(err("x > y"), QuerierError::Unsupported(_)));
+    }
+
+    #[test]
+    fn scalar_comparison_sets_filter() {
+        for (q, op, scalar, left) in [
+            ("x > 5", CmpOp::Gt, 5.0, false),
+            ("x == 0", CmpOp::Eq, 0.0, false),
+            ("x != 0", CmpOp::Ne, 0.0, false),
+            ("x <= 10", CmpOp::Le, 10.0, false),
+            ("5 < x", CmpOp::Lt, 5.0, true),
+        ] {
+            let p = plan(q);
+            assert_eq!(
+                p.filter,
+                Some(ScalarCompare {
+                    op,
+                    scalar,
+                    scalar_left: left
+                }),
+                "{q}"
+            );
+            assert!(p.transforms.is_empty(), "{q}");
+        }
+    }
+
+    #[test]
+    fn bool_comparison_appends_transform() {
+        let p = plan("x > bool 5");
+        assert!(p.filter.is_none());
+        assert_eq!(
+            p.transforms,
+            vec![ValueOp::CompareBool(CmpOp::Gt, 5.0, false)]
+        );
+    }
+
+    #[test]
+    fn comparison_composes_with_aggregation() {
+        // Filter applies to the aggregated result.
+        let p = plan("sum(x) > 100");
+        assert_eq!(p.aggregate, MetricAgg::Sum);
+        assert_eq!(
+            p.filter,
+            Some(ScalarCompare {
+                op: CmpOp::Gt,
+                scalar: 100.0,
+                scalar_left: false
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Lowers `vector CMP scalar` / `scalar CMP vector` comparisons (`== != > < >= <=`) — previously `Unsupported`. Ubiquitous in alerting-style queries.

- Without `bool`: filters the result to samples where the comparison holds (`http_errors > 0`).
- With `bool`: maps each value to 1/0 (`up == bool 1`).

Vector-to-vector comparison stays unsupported (tracked with the vector-matching epic).

## How

- `promql.rs`: `CmpOp`, `ScalarCompare`, `ValueOp::CompareBool`, `MetricPlan.filter`; `lower_comparison` handles both operand orders and the `bool` modifier.
- `metrics.rs`: shared `cmp_bool_expr`/`cmp_f64`; filter applied on both the matrix path (`df.filter`) and the `histogram_quantile` row path; `bool` reuses the value-transform pipeline.

## Test

Lowering (`scalar_comparison_sets_filter`, `bool_comparison_appends_transform`, `comparison_composes_with_aggregation`) and execution (`scalar_comparison_filters_series`, `scalar_comparison_bool_maps_to_one_or_zero`) against an in-memory table.

Refs #336