### PR TITLE
feat(querier): PromQL histogram_count() and histogram_sum()

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -65,7 +65,8 @@ wrong result.
 |----------|--------|
 | `histogram_quantile(phi, metric)` | ✅ (interpolated from OTLP buckets; the argument is the histogram metric name, not `le`-keyed `_bucket` series) |
 | `histogram_quantile(phi, rate(metric[5m]))` | ❌ |
-| `histogram_count`, `histogram_sum`, `histogram_fraction` | ❌ |
+| `histogram_count`, `histogram_sum` | ✅ (sum the stored count/sum columns) |
+| `histogram_fraction` | ❌ |
 
 ## Binary operators
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CmpOp, Grouping, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec, ValueOp,
-    plan_promql,
+    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec,
+    ValueOp, plan_promql,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -106,6 +106,14 @@ impl MetricsService {
         if let Some(phi) = plan.quantile {
             return self
                 .histogram_query(&plan, phi, start, end, step, tenant_slug, dataset_slug)
+                .await;
+        }
+
+        // histogram_count/histogram_sum aggregate the histogram table's
+        // scalar count/sum column.
+        if let Some(hf) = plan.histogram_fn {
+            return self
+                .histogram_scalar_query(&plan, hf, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
@@ -420,6 +428,54 @@ impl MetricsService {
         let batch = RecordBatch::try_new(schema, columns)
             .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
         Ok(vec![batch])
+    }
+
+    /// `histogram_count(v)` / `histogram_sum(v)`: sum the stored histogram's
+    /// `count`/`sum` column per (step bucket, series).
+    #[allow(clippy::too_many_arguments)]
+    async fn histogram_scalar_query(
+        &self,
+        plan: &MetricPlan,
+        hf: HistogramFn,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let table_ref = build_table_reference(tenant_slug, dataset_slug, "metrics_histogram")
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        // No histogram table yet → empty result, not an error.
+        let Ok(df) = self.session_context.table(table_ref).await else {
+            return Ok(vec![]);
+        };
+        let df = apply_filters(df, plan, start - plan.offset_ns, end - plan.offset_ns)?;
+        let column = match hf {
+            HistogramFn::Count => "count",
+            HistogramFn::Sum => "sum",
+        };
+        let df = df
+            .aggregate(
+                vec![
+                    bucket_expr(step, plan.offset_ns),
+                    col("metric_name"),
+                    col("service_name"),
+                ],
+                vec![sum(col(column)).alias("value")],
+            )
+            .map_err(QuerierError::QueryFailed)?
+            .select(vec![
+                col("bucket"),
+                col("metric_name"),
+                col("service_name"),
+                cast_value_f64(col("value")).alias("value"),
+            ])
+            .map_err(QuerierError::QueryFailed)?;
+        df.sort(vec![SortExpr::new(col("bucket"), true, true)])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)
     }
 
     /// Resolve the grouping labels to physical columns. Only labels backed
@@ -1618,6 +1674,8 @@ mod tests {
             ),
             Field::new("service_name", DataType::Utf8, false),
             Field::new("metric_name", DataType::Utf8, false),
+            Field::new("count", DataType::Int64, false),
+            Field::new("sum", DataType::Float64, true),
             Field::new("bucket_counts", DataType::Utf8, true),
             Field::new("explicit_bounds", DataType::Utf8, true),
             Field::new("attributes", DataType::Utf8, true),
@@ -1631,6 +1689,8 @@ mod tests {
                 Arc::new(TimestampNanosecondArray::from(vec![100, 100])),
                 Arc::new(StringArray::from(vec!["api", "api"])),
                 Arc::new(StringArray::from(vec!["latency", "latency"])),
+                Arc::new(datafusion::arrow::array::Int64Array::from(vec![10, 10])),
+                Arc::new(Float64Array::from(vec![55.0, 55.0])),
                 Arc::new(StringArray::from(vec!["[1,2,3,4]", "[1,2,3,4]"])),
                 Arc::new(StringArray::from(vec!["[1,2,4]", "[1,2,4]"])),
                 Arc::new(StringArray::from(vec!["{}", "{}"])),
@@ -1671,5 +1731,18 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn histogram_count_and_sum_aggregate_the_columns() {
+        let service = service_with_histogram();
+        // Two points: count 10+10 = 20, sum 55+55 = 110.
+        let out = matrix(&service, "histogram_count(latency)", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 20.0);
+
+        let out = matrix(&service, "histogram_sum(latency)", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert!((out[0].2 - 110.0).abs() < 1e-9, "got {}", out[0].2);
     }
 }

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -215,6 +215,18 @@ pub struct MetricPlan {
     /// `offset` modifier in nanoseconds: the query window is shifted back by
     /// this amount (negative for `offset -5m`). Zero when absent.
     pub offset_ns: i64,
+    /// Set for `histogram_count(v)` / `histogram_sum(v)` — aggregate the
+    /// stored histogram's `count`/`sum` column instead of a scalar `value`.
+    pub histogram_fn: Option<HistogramFn>,
+}
+
+/// A scalar reduction over a stored histogram's `count`/`sum` columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistogramFn {
+    /// `histogram_count(v)` — total observation count.
+    Count,
+    /// `histogram_sum(v)` — sum of observed values.
+    Sum,
 }
 
 /// A `topk`/`bottomk` selection: keep `k` series per bucket, ranked by value.
@@ -240,6 +252,14 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
         // `histogram_quantile(phi, <selector>)` targets the histogram table.
         Expr::Call(call) if call.func.name == "histogram_quantile" => {
             lower_histogram_quantile(call)
+        }
+        // `histogram_count(v)` / `histogram_sum(v)` reduce the stored
+        // histogram's count/sum column.
+        Expr::Call(call) if call.func.name == "histogram_count" => {
+            lower_histogram_scalar(call, HistogramFn::Count)
+        }
+        Expr::Call(call) if call.func.name == "histogram_sum" => {
+            lower_histogram_scalar(call, HistogramFn::Sum)
         }
         // A math function wrapping a vector: `abs(...)`, `clamp_min(..., 0)`.
         Expr::Call(call) if is_math_fn(call.func.name) => lower_math_call(call),
@@ -380,6 +400,7 @@ fn lower_selector(
         filter: None,
         agg_param: None,
         offset_ns,
+        histogram_fn: None,
     })
 }
 
@@ -452,6 +473,32 @@ fn lower_histogram_quantile(call: &parser::Call) -> Result<MetricPlan, QuerierEr
     };
     let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
     plan.quantile = Some(phi);
+    Ok(plan)
+}
+
+/// Lower `histogram_count(v)` / `histogram_sum(v)`. The argument must be a
+/// plain vector selector; the stored histogram's `count`/`sum` column is
+/// summed per bucket and series.
+fn lower_histogram_scalar(
+    call: &parser::Call,
+    hf: HistogramFn,
+) -> Result<MetricPlan, QuerierError> {
+    let name = match hf {
+        HistogramFn::Count => "histogram_count",
+        HistogramFn::Sum => "histogram_sum",
+    };
+    let inner = call
+        .args
+        .args
+        .first()
+        .ok_or_else(|| QuerierError::InvalidInput(format!("{name} expects (selector)")))?;
+    let Expr::VectorSelector(vs) = unwrap_paren(inner) else {
+        return Err(QuerierError::Unsupported(format!(
+            "{name} over rate()/aggregations is not supported yet (#335); use {name}(metric)"
+        )));
+    };
+    let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
+    plan.histogram_fn = Some(hf);
     Ok(plan)
 }
 
@@ -1114,6 +1161,16 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn histogram_count_and_sum_set_histogram_fn() {
+        let c = plan("histogram_count(latency)");
+        assert_eq!(c.metric_name, "latency");
+        assert_eq!(c.histogram_fn, Some(HistogramFn::Count));
+        assert!(c.quantile.is_none());
+        let s = plan("histogram_sum(latency)");
+        assert_eq!(s.histogram_fn, Some(HistogramFn::Sum));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `histogram_count(v)` and `histogram_sum(v)` over stored OTLP histograms.

## How

Routes to the `metrics_histogram` table and sums its stored `count`/`sum` column per (step bucket, series), honoring the `offset` modifier. Bare selector argument only, like `histogram_quantile`.

## Test

Lowering (`histogram_count_and_sum_set_histogram_fn`) and execution (`histogram_count_and_sum_aggregate_the_columns`) against an in-memory histogram table (the fixture gains `count`/`sum` columns to match the real schema).

Refs #336