### PR TITLE
feat(querier): PromQL irate() and idelta() range functions

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -50,11 +50,12 @@ wrong result.
 | `increase` | ✅ (counter delta) |
 | `delta` | ✅ (gauge delta: last − first, no reset correction) |
 | `deriv` | ✅ (per-second slope via linear regression; needs ≥2 samples) |
+| `irate`, `idelta` | ✅ (from the last two samples in the window) |
 | `avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time` | ✅ |
 | `count_over_time`, `last_over_time` | ✅ |
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |
 | `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
-| `irate`, `idelta`, `delta`, `deriv`, `resets`, `changes` | ❌ |
+| `resets`, `changes` | ❌ |
 | `present_over_time` | ✅ (1 per bucket with samples) |
 | `absent_over_time`, `quantile_over_time` | ❌ |
 
@@ -90,7 +91,7 @@ wrong result.
 
 ## Roadmap
 
-Tracked under epic #328 and #335. Unsupported items above are being added
-incrementally; comparison operators and `irate` are the next planned
-increments. Full vector-to-vector binary matching
-(`on`/`ignoring`/`group_left`) and subqueries are larger efforts.
+Tracked under epic #328 and #336. Unsupported items above are being added
+incrementally. Full vector-to-vector binary matching
+(`on`/`ignoring`/`group_left`) and subqueries are the larger remaining
+efforts.

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -22,7 +22,7 @@ use datafusion::functions::datetime::expr_fn::date_bin;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
 use datafusion::functions_aggregate::expr_fn::{
-    avg, count, first_value, last_value, max, min, regr_slope, stddev_pop, sum, var_pop,
+    avg, count, first_value, last_value, max, min, nth_value, regr_slope, stddev_pop, sum, var_pop,
 };
 use datafusion::logical_expr::{Expr, SortExpr, cast, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
@@ -209,6 +209,37 @@ impl MetricsService {
                 ])
                 .map_err(QuerierError::QueryFailed)?
             }
+            // `irate`/`idelta`: the last two samples in the window.
+            RangeFn::Irate | RangeFn::Idelta => {
+                let order = vec![SortExpr::new(col("timestamp"), true, true)];
+                let secs = cast_value_f64(cast(cast_ns(col("timestamp")), DataType::Int64))
+                    / lit(1_000_000_000.0);
+                let reduced = df
+                    .aggregate(
+                        vec![bucket, col("metric_name"), col("service_name")],
+                        vec![
+                            nth_value(col("value"), -1, order.clone()).alias("v_last"),
+                            nth_value(col("value"), -2, order.clone()).alias("v_prev"),
+                            nth_value(secs.clone(), -1, order.clone()).alias("t_last"),
+                            nth_value(secs, -2, order).alias("t_prev"),
+                        ],
+                    )
+                    .map_err(QuerierError::QueryFailed)?;
+                let d = col("v_last") - col("v_prev");
+                let per_series = match range.function {
+                    RangeFn::Idelta => d,
+                    RangeFn::Irate => d / (col("t_last") - col("t_prev")),
+                    _ => unreachable!("only irate/idelta here"),
+                };
+                reduced
+                    .select(vec![
+                        col("bucket"),
+                        col("metric_name"),
+                        col("service_name"),
+                        cast_value_f64(per_series).alias("value"),
+                    ])
+                    .map_err(QuerierError::QueryFailed)?
+            }
             // rate/increase/delta: (last - first)[/seconds].
             _ => {
                 let order = vec![SortExpr::new(col("timestamp"), true, true)];
@@ -225,7 +256,9 @@ impl MetricsService {
                 let per_series = match range.function {
                     RangeFn::Increase | RangeFn::Delta => delta,
                     RangeFn::Rate => delta / lit(range.seconds),
-                    RangeFn::Deriv => unreachable!("deriv handled above"),
+                    RangeFn::Deriv | RangeFn::Irate | RangeFn::Idelta => {
+                        unreachable!("handled above")
+                    }
                 };
                 reduced
                     .select(vec![
@@ -1267,6 +1300,26 @@ mod tests {
         // api samples: (t=100ns, 1), (t=200ns, 3). Slope over Δt=100ns is
         // 2 / 100e-9 = 2e7 values/second.
         let out = matrix(&service, "deriv(reqs[1m])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert!((api.2 - 2.0e7).abs() < 1.0, "got {}", api.2);
+    }
+
+    #[tokio::test]
+    async fn irate_and_idelta_use_last_two_samples() {
+        let service = service_with_data();
+        // api samples: (100ns, 1), (200ns, 3). idelta = 3 - 1 = 2.
+        let out = matrix(&service, "idelta(reqs[1m])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 2.0);
+
+        // irate = 2 / (Δt = 100ns = 1e-7 s) = 2e7.
+        let out = matrix(&service, "irate(reqs[1m])", 1000).await;
         let api = out
             .iter()
             .find(|(_, s, _)| s.as_deref() == Some("api"))

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -27,7 +27,7 @@
 //!   (`metric * 8`, `1024 / metric`) as value transforms on the result.
 //!
 //! Scalar comparisons (`metric > 5`, `5 < metric`, with an optional `bool`
-//! modifier) filter the result or map it to 1/0. `irate`, logical and
+//! modifier) filter the result or map it to 1/0. Logical and
 //! vector-to-vector operators, subqueries, and `histogram_quantile` over an
 //! inner `rate()`/aggregation are not lowered yet and return
 //! [`QuerierError::Unsupported`] (#335).
@@ -101,6 +101,11 @@ pub enum RangeFn {
     /// `deriv(metric[range])` — per-second derivative estimated by simple
     /// linear regression of the samples against time.
     Deriv,
+    /// `irate(metric[range])` — per-second instant rate from the last two
+    /// samples in the window.
+    Irate,
+    /// `idelta(metric[range])` — difference between the last two samples.
+    Idelta,
 }
 
 /// A range-vector spec: the function and its window in seconds.
@@ -301,9 +306,12 @@ fn build_plan(
                 "increase" => RangeFn::Increase,
                 "delta" => RangeFn::Delta,
                 "deriv" => RangeFn::Deriv,
+                "irate" => RangeFn::Irate,
+                "idelta" => RangeFn::Idelta,
                 other => {
                     return Err(QuerierError::Unsupported(format!(
-                        "function '{other}' (supported: rate, increase, delta, deriv, *_over_time)"
+                        "function '{other}' (supported: rate, increase, delta, deriv, irate, \
+                         idelta, *_over_time)"
                     )));
                 }
             };
@@ -833,6 +841,18 @@ mod tests {
     }
 
     #[test]
+    fn irate_and_idelta_are_range_functions() {
+        for (q, f) in [
+            ("irate(x[5m])", RangeFn::Irate),
+            ("idelta(x[5m])", RangeFn::Idelta),
+        ] {
+            let p = plan(q);
+            assert_eq!(p.range.unwrap().function, f, "{q}");
+            assert_eq!(p.grouping, Grouping::Natural, "{q}");
+        }
+    }
+
+    #[test]
     fn sum_over_rate() {
         let p = plan(r#"sum(rate(http_requests_total[5m]))"#);
         assert_eq!(p.aggregate, MetricAgg::Sum);
@@ -1017,7 +1037,7 @@ mod tests {
     #[test]
     fn unsupported_shapes() {
         assert!(matches!(
-            err(r#"irate(x[5m])"#),
+            err(r#"resets(x[5m])"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));


### PR DESCRIPTION
## What

Adds `irate(metric[range])` and `idelta(metric[range])` — the instant rate / delta from the **last two samples** in each window.

## How

- `promql.rs`: `RangeFn::Irate`/`Idelta`; `build_plan` maps them.
- `metrics.rs`: a new stage-1 reducer aggregates each bucket with `nth_value(-1)`/`nth_value(-2)` ordered by timestamp; `idelta` = last − prev, `irate` = that ÷ the samples' time gap in seconds. Buckets with fewer than two samples yield no value (Prometheus semantics).

## Test

Lowering (`irate_and_idelta_are_range_functions`) and execution (`irate_and_idelta_use_last_two_samples`) against an in-memory table.

Refs #336