### PR TITLE
feat(querier): PromQL <agg>_over_time under an outer aggregation

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -54,7 +54,7 @@ wrong result.
 | `avg_over_time`, `sum_over_time`, `min_over_time`, `max_over_time` | ✅ |
 | `count_over_time`, `last_over_time` | ✅ |
 | `stddev_over_time`, `stdvar_over_time` | ✅ (population) |
-| `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ❌ |
+| `<agg>_over_time` under an outer aggregation, e.g. `sum(avg_over_time(…))` | ✅ |
 | `resets`, `changes` | ✅ (counted over the ordered samples in each bucket) |
 | `present_over_time` | ✅ (1 per bucket with samples) |
 | `quantile_over_time(phi, …)` | ✅ (per-series phi-quantile of the bucket) |

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -196,6 +196,27 @@ impl MetricsService {
             self.simple_query(df, bucket, plan.aggregate, plan.agg_param, &group_cols)?
         };
 
+        // A second aggregation folds the per-series result, e.g. the outer
+        // `sum` in `sum(avg_over_time(x[5m]))`.
+        let (df, group_cols) = if let Some((outer_agg, outer_grouping)) = &plan.outer_agg {
+            let outer_cols = Self::group_columns_for(outer_grouping)?;
+            let mut group_exprs = vec![col("bucket"), col("metric_name")];
+            group_exprs.extend(outer_cols.iter().map(|c| col(*c)));
+            let df = df
+                .aggregate(
+                    group_exprs,
+                    vec![aggregate_expr(*outer_agg, None).alias("value")],
+                )
+                .map_err(QuerierError::QueryFailed)?;
+            let mut proj = vec![col("bucket"), col("metric_name")];
+            proj.extend(outer_cols.iter().map(|c| col(*c)));
+            proj.push(cast_value_f64(col("value")).alias("value"));
+            let df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+            (df, outer_cols)
+        } else {
+            (df, group_cols)
+        };
+
         // Apply math / scalar-arithmetic transforms to the result value.
         let df = apply_transforms_df(df, &plan.transforms, &group_cols)?;
 
@@ -800,7 +821,12 @@ impl MetricsService {
     /// Resolve the grouping labels to physical columns. Only labels backed
     /// by a dedicated column can be grouped.
     fn group_columns(&self, plan: &MetricPlan) -> Result<Vec<&'static str>, QuerierError> {
-        match &plan.grouping {
+        Self::group_columns_for(&plan.grouping)
+    }
+
+    /// Resolve a [`Grouping`] to physical group columns.
+    fn group_columns_for(grouping: &Grouping) -> Result<Vec<&'static str>, QuerierError> {
+        match grouping {
             // Bare selector: one series per service.
             Grouping::Natural => Ok(vec!["service_name"]),
             // sum(x): collapse everything.
@@ -1941,6 +1967,19 @@ mod tests {
             .find(|(_, s, _)| s.as_deref() == Some("api"))
             .unwrap();
         assert!((api_sd.2 - 1.0).abs() < 1e-9, "got {}", api_sd.2);
+    }
+
+    #[tokio::test]
+    async fn over_time_under_aggregation_folds_series() {
+        let service = service_with_data();
+        // avg_over_time per series: api=(1+3)/2=2, web=5. sum → 7.
+        let out = matrix(&service, "sum(avg_over_time(reqs[1m]))", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 7.0);
+        // max per service: api=3, web=5 (max_over_time), then min across → 3.
+        let out = matrix(&service, "min(max_over_time(reqs[1m]))", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].2, 3.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -222,6 +222,9 @@ pub struct MetricPlan {
     /// Set for `resets(v[range])` / `changes(v[range])` — count sequence
     /// events over the ordered samples in each bucket.
     pub sequence_fn: Option<SequenceFn>,
+    /// A second aggregation folded over the per-series result, e.g. the outer
+    /// `sum` in `sum(avg_over_time(x[5m]))`. The inner reducer is `aggregate`.
+    pub outer_agg: Option<(MetricAgg, Grouping)>,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -448,13 +451,14 @@ fn build_plan(
             }
 
             if let Some(reducer) = over_time_agg(call.func.name) {
+                // The reducer runs per series; if wrapped in an aggregation
+                // (`sum(avg_over_time(…))`), fold the per-series result with a
+                // second stage.
+                let mut plan = lower_selector(&ms.vs, reducer, Grouping::Natural, None)?;
                 if grouping != Grouping::Natural || aggregate != MetricAgg::Last {
-                    return Err(QuerierError::Unsupported(format!(
-                        "{} under an outer aggregation is not supported yet (#335)",
-                        call.func.name
-                    )));
+                    plan.outer_agg = Some((aggregate, grouping));
                 }
-                return lower_selector(&ms.vs, reducer, Grouping::Natural, None);
+                return Ok(plan);
             }
 
             let function = match call.func.name {
@@ -534,6 +538,7 @@ fn lower_selector(
         offset_ns,
         histogram_fn: None,
         sequence_fn: None,
+        outer_agg: None,
     })
 }
 
@@ -1179,11 +1184,20 @@ mod tests {
     }
 
     #[test]
-    fn over_time_under_aggregation_unsupported() {
-        assert!(matches!(
-            err(r#"sum(avg_over_time(x[5m]))"#),
-            QuerierError::Unsupported(_)
-        ));
+    fn over_time_under_aggregation_sets_outer() {
+        let p = plan(r#"sum(avg_over_time(x[5m]))"#);
+        assert_eq!(p.aggregate, MetricAgg::Avg); // inner reducer
+        assert_eq!(p.grouping, Grouping::Natural);
+        assert_eq!(p.outer_agg, Some((MetricAgg::Sum, Grouping::Collapse)));
+        // With `by (…)` on the outer aggregation.
+        let p = plan(r#"max by (job) (min_over_time(x[5m]))"#);
+        assert_eq!(p.aggregate, MetricAgg::Min);
+        assert_eq!(
+            p.outer_agg,
+            Some((MetricAgg::Max, Grouping::By(vec!["job".into()])))
+        );
+        // Bare over_time has no outer aggregation.
+        assert_eq!(plan(r#"avg_over_time(x[5m])"#).outer_agg, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Support `sum(avg_over_time(x[5m]))` and similar — an `_over_time` reducer wrapped in an outer aggregation (previously `Unsupported`).

## How

The reducer runs per series (stage 1); a second aggregation folds the per-series result by the outer grouping (stage 2), carried in `MetricPlan::outer_agg`. `group_columns` was factored to resolve a `Grouping` directly for the outer stage.

## Test

Lowering (`over_time_under_aggregation_sets_outer`) and execution (`over_time_under_aggregation_folds_series`, e.g. `sum(avg_over_time(reqs[1m]))` = 7).

Refs #336