### PR TITLE
feat(querier): PromQL vector-to-vector comparison (a CMP b)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -76,7 +76,7 @@ wrong result.
 | Arithmetic `+ - * / % ^` with a scalar (`metric * 8`, `1024 / metric`) | ✅ |
 | Comparison `== != > < >= <=` with a scalar (`metric > 5`, `5 < metric`) | ✅ (filters series; with `bool` maps to 1/0) |
 | Arithmetic `+ - * / % ^` between two vectors (`a / b`) | ✅ (one-to-one match on `job`/`service`; drops `__name__`) |
-| Comparison between two vectors | ❌ |
+| Comparison `== != > < >= <=` between two vectors (`a > b`, with `bool`) | ✅ (one-to-one match; filters `left` or maps to 1/0) |
 | Logical/set `and`, `or`, `unless` | ❌ |
 | `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -117,6 +117,25 @@ impl MetricsService {
                 )
                 .await
             }
+            QueryPlan::BinaryCompare {
+                left,
+                op,
+                right,
+                return_bool,
+            } => {
+                self.eval_binary_compare(
+                    &left,
+                    op,
+                    &right,
+                    return_bool,
+                    start,
+                    end,
+                    step,
+                    tenant_slug,
+                    dataset_slug,
+                )
+                .await
+            }
         }
     }
 
@@ -255,6 +274,85 @@ impl MetricsService {
         for ((bucket, service), value) in out {
             ts.push(bucket);
             names.push(String::new()); // __name__ is dropped for binary ops
+            services.push(service);
+            values.push(value);
+        }
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
+    }
+
+    /// Execute a `left CMP right` vector-to-vector comparison. Series are
+    /// matched one-to-one on (bucket, service_name). Without `bool` the
+    /// left series is kept (with its metric name) where the comparison holds;
+    /// with `bool` each matched pair maps to 1/0 and the name is dropped.
+    #[allow(clippy::too_many_arguments)]
+    async fn eval_binary_compare(
+        &self,
+        left: &MetricPlan,
+        op: CmpOp,
+        right: &MetricPlan,
+        return_bool: bool,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let left_batches = self
+            .eval_plan(left, start, end, step, tenant_slug, dataset_slug)
+            .await?;
+        let right_batches = self
+            .eval_plan(right, start, end, step, tenant_slug, dataset_slug)
+            .await?;
+
+        let mut rhs: BTreeMap<(i64, String), f64> = BTreeMap::new();
+        for batch in &right_batches {
+            for (bucket, service, value) in matrix_rows(batch)? {
+                rhs.insert((bucket, service), value);
+            }
+        }
+
+        // (bucket, service) → (metric_name, value).
+        let mut out: BTreeMap<(i64, String), (String, f64)> = BTreeMap::new();
+        for batch in &left_batches {
+            for (bucket, metric, service, lv) in matrix_rows_named(batch)? {
+                let Some(&rv) = rhs.get(&(bucket, service.clone())) else {
+                    continue;
+                };
+                let holds = cmp_f64(lv, op, rv, false);
+                if return_bool {
+                    let v = if holds { 1.0 } else { 0.0 };
+                    out.insert((bucket, service), (String::new(), v));
+                } else if holds {
+                    out.insert((bucket, service), (metric, lv));
+                }
+            }
+        }
+
+        let mut ts = Vec::with_capacity(out.len());
+        let mut names = Vec::with_capacity(out.len());
+        let mut services = Vec::with_capacity(out.len());
+        let mut values = Vec::with_capacity(out.len());
+        for ((bucket, service), (metric, value)) in out {
+            ts.push(bucket);
+            names.push(metric);
             services.push(service);
             values.push(value);
         }
@@ -1001,6 +1099,39 @@ fn matrix_rows(batch: &RecordBatch) -> Result<Vec<(i64, String, f64)>, QuerierEr
         }
         let svc = service.map(|c| c.value(i).to_string()).unwrap_or_default();
         out.push((bucket.value(i), svc, value.value(i)));
+    }
+    Ok(out)
+}
+
+/// Like [`matrix_rows`] but keeps the metric name: `(bucket, metric, service,
+/// value)`. Used by comparison filtering, which preserves the left labels.
+fn matrix_rows_named(batch: &RecordBatch) -> Result<Vec<(i64, String, String, f64)>, QuerierError> {
+    let bucket = batch
+        .column_by_name("bucket")
+        .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+        .ok_or_else(|| {
+            QuerierError::InvalidInput("bucket column is not a timestamp".to_string())
+        })?;
+    let metric = string_column(batch, "metric_name")?;
+    let service = batch
+        .column_by_name("service_name")
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+    let value = batch
+        .column_by_name("value")
+        .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+        .ok_or_else(|| QuerierError::InvalidInput("value column is not Float64".to_string()))?;
+    let mut out = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        if bucket.is_null(i) || value.is_null(i) {
+            continue;
+        }
+        let svc = service.map(|c| c.value(i).to_string()).unwrap_or_default();
+        out.push((
+            bucket.value(i),
+            metric.value(i).to_string(),
+            svc,
+            value.value(i),
+        ));
     }
     Ok(out)
 }
@@ -1861,6 +1992,27 @@ mod tests {
         // `reqs - reqs` = 0 per series.
         let sub = matrix(&service, "reqs - reqs", 1000).await;
         assert!(sub.iter().all(|(_, _, v)| *v == 0.0));
+    }
+
+    #[tokio::test]
+    async fn vector_comparison_filters_and_bools() {
+        let service = service_with_data();
+        // api=3, web=5. `reqs >= reqs` holds for both → both kept, with the
+        // left value and metric name preserved (filtering comparison).
+        let out = matrix(&service, "reqs >= reqs", 1000).await;
+        assert_eq!(out.len(), 2);
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert_eq!(api.0, "reqs"); // metric name preserved for filtering
+        assert_eq!(api.2, 3.0);
+        // A comparison that never holds → empty.
+        assert!(matrix(&service, "reqs > reqs", 1000).await.is_empty());
+        // `bool` maps to 1/0 and drops the name: 3>=3 and 5>=5 → 1.0 each.
+        let b = matrix(&service, "reqs >= bool reqs", 1000).await;
+        assert!(!b.is_empty());
+        assert!(b.iter().all(|(n, _, v)| n.is_empty() && *v == 1.0));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -28,11 +28,10 @@
 //!
 //! Scalar comparisons (`metric > 5`, `5 < metric`, with an optional `bool`
 //! modifier) filter the result or map it to 1/0. Vector-to-vector arithmetic
-//! (`a / b`) matches series one-to-one on their shared materialized label.
-//! Vector-to-vector comparison, logical set ops, `on`/`ignoring`/`group_left`
-//! matching, subqueries, and `histogram_quantile` over an inner
-//! `rate()`/aggregation are not lowered yet and return
-//! [`QuerierError::Unsupported`] (#335).
+//! (`a / b`) and comparison (`a > b`) match series one-to-one on their shared
+//! materialized label. Logical set ops, `on`/`ignoring`/`group_left` matching,
+//! subqueries, and `histogram_quantile` over an inner `rate()`/aggregation are
+//! not lowered yet and return [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -273,14 +272,61 @@ pub enum QueryPlan {
         op: ArithOp,
         right: Box<MetricPlan>,
     },
+    /// `left CMP right` between two vectors. Without `bool` it filters `left`
+    /// to the series whose value satisfies the comparison against the matched
+    /// `right`; with `bool` it maps each matched pair to 1/0.
+    BinaryCompare {
+        left: Box<MetricPlan>,
+        op: CmpOp,
+        right: Box<MetricPlan>,
+        return_bool: bool,
+    },
 }
 
 /// Parse and lower a PromQL query to a [`QueryPlan`].
 pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
     let expr = parser::parse(query)
         .map_err(|e| QuerierError::InvalidInput(format!("invalid PromQL: {e}")))?;
-    // A top-level arithmetic binary with two vector operands is a
-    // vector-to-vector operation; anything else is a single plan.
+    // A top-level binary with two vector operands is a vector-to-vector
+    // operation. Explicit `on`/`ignoring`/`group_left` matching is not
+    // supported yet — only the default one-to-one match (#335).
+    if let Expr::Binary(bin) = unwrap_paren(&expr)
+        && bin.op.is_comparison_operator()
+        && as_scalar(&bin.lhs).is_none()
+        && as_scalar(&bin.rhs).is_none()
+        && bin.modifier.as_ref().is_none_or(|m| {
+            m.matching.is_none()
+                && matches!(
+                    m.card,
+                    promql_parser::parser::VectorMatchCardinality::OneToOne
+                )
+        })
+    {
+        let op = match format!("{}", bin.op).as_str() {
+            "==" => Some(CmpOp::Eq),
+            "!=" => Some(CmpOp::Ne),
+            ">" => Some(CmpOp::Gt),
+            "<" => Some(CmpOp::Lt),
+            ">=" => Some(CmpOp::Ge),
+            "<=" => Some(CmpOp::Le),
+            _ => None,
+        };
+        if let Some(op) = op {
+            let return_bool = bin
+                .modifier
+                .as_ref()
+                .map(|m| m.return_bool)
+                .unwrap_or(false);
+            let left = Box::new(lower(unwrap_paren(&bin.lhs))?);
+            let right = Box::new(lower(unwrap_paren(&bin.rhs))?);
+            return Ok(QueryPlan::BinaryCompare {
+                left,
+                op,
+                right,
+                return_bool,
+            });
+        }
+    }
     if let Expr::Binary(bin) = unwrap_paren(&expr)
         && !bin.op.is_comparison_operator()
         && as_scalar(&bin.lhs).is_none()
@@ -1321,9 +1367,32 @@ mod tests {
             plan_query("a * 2").expect("plan"),
             QueryPlan::Single(_)
         ));
-        // Vector-to-vector comparison and set ops stay unsupported for now.
-        assert!(plan_query("a > b").is_err());
+        // Logical set ops and explicit matching stay unsupported for now.
         assert!(plan_query("a and b").is_err());
+        assert!(plan_query("a / on(job) b").is_err());
+    }
+
+    #[test]
+    fn vector_comparison_is_a_binary_plan() {
+        match plan_query("a > b").expect("plan") {
+            QueryPlan::BinaryCompare {
+                left,
+                op,
+                right,
+                return_bool,
+            } => {
+                assert_eq!(left.metric_name, "a");
+                assert_eq!(right.metric_name, "b");
+                assert_eq!(op, CmpOp::Gt);
+                assert!(!return_bool);
+            }
+            other => panic!("expected compare, got {other:?}"),
+        }
+        // `bool` modifier is carried through.
+        match plan_query("a == bool b").expect("plan") {
+            QueryPlan::BinaryCompare { return_bool, .. } => assert!(return_bool),
+            other => panic!("expected compare, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Second slice of the vector-matching epic (#11): comparison **between two vectors** (`a > b`, `a == b`, …). Common in alerting.

## How

`QueryPlan::BinaryCompare`: series matched one-to-one on (bucket, service_name). Without `bool` the left series is kept (metric name preserved) where the comparison holds; with `bool` each matched pair maps to 1/0 and drops `__name__`. Explicit `on`/`ignoring`/`group_left` matching remains unsupported (#335).

## Test

Lowering (`vector_comparison_is_a_binary_plan`) and execution (`vector_comparison_filters_and_bools`).

Refs #336, #11