### PR TITLE
feat(querier): PromQL quantile_over_time(phi, …)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -57,7 +57,8 @@ wrong result.
 | `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
 | `resets`, `changes` | ❌ |
 | `present_over_time` | ✅ (1 per bucket with samples) |
-| `absent_over_time`, `quantile_over_time` | ❌ |
+| `quantile_over_time(phi, …)` | ✅ (per-series phi-quantile of the bucket) |
+| `absent_over_time` | ❌ |
 
 ## Histograms
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -1327,6 +1327,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn quantile_over_time_is_percentile_per_series() {
+        let service = service_with_data();
+        // api samples [1, 3] → median 2; web [5] → 5.
+        let out = matrix(&service, "quantile_over_time(0.5, reqs[1m])", 1000).await;
+        let by = |svc: &str| {
+            out.iter()
+                .find(|(_, s, _)| s.as_deref() == Some(svc))
+                .unwrap()
+                .2
+        };
+        assert!((by("api") - 2.0).abs() < 1e-9, "got {}", by("api"));
+        assert!((by("web") - 5.0).abs() < 1e-9, "got {}", by("web"));
+    }
+
+    #[tokio::test]
     async fn quantile_is_percentile_across_the_bucket() {
         let service = service_with_data();
         // Values in the bucket are [1, 3, 5]; the 0.5-quantile (median) is 3.

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -308,6 +308,9 @@ fn build_plan(
     match inner {
         Expr::Paren(p) => build_plan(&p.expr, aggregate, grouping),
         Expr::VectorSelector(vs) => lower_selector(vs, aggregate, grouping, None),
+        Expr::Call(call) if call.func.name == "quantile_over_time" => {
+            lower_quantile_over_time(call, aggregate, grouping)
+        }
         Expr::Call(call) => {
             let arg = call.args.first().ok_or_else(|| {
                 QuerierError::InvalidInput(format!("{} expects one argument", call.func.name))
@@ -449,6 +452,40 @@ fn lower_quantile(agg: &parser::AggregateExpr) -> Result<MetricPlan, QuerierErro
     };
     let grouping = grouping_from(agg.modifier.as_ref())?;
     let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Quantile, grouping)?;
+    plan.agg_param = Some(phi);
+    Ok(plan)
+}
+
+/// Lower `quantile_over_time(phi, metric[range])` — the phi-quantile of the
+/// samples in each bucket. Like the other `_over_time` reducers it only
+/// supports the bare form (no outer aggregation, #335).
+fn lower_quantile_over_time(
+    call: &parser::Call,
+    aggregate: MetricAgg,
+    grouping: Grouping,
+) -> Result<MetricPlan, QuerierError> {
+    if grouping != Grouping::Natural || aggregate != MetricAgg::Last {
+        return Err(QuerierError::Unsupported(
+            "quantile_over_time under an outer aggregation is not supported yet (#335)".to_string(),
+        ));
+    }
+    let phi = match call.args.args.first().map(|a| unwrap_paren(a)) {
+        Some(Expr::NumberLiteral(n)) => n.val,
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "quantile_over_time requires a numeric literal phi".to_string(),
+            ));
+        }
+    };
+    let matrix = call.args.args.get(1).ok_or_else(|| {
+        QuerierError::InvalidInput("quantile_over_time expects (phi, range-vector)".to_string())
+    })?;
+    let Expr::MatrixSelector(ms) = unwrap_paren(matrix) else {
+        return Err(QuerierError::Unsupported(
+            "quantile_over_time requires a range-vector selector like metric[5m]".to_string(),
+        ));
+    };
+    let mut plan = lower_selector(&ms.vs, MetricAgg::Quantile, Grouping::Natural, None)?;
     plan.agg_param = Some(phi);
     Ok(plan)
 }
@@ -868,6 +905,15 @@ mod tests {
             err("x @ 1600000000"),
             QuerierError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn quantile_over_time_carries_phi() {
+        let p = plan("quantile_over_time(0.9, x[5m])");
+        assert_eq!(p.aggregate, MetricAgg::Quantile);
+        assert_eq!(p.agg_param, Some(0.9));
+        assert_eq!(p.grouping, Grouping::Natural);
+        assert!(p.range.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `quantile_over_time(phi, metric[range])` — the phi-quantile of each bucket's samples per series.

## How

Reuses the `MetricAgg::Quantile` reducer (percentile_cont) via a two-arg `_over_time` lowering; phi carried in `MetricPlan::agg_param`. Bare form only, like the other `_over_time` reducers.

## Test

Lowering (`quantile_over_time_carries_phi`) and execution (`quantile_over_time_is_percentile_per_series`).

Refs #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the PromQL `quantile_over_time` function.
  * Calculates quantiles independently for each time series over the selected range.
  * Supports numeric quantile parameters, such as median calculations with `0.5`.

* **Documentation**
  * Updated the PromQL support matrix to mark `quantile_over_time` as supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->