### PR TITLE
feat(querier): PromQL offset modifier

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -27,7 +27,7 @@ wrong result.
 | Label matchers `=`, `!=`, `=~`, `!~` | ✅ (regex on attribute labels: `=`/`!=` only) |
 | `__name__` matcher | ✅ |
 | Range vector selector `metric[5m]` (as a function argument) | ✅ |
-| `offset` modifier | ❌ |
+| `offset` modifier (`metric offset 5m`) | ✅ |
 | `@` modifier | ❌ |
 | Subqueries `expr[5m:1m]` | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -112,11 +112,12 @@ impl MetricsService {
         let group_cols = self.group_columns(&plan)?;
 
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
-        let df = apply_filters(df, &plan, start, end)?;
+        // `offset` shifts the sampled window back in time.
+        let df = apply_filters(df, &plan, start - plan.offset_ns, end - plan.offset_ns)?;
 
         // Bucket timestamps into step-aligned windows (cast the
         // microsecond storage timestamp to nanoseconds first).
-        let bucket = bucket_expr(step);
+        let bucket = bucket_expr(step, plan.offset_ns);
 
         let df = if let Some(range) = plan.range {
             self.range_query(
@@ -327,10 +328,10 @@ impl MetricsService {
         let Ok(df) = self.session_context.table(table_ref).await else {
             return Ok(vec![]);
         };
-        let df = apply_filters(df, plan, start, end)?;
+        let df = apply_filters(df, plan, start - plan.offset_ns, end - plan.offset_ns)?;
         let batches = df
             .select(vec![
-                bucket_expr(step),
+                bucket_expr(step, plan.offset_ns),
                 col("metric_name"),
                 col("service_name"),
                 col("bucket_counts"),
@@ -1120,12 +1121,22 @@ fn cast_value_f64(expr: Expr) -> Expr {
 
 /// The step-aligned `date_bin` bucket expression, aligned to the epoch.
 /// The microsecond storage timestamp is cast to nanoseconds first.
-fn bucket_expr(step: i64) -> Expr {
+fn bucket_expr(step: i64, offset_ns: i64) -> Expr {
     let stride = lit(ScalarValue::IntervalMonthDayNano(Some(
         IntervalMonthDayNano::new(0, 0, step),
     )));
     let origin = lit(ScalarValue::TimestampNanosecond(Some(0), None));
-    date_bin(stride, cast_ns(col("timestamp")), origin).alias("bucket")
+    // `offset` shifts the sampled window back in time; add it back to the
+    // timestamp before binning so results align to the query grid.
+    let ts = if offset_ns != 0 {
+        cast_ns(col("timestamp"))
+            + lit(ScalarValue::IntervalMonthDayNano(Some(
+                IntervalMonthDayNano::new(0, 0, offset_ns),
+            )))
+    } else {
+        cast_ns(col("timestamp"))
+    };
+    date_bin(stride, ts, origin).alias("bucket")
 }
 
 #[cfg(test)]
@@ -1240,6 +1251,15 @@ mod tests {
             .unwrap();
         assert_eq!(api.2, 3.0); // last of [1,3]
         assert_eq!(web.2, 5.0);
+    }
+
+    #[tokio::test]
+    async fn offset_shifts_the_query_window() {
+        let service = service_with_data();
+        // Without offset the samples (ts 100–300ns) fall in the [0,1000] window.
+        assert!(!matrix(&service, "reqs", 1000).await.is_empty());
+        // A 5m offset shifts the sampled window far into the past → no samples.
+        assert!(matrix(&service, "reqs offset 5m", 1000).await.is_empty());
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -212,6 +212,9 @@ pub struct MetricPlan {
     pub filter: Option<ScalarCompare>,
     /// The phi for a parameterized `quantile(phi, …)` aggregation.
     pub agg_param: Option<f64>,
+    /// `offset` modifier in nanoseconds: the query window is shifted back by
+    /// this amount (negative for `offset -5m`). Zero when absent.
+    pub offset_ns: i64,
 }
 
 /// A `topk`/`bottomk` selection: keep `k` series per bucket, ranked by value.
@@ -360,6 +363,11 @@ fn lower_selector(
     }
     let metric_name = metric_name
         .ok_or_else(|| QuerierError::InvalidInput("selector has no metric name".to_string()))?;
+    let offset_ns = match &vs.offset {
+        None => 0,
+        Some(promql_parser::parser::Offset::Pos(d)) => d.as_nanos() as i64,
+        Some(promql_parser::parser::Offset::Neg(d)) => -(d.as_nanos() as i64),
+    };
     Ok(MetricPlan {
         metric_name,
         matchers,
@@ -371,6 +379,7 @@ fn lower_selector(
         topk: None,
         filter: None,
         agg_param: None,
+        offset_ns,
     })
 }
 
@@ -787,6 +796,15 @@ mod tests {
         let p = plan(r#"stddev by (job) (x)"#);
         assert_eq!(p.aggregate, MetricAgg::Stddev);
         assert_eq!(p.grouping, Grouping::By(vec!["job".into()]));
+    }
+
+    #[test]
+    fn offset_modifier_sets_offset_ns() {
+        assert_eq!(plan("x").offset_ns, 0);
+        assert_eq!(plan("x offset 5m").offset_ns, 300_000_000_000);
+        assert_eq!(plan("x offset -30s").offset_ns, -30_000_000_000);
+        // Offset inside a range function is read from the inner selector.
+        assert_eq!(plan("rate(x[5m] offset 1h)").offset_ns, 3_600_000_000_000);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds the `offset` modifier (`metric offset 5m`, including inside a range function like `rate(x[5m] offset 1h)`; negative offsets shift forward).

## How

- `promql.rs`: `MetricPlan::offset_ns` read from the selector's parsed `Offset`.
- `metrics.rs`: the sampled window is shifted back by the offset and `bucket_expr` adds it back so results stay aligned to the query grid. Honored on both the matrix and `histogram_quantile` paths.

## Test

Lowering (`offset_modifier_sets_offset_ns`) and execution (`offset_shifts_the_query_window`).

Refs #336