### PR TITLE
feat(querier): PromQL resets() and changes() range functions

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -55,7 +55,7 @@ wrong result.
 | `count_over_time`, `last_over_time` | ✅ |
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |
 | `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
-| `resets`, `changes` | ❌ |
+| `resets`, `changes` | ✅ (counted over the ordered samples in each bucket) |
 | `present_over_time` | ✅ (1 per bucket with samples) |
 | `absent_over_time`, `quantile_over_time` | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, MatchKind, MetricAgg, MetricPlan, TopKSpec,
-    ValueOp, plan_promql,
+    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, MatchKind, MetricAgg, MetricPlan,
+    SequenceFn, TopKSpec, ValueOp, plan_promql,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -114,6 +114,13 @@ impl MetricsService {
         if let Some(hf) = plan.histogram_fn {
             return self
                 .histogram_scalar_query(&plan, hf, start, end, step, tenant_slug, dataset_slug)
+                .await;
+        }
+
+        // resets/changes count events over the ordered per-bucket samples.
+        if let Some(sf) = plan.sequence_fn {
+            return self
+                .sequence_query(&plan, sf, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
@@ -476,6 +483,118 @@ impl MetricsService {
             .collect()
             .await
             .map_err(QuerierError::QueryFailed)
+    }
+
+    /// `resets(v[range])` / `changes(v[range])`: count sequence events over
+    /// the ordered samples in each (step bucket, series). Computed row-wise
+    /// in Rust since the aggregate path can't see consecutive samples.
+    #[allow(clippy::too_many_arguments)]
+    async fn sequence_query(
+        &self,
+        plan: &MetricPlan,
+        sf: SequenceFn,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let df = self.scan_union(tenant_slug, dataset_slug).await?;
+        let df = apply_filters(df, plan, start - plan.offset_ns, end - plan.offset_ns)?;
+        let batches = df
+            .select(vec![
+                bucket_expr(step, plan.offset_ns),
+                col("metric_name"),
+                col("service_name"),
+                col("value"),
+                cast_ns(col("timestamp")).alias("ts"),
+            ])
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Group ordered (timestamp, value) samples per (bucket, series).
+        let mut groups: BTreeMap<(i64, String, String), Vec<(i64, f64)>> = BTreeMap::new();
+        for batch in &batches {
+            let bucket = batch
+                .column_by_name("bucket")
+                .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+                .ok_or_else(|| {
+                    QuerierError::InvalidInput("bucket column is not a timestamp".to_string())
+                })?;
+            let name = string_column(batch, "metric_name")?;
+            let service = string_column(batch, "service_name")?;
+            let value = batch
+                .column_by_name("value")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+                .ok_or_else(|| {
+                    QuerierError::InvalidInput("value column is not Float64".to_string())
+                })?;
+            let ts = batch
+                .column_by_name("ts")
+                .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+                .ok_or_else(|| {
+                    QuerierError::InvalidInput("ts column is not a timestamp".to_string())
+                })?;
+            for i in 0..batch.num_rows() {
+                if bucket.is_null(i) || value.is_null(i) || ts.is_null(i) {
+                    continue;
+                }
+                groups
+                    .entry((
+                        bucket.value(i),
+                        name.value(i).to_string(),
+                        service.value(i).to_string(),
+                    ))
+                    .or_default()
+                    .push((ts.value(i), value.value(i)));
+            }
+        }
+
+        let mut out_ts = Vec::with_capacity(groups.len());
+        let mut names = Vec::with_capacity(groups.len());
+        let mut services = Vec::with_capacity(groups.len());
+        let mut values = Vec::with_capacity(groups.len());
+        for ((bucket_ns, metric, service), mut samples) in groups {
+            samples.sort_by_key(|(t, _)| *t);
+            let mut count = 0.0;
+            for w in samples.windows(2) {
+                let prev = w[0].1;
+                let cur = w[1].1;
+                let event = match sf {
+                    SequenceFn::Resets => cur < prev,
+                    SequenceFn::Changes => cur != prev,
+                };
+                if event {
+                    count += 1.0;
+                }
+            }
+            out_ts.push(bucket_ns);
+            names.push(metric);
+            services.push(service);
+            values.push(count);
+        }
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(out_ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
     }
 
     /// Resolve the grouping labels to physical columns. Only labels backed
@@ -1431,6 +1550,24 @@ mod tests {
             .find(|(_, s, _)| s.as_deref() == Some("api"))
             .unwrap();
         assert!((api.2 - 2.0e7).abs() < 1.0, "got {}", api.2);
+    }
+
+    #[tokio::test]
+    async fn changes_and_resets_count_sequence_events() {
+        let service = service_with_data();
+        // api samples [1, 3] → 1 change, 0 resets. web [5] → 0.
+        let changes = matrix(&service, "changes(reqs[1m])", 1000).await;
+        let api = changes
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 1.0);
+        let resets = matrix(&service, "resets(reqs[1m])", 1000).await;
+        let api = resets
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 0.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -218,6 +218,18 @@ pub struct MetricPlan {
     /// Set for `histogram_count(v)` / `histogram_sum(v)` — aggregate the
     /// stored histogram's `count`/`sum` column instead of a scalar `value`.
     pub histogram_fn: Option<HistogramFn>,
+    /// Set for `resets(v[range])` / `changes(v[range])` — count sequence
+    /// events over the ordered samples in each bucket.
+    pub sequence_fn: Option<SequenceFn>,
+}
+
+/// A per-bucket reduction that needs the ordered sample sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SequenceFn {
+    /// `resets(v[range])` — number of counter resets (value decreases).
+    Resets,
+    /// `changes(v[range])` — number of times the value changed.
+    Changes,
 }
 
 /// A scalar reduction over a stored histogram's `count`/`sum` columns.
@@ -322,6 +334,20 @@ fn build_plan(
             // `<agg>_over_time(metric[range])` reduces the raw samples in each
             // bucket. Only the bare form is supported; an outer aggregation
             // would need a second reduce stage (#335).
+            // `resets`/`changes` count events over the ordered samples in
+            // each bucket (bare form only).
+            if let Some(sf) = sequence_fn_for(call.func.name) {
+                if grouping != Grouping::Natural || aggregate != MetricAgg::Last {
+                    return Err(QuerierError::Unsupported(format!(
+                        "{} under an outer aggregation is not supported yet (#335)",
+                        call.func.name
+                    )));
+                }
+                let mut plan = lower_selector(&ms.vs, MetricAgg::Last, Grouping::Natural, None)?;
+                plan.sequence_fn = Some(sf);
+                return Ok(plan);
+            }
+
             if let Some(reducer) = over_time_agg(call.func.name) {
                 if grouping != Grouping::Natural || aggregate != MetricAgg::Last {
                     return Err(QuerierError::Unsupported(format!(
@@ -408,6 +434,7 @@ fn lower_selector(
         agg_param: None,
         offset_ns,
         histogram_fn: None,
+        sequence_fn: None,
     })
 }
 
@@ -714,6 +741,14 @@ fn over_time_agg(name: &str) -> Option<MetricAgg> {
         // 1 for every bucket that has at least one sample (buckets with no
         // sample produce no row, which is exactly `present_over_time`).
         "present_over_time" => MetricAgg::Group,
+        _ => return None,
+    })
+}
+
+fn sequence_fn_for(name: &str) -> Option<SequenceFn> {
+    Some(match name {
+        "resets" => SequenceFn::Resets,
+        "changes" => SequenceFn::Changes,
         _ => return None,
     })
 }
@@ -1156,11 +1191,22 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_shapes() {
+    fn resets_and_changes_set_sequence_fn() {
+        assert_eq!(plan("resets(x[5m])").sequence_fn, Some(SequenceFn::Resets));
+        assert_eq!(
+            plan("changes(x[5m])").sequence_fn,
+            Some(SequenceFn::Changes)
+        );
+        assert!(plan("resets(x[5m])").range.is_none());
+        // Under an outer aggregation is unsupported (#335).
         assert!(matches!(
-            err(r#"resets(x[5m])"#),
+            err("sum(changes(x[5m]))"),
             QuerierError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn unsupported_shapes() {
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
         // histogram_quantile over an inner rate() is not lowered yet.
         assert!(matches!(


### PR DESCRIPTION
## What

Adds `resets(v[range])` (counter resets — value decreases) and `changes(v[range])` (value changes), counted over the ordered samples in each step bucket.

## How

- `promql.rs`: `SequenceFn` + `MetricPlan::sequence_fn`; a `sequence_fn_for` lowering in `build_plan` (bare form only, like `_over_time`).
- `metrics.rs`: a row-wise `sequence_query` (like the histogram path) collects each (bucket, series)'s ordered `(timestamp, value)` samples and counts events. Honors the `offset` modifier.

## Test

Lowering (`resets_and_changes_set_sequence_fn`) and execution (`changes_and_resets_count_sequence_events`).

Refs #336