### PR TITLE
feat(querier): PromQL vector-to-vector arithmetic (a OP b)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -75,7 +75,7 @@ wrong result.
 |----------|--------|
 | Arithmetic `+ - * / % ^` with a scalar (`metric * 8`, `1024 / metric`) | ✅ |
 | Comparison `== != > < >= <=` with a scalar (`metric > 5`, `5 < metric`) | ✅ (filters series; with `bool` maps to 1/0) |
-| Arithmetic between two vectors | ❌ |
+| Arithmetic `+ - * / % ^` between two vectors (`a / b`) | ✅ (one-to-one match on `job`/`service`; drops `__name__`) |
 | Comparison between two vectors | ❌ |
 | Logical/set `and`, `or`, `unless` | ❌ |
 | `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, MatchKind, MetricAgg, MetricPlan,
-    SequenceFn, TopKSpec, ValueOp, plan_promql,
+    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, MatchKind, MetricAgg, MetricPlan, QueryPlan,
+    SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -99,13 +99,43 @@ impl MetricsService {
                 "step must be a positive nanosecond interval".to_string(),
             ));
         }
-        let plan = plan_promql(query)?;
+        match plan_query(query)? {
+            QueryPlan::Single(plan) => {
+                self.eval_plan(&plan, start, end, step, tenant_slug, dataset_slug)
+                    .await
+            }
+            QueryPlan::BinaryVector { left, op, right } => {
+                self.eval_binary(
+                    &left,
+                    op,
+                    &right,
+                    start,
+                    end,
+                    step,
+                    tenant_slug,
+                    dataset_slug,
+                )
+                .await
+            }
+        }
+    }
 
+    /// Execute a single lowered [`MetricPlan`] to matrix RecordBatches.
+    #[allow(clippy::too_many_arguments)]
+    async fn eval_plan(
+        &self,
+        plan: &MetricPlan,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
         // histogram_quantile targets the histogram table with a distinct
         // (row-wise, interpolated) execution path.
         if let Some(phi) = plan.quantile {
             return self
-                .histogram_query(&plan, phi, start, end, step, tenant_slug, dataset_slug)
+                .histogram_query(plan, phi, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
@@ -113,22 +143,22 @@ impl MetricsService {
         // scalar count/sum column.
         if let Some(hf) = plan.histogram_fn {
             return self
-                .histogram_scalar_query(&plan, hf, start, end, step, tenant_slug, dataset_slug)
+                .histogram_scalar_query(plan, hf, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
         // resets/changes count events over the ordered per-bucket samples.
         if let Some(sf) = plan.sequence_fn {
             return self
-                .sequence_query(&plan, sf, start, end, step, tenant_slug, dataset_slug)
+                .sequence_query(plan, sf, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
-        let group_cols = self.group_columns(&plan)?;
+        let group_cols = self.group_columns(plan)?;
 
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
         // `offset` shifts the sampled window back in time.
-        let df = apply_filters(df, &plan, start - plan.offset_ns, end - plan.offset_ns)?;
+        let df = apply_filters(df, plan, start - plan.offset_ns, end - plan.offset_ns)?;
 
         // Bucket timestamps into step-aligned windows (cast the
         // microsecond storage timestamp to nanoseconds first).
@@ -175,6 +205,78 @@ impl MetricsService {
             return apply_topk(batches, spec);
         }
         Ok(batches)
+    }
+
+    /// Execute a `left OP right` vector-to-vector arithmetic: evaluate both
+    /// sides, then match one-to-one on (bucket, service_name) and combine the
+    /// values. The output series drops the metric name (`__name__`), matching
+    /// Prometheus. Only series present on both sides are emitted.
+    #[allow(clippy::too_many_arguments)]
+    async fn eval_binary(
+        &self,
+        left: &MetricPlan,
+        op: ArithOp,
+        right: &MetricPlan,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let left_batches = self
+            .eval_plan(left, start, end, step, tenant_slug, dataset_slug)
+            .await?;
+        let right_batches = self
+            .eval_plan(right, start, end, step, tenant_slug, dataset_slug)
+            .await?;
+
+        // Index the right side by (bucket, service_name).
+        let mut rhs: BTreeMap<(i64, String), f64> = BTreeMap::new();
+        for batch in &right_batches {
+            for (bucket, service, value) in matrix_rows(batch)? {
+                rhs.insert((bucket, service), value);
+            }
+        }
+
+        // BTreeMap keeps output sorted by (bucket, series).
+        let mut out: BTreeMap<(i64, String), f64> = BTreeMap::new();
+        for batch in &left_batches {
+            for (bucket, service, lv) in matrix_rows(batch)? {
+                if let Some(&rv) = rhs.get(&(bucket, service.clone())) {
+                    out.insert((bucket, service), arith_f64(op, lv, rv, false));
+                }
+            }
+        }
+
+        let mut ts = Vec::with_capacity(out.len());
+        let mut names = Vec::with_capacity(out.len());
+        let mut services = Vec::with_capacity(out.len());
+        let mut values = Vec::with_capacity(out.len());
+        for ((bucket, service), value) in out {
+            ts.push(bucket);
+            names.push(String::new()); // __name__ is dropped for binary ops
+            services.push(service);
+            values.push(value);
+        }
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
     }
 
     /// Aggregate `value` per (bucket, metric_name, group) directly.
@@ -874,6 +976,33 @@ fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArr
         .ok_or_else(|| {
             QuerierError::InvalidInput(format!("column '{name}' is not a string column"))
         })
+}
+
+/// Extract `(bucket_ns, service_name, value)` rows from a matrix batch.
+/// Series with no `service_name` column (collapsed groupings) use "".
+fn matrix_rows(batch: &RecordBatch) -> Result<Vec<(i64, String, f64)>, QuerierError> {
+    let bucket = batch
+        .column_by_name("bucket")
+        .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+        .ok_or_else(|| {
+            QuerierError::InvalidInput("bucket column is not a timestamp".to_string())
+        })?;
+    let service = batch
+        .column_by_name("service_name")
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+    let value = batch
+        .column_by_name("value")
+        .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+        .ok_or_else(|| QuerierError::InvalidInput("value column is not Float64".to_string()))?;
+    let mut out = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        if bucket.is_null(i) || value.is_null(i) {
+            continue;
+        }
+        let svc = service.map(|c| c.value(i).to_string()).unwrap_or_default();
+        out.push((bucket.value(i), svc, value.value(i)));
+    }
+    Ok(out)
 }
 
 /// Apply the metric-name filter, label matchers, and time window.
@@ -1709,6 +1838,29 @@ mod tests {
         // abs over a rate that is negative is not exercised here; abs of a
         // positive last value is a no-op.
         assert_eq!(by(matrix(&service, "abs(reqs)", 1000).await, "api"), 3.0);
+    }
+
+    #[tokio::test]
+    async fn vector_arithmetic_matches_on_service() {
+        let service = service_with_data();
+        // reqs last per series: api=3, web=5. `reqs / reqs` matches each
+        // series to itself → 1.0, and drops the metric name.
+        let out = matrix(&service, "reqs / reqs", 1000).await;
+        assert_eq!(out.len(), 2);
+        for (name, _svc, v) in &out {
+            assert_eq!(name, "");
+            assert_eq!(*v, 1.0);
+        }
+        // `reqs * reqs`: api 3*3=9, web 5*5=25.
+        let mul = matrix(&service, "reqs * reqs", 1000).await;
+        let api = mul
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.2, 9.0);
+        // `reqs - reqs` = 0 per series.
+        let sub = matrix(&service, "reqs - reqs", 1000).await;
+        assert!(sub.iter().all(|(_, _, v)| *v == 0.0));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -27,9 +27,11 @@
 //!   (`metric * 8`, `1024 / metric`) as value transforms on the result.
 //!
 //! Scalar comparisons (`metric > 5`, `5 < metric`, with an optional `bool`
-//! modifier) filter the result or map it to 1/0. Logical and
-//! vector-to-vector operators, subqueries, and `histogram_quantile` over an
-//! inner `rate()`/aggregation are not lowered yet and return
+//! modifier) filter the result or map it to 1/0. Vector-to-vector arithmetic
+//! (`a / b`) matches series one-to-one on their shared materialized label.
+//! Vector-to-vector comparison, logical set ops, `on`/`ignoring`/`group_left`
+//! matching, subqueries, and `histogram_quantile` over an inner
+//! `rate()`/aggregation are not lowered yet and return
 //! [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
@@ -256,6 +258,54 @@ pub fn plan_promql(query: &str) -> Result<MetricPlan, QuerierError> {
     let expr = parser::parse(query)
         .map_err(|e| QuerierError::InvalidInput(format!("invalid PromQL: {e}")))?;
     lower(&expr)
+}
+
+/// A top-level query plan. Most queries are a single [`MetricPlan`], but a
+/// `vector OP vector` arithmetic expression lowers to a binary of two plans
+/// joined on their shared series identity at execution time.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryPlan {
+    Single(Box<MetricPlan>),
+    /// `left OP right` between two instant/range vectors (arithmetic only for
+    /// now; matched one-to-one on the shared materialized label).
+    BinaryVector {
+        left: Box<MetricPlan>,
+        op: ArithOp,
+        right: Box<MetricPlan>,
+    },
+}
+
+/// Parse and lower a PromQL query to a [`QueryPlan`].
+pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
+    let expr = parser::parse(query)
+        .map_err(|e| QuerierError::InvalidInput(format!("invalid PromQL: {e}")))?;
+    // A top-level arithmetic binary with two vector operands is a
+    // vector-to-vector operation; anything else is a single plan.
+    if let Expr::Binary(bin) = unwrap_paren(&expr)
+        && !bin.op.is_comparison_operator()
+        && as_scalar(&bin.lhs).is_none()
+        && as_scalar(&bin.rhs).is_none()
+    {
+        // Only plain arithmetic tokens; logical set ops (`and`/`or`/`unless`)
+        // and `on`/`ignoring`/`group_left` matching stay unsupported (#335).
+        let op = match format!("{}", bin.op).as_str() {
+            "+" => Some(ArithOp::Add),
+            "-" => Some(ArithOp::Sub),
+            "*" => Some(ArithOp::Mul),
+            "/" => Some(ArithOp::Div),
+            "%" => Some(ArithOp::Mod),
+            "^" => Some(ArithOp::Pow),
+            _ => None,
+        };
+        if let Some(op) = op
+            && bin.modifier.is_none()
+        {
+            let left = Box::new(lower(unwrap_paren(&bin.lhs))?);
+            let right = Box::new(lower(unwrap_paren(&bin.rhs))?);
+            return Ok(QueryPlan::BinaryVector { left, op, right });
+        }
+    }
+    Ok(QueryPlan::Single(Box::new(lower(&expr)?)))
 }
 
 fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
@@ -1252,7 +1302,33 @@ mod tests {
     }
 
     #[test]
+    fn vector_arithmetic_is_a_binary_plan() {
+        match plan_query("a / b").expect("plan") {
+            QueryPlan::BinaryVector { left, op, right } => {
+                assert_eq!(left.metric_name, "a");
+                assert_eq!(right.metric_name, "b");
+                assert_eq!(op, ArithOp::Div);
+            }
+            other => panic!("expected binary, got {other:?}"),
+        }
+        // Aggregations on each side are fine.
+        assert!(matches!(
+            plan_query("sum(a) - sum(b)").expect("plan"),
+            QueryPlan::BinaryVector { .. }
+        ));
+        // Scalar arithmetic stays a single plan.
+        assert!(matches!(
+            plan_query("a * 2").expect("plan"),
+            QueryPlan::Single(_)
+        ));
+        // Vector-to-vector comparison and set ops stay unsupported for now.
+        assert!(plan_query("a > b").is_err());
+        assert!(plan_query("a and b").is_err());
+    }
+
+    #[test]
     fn unsupported_shapes() {
+        // A bare MetricPlan can't represent vector-to-vector arithmetic.
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
         // histogram_quantile over an inner rate() is not lowered yet.
         assert!(matches!(


### PR DESCRIPTION
## What

First slice of the vector-matching epic (#11): arithmetic **between two vectors** (`a / b`, `a + b`, `a * b`, `a - b`, `a % b`, `a ^ b`) — previously `Unsupported`. This is the single biggest gap for real dashboards/alerts.

## How

- New `QueryPlan` layer: `plan_query` lowers a top-level arithmetic binary with two vector operands to `QueryPlan::BinaryVector`, everything else to `Single(MetricPlan)` (existing behavior preserved).
- The single-plan execution is extracted into `eval_plan`; `eval_binary` evaluates both sides and matches series **one-to-one on (bucket, service_name)** — the only materialized join label — applying the operator and dropping `__name__` like Prometheus. Only series present on both sides are emitted.

## Scope / follow-ups (still #335)

Vector-to-vector **comparison**, logical set ops (`and`/`or`/`unless`), and explicit `on`/`ignoring`/`group_left`/`group_right` matching are the next slices of the epic. `scalar OP vector` is unchanged (handled inline).

## Test

Lowering (`vector_arithmetic_is_a_binary_plan`) and execution (`vector_arithmetic_matches_on_service`) against an in-memory table.

Refs #336, #11