### PR TITLE
feat(querier): PromQL quantile(phi, …) aggregation

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -39,8 +39,8 @@ wrong result.
 | `topk(k, …)`, `bottomk(k, …)` (no `by`/`without`) | ✅ |
 | `stddev`, `stdvar` (population), `group` (with/without `by (…)`) | ✅ |
 | `without (…)` grouping | ✅ (over `job`/`service`; attribute labels aren't materialized) |
+| `quantile(phi, …)` (parameterized, with/without `by (…)`) | ✅ |
 | `count_values` | ❌ |
-| `quantile` (parameterized) | ❌ |
 
 ## Range (`[range]`) functions
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -119,9 +119,16 @@ impl MetricsService {
         let bucket = bucket_expr(step);
 
         let df = if let Some(range) = plan.range {
-            self.range_query(df, bucket, range, plan.aggregate, &group_cols)?
+            self.range_query(
+                df,
+                bucket,
+                range,
+                plan.aggregate,
+                plan.agg_param,
+                &group_cols,
+            )?
         } else {
-            self.simple_query(df, bucket, plan.aggregate, &group_cols)?
+            self.simple_query(df, bucket, plan.aggregate, plan.agg_param, &group_cols)?
         };
 
         // Apply math / scalar-arithmetic transforms to the result value.
@@ -160,12 +167,13 @@ impl MetricsService {
         df: DataFrame,
         bucket: Expr,
         aggregate: MetricAgg,
+        param: Option<f64>,
         group_cols: &[&str],
     ) -> Result<DataFrame, QuerierError> {
         let mut group_exprs = vec![bucket, col("metric_name")];
         group_exprs.extend(group_cols.iter().map(|c| col(*c)));
 
-        let value = aggregate_expr(aggregate).alias("value");
+        let value = aggregate_expr(aggregate, param).alias("value");
         let df = df
             .aggregate(group_exprs, vec![value])
             .map_err(QuerierError::QueryFailed)?;
@@ -185,6 +193,7 @@ impl MetricsService {
         bucket: Expr,
         range: super::promql::RangeSpec,
         aggregate: MetricAgg,
+        param: Option<f64>,
         group_cols: &[&str],
     ) -> Result<DataFrame, QuerierError> {
         use super::promql::RangeFn;
@@ -280,7 +289,10 @@ impl MetricsService {
         let mut group_exprs = vec![col("bucket"), col("metric_name")];
         group_exprs.extend(group_cols.iter().map(|c| col(*c)));
         let df = df
-            .aggregate(group_exprs, vec![aggregate_expr(aggregate).alias("value")])
+            .aggregate(
+                group_exprs,
+                vec![aggregate_expr(aggregate, param).alias("value")],
+            )
             .map_err(QuerierError::QueryFailed)?;
         let mut proj = vec![col("bucket"), col("metric_name")];
         proj.extend(group_cols.iter().map(|c| col(*c)));
@@ -748,7 +760,8 @@ fn attribute_fragment(key: &str, value: &str) -> String {
     format!("{json_key}:{json_value}")
 }
 
-fn aggregate_expr(agg: MetricAgg) -> Expr {
+fn aggregate_expr(agg: MetricAgg, param: Option<f64>) -> Expr {
+    use datafusion::functions_aggregate::expr_fn::percentile_cont;
     let value = col("value");
     match agg {
         MetricAgg::Sum => sum(value),
@@ -760,6 +773,11 @@ fn aggregate_expr(agg: MetricAgg) -> Expr {
         MetricAgg::StdVar => var_pop(value),
         // `group()` yields a constant 1 for every output series.
         MetricAgg::Group => max(lit(1.0_f64)),
+        // `quantile(phi, …)` — the phi-quantile of the grouped values.
+        MetricAgg::Quantile => {
+            let phi = param.unwrap_or(0.5);
+            percentile_cont(SortExpr::new(value, true, true), lit(phi))
+        }
         // Last value in the bucket, ordered by timestamp.
         MetricAgg::Last => last_value(value, vec![SortExpr::new(col("timestamp"), true, true)]),
     }
@@ -1230,6 +1248,18 @@ mod tests {
         let out = matrix(&service, "sum(reqs)", 1000).await;
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].2, 9.0); // 1+3+5
+    }
+
+    #[tokio::test]
+    async fn quantile_is_percentile_across_the_bucket() {
+        let service = service_with_data();
+        // Values in the bucket are [1, 3, 5]; the 0.5-quantile (median) is 3.
+        let out = matrix(&service, "quantile(0.5, reqs)", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert!((out[0].2 - 3.0).abs() < 1e-9, "got {}", out[0].2);
+        // The 0-quantile is the minimum.
+        let out = matrix(&service, "quantile(0, reqs)", 1000).await;
+        assert!((out[0].2 - 1.0).abs() < 1e-9, "got {}", out[0].2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -56,6 +56,9 @@ pub enum MetricAgg {
     StdVar,
     /// `group(...)` — a constant `1` per output series.
     Group,
+    /// `quantile(phi, …)` — the phi-quantile across series (phi is carried in
+    /// [`MetricPlan::agg_param`]).
+    Quantile,
 }
 
 /// How series are grouped.
@@ -207,6 +210,8 @@ pub struct MetricPlan {
     /// Set for a `vector CMP scalar` comparison without `bool` — keep only
     /// the samples where the comparison holds.
     pub filter: Option<ScalarCompare>,
+    /// The phi for a parameterized `quantile(phi, …)` aggregation.
+    pub agg_param: Option<f64>,
 }
 
 /// A `topk`/`bottomk` selection: keep `k` series per bucket, ranked by value.
@@ -245,10 +250,13 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             if op == "topk" || op == "bottomk" {
                 return lower_topk(agg, op == "bottomk");
             }
+            if op == "quantile" {
+                return lower_quantile(agg);
+            }
             let aggregate = aggregate_op(&op)?;
             if agg.param.is_some() {
                 return Err(QuerierError::Unsupported(
-                    "parameterized aggregation (quantile/count_values)".to_string(),
+                    "parameterized aggregation (count_values)".to_string(),
                 ));
             }
             let grouping = grouping_from(agg.modifier.as_ref())?;
@@ -362,6 +370,7 @@ fn lower_selector(
         transforms: Vec::new(),
         topk: None,
         filter: None,
+        agg_param: None,
     })
 }
 
@@ -386,6 +395,24 @@ fn lower_topk(agg: &parser::AggregateExpr, bottom: bool) -> Result<MetricPlan, Q
     }
     let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Last, Grouping::Natural)?;
     plan.topk = Some(TopKSpec { k, bottom });
+    Ok(plan)
+}
+
+/// Lower `quantile(phi, expr)` — the phi-quantile across the grouped series.
+/// phi must be a numeric literal; it is carried in [`MetricPlan::agg_param`]
+/// and evaluated with `percentile_cont` at execution time.
+fn lower_quantile(agg: &parser::AggregateExpr) -> Result<MetricPlan, QuerierError> {
+    let phi = match agg.param.as_deref().map(unwrap_paren) {
+        Some(Expr::NumberLiteral(n)) => n.val,
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "quantile requires a numeric literal phi".to_string(),
+            ));
+        }
+    };
+    let grouping = grouping_from(agg.modifier.as_ref())?;
+    let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Quantile, grouping)?;
+    plan.agg_param = Some(phi);
     Ok(plan)
 }
 
@@ -759,6 +786,19 @@ mod tests {
         // With `by (…)` grouping.
         let p = plan(r#"stddev by (job) (x)"#);
         assert_eq!(p.aggregate, MetricAgg::Stddev);
+        assert_eq!(p.grouping, Grouping::By(vec!["job".into()]));
+    }
+
+    #[test]
+    fn quantile_aggregation_carries_phi() {
+        let p = plan("quantile(0.9, x)");
+        assert_eq!(p.aggregate, MetricAgg::Quantile);
+        assert_eq!(p.agg_param, Some(0.9));
+        assert_eq!(p.grouping, Grouping::Collapse);
+        // With grouping.
+        let p = plan("quantile by (job) (0.5, x)");
+        assert_eq!(p.aggregate, MetricAgg::Quantile);
+        assert_eq!(p.agg_param, Some(0.5));
         assert_eq!(p.grouping, Grouping::By(vec!["job".into()]));
     }
 


### PR DESCRIPTION
## What

Adds the parameterized `quantile(phi, v)` aggregation (with/without `by`/`without` grouping).

## How

- `promql.rs`: `MetricAgg::Quantile`; `MetricPlan::agg_param` carries phi; `lower_quantile` handles the aggregate's parameter.
- `metrics.rs`: `aggregate_expr` takes the param and evaluates `percentile_cont(value, phi)`; threaded through `simple_query`/`range_query`.
- Consistent with the other instant aggregations, which reduce the raw samples per bucket.

## Test

Lowering (`quantile_aggregation_carries_phi`) and execution (`quantile_is_percentile_across_the_bucket`) against an in-memory table.

Refs #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parameterized PromQL `quantile(phi, ...)` aggregations.
  * Supports `by (...)` and `without (...)` grouping with quantile queries.
  * Quantile calculations now honor the specified percentile value, including `0` for minimum and `0.5` for median.

* **Documentation**
  * Updated PromQL function documentation to mark `quantile` as supported.

* **Bug Fixes**
  * Improved handling of quantile results in range and instant queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->