### PR TITLE
feat(querier): PromQL absent() and absent_over_time()

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -58,7 +58,7 @@ wrong result.
 | `resets`, `changes` | ✅ (counted over the ordered samples in each bucket) |
 | `present_over_time` | ✅ (1 per bucket with samples) |
 | `quantile_over_time(phi, …)` | ✅ (per-series phi-quantile of the bucket) |
-| `absent_over_time` | ❌ |
+| `absent_over_time` | ✅ (1 per empty step bucket) |
 
 ## Histograms
 
@@ -88,7 +88,8 @@ wrong result.
 | `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ✅ |
 | `sort`, `sort_desc` | ❌ |
 | `label_replace`, `label_join` | ❌ |
-| `vector`, `scalar`, `absent` | ❌ |
+| `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
+| `vector`, `scalar` | ❌ |
 | `time`, `timestamp`, `day_of_week`, `hour`, … | ❌ |
 
 ## Roadmap

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -100,6 +100,10 @@ impl MetricsService {
             ));
         }
         match plan_query(query)? {
+            QueryPlan::Single(plan) if plan.absent => {
+                self.eval_absent(&plan, start, end, step, tenant_slug, dataset_slug)
+                    .await
+            }
             QueryPlan::Single(plan) => {
                 self.eval_plan(&plan, start, end, step, tenant_slug, dataset_slug)
                     .await
@@ -478,6 +482,90 @@ impl MetricsService {
             services.push(service);
             values.push(value);
         }
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
+    }
+
+    /// `absent(v)` / `absent_over_time(v[range])`: emit a `1`-valued series
+    /// for every step bucket in `[start, end]` where the selector matched no
+    /// data. The output carries the `job`/`service` equality matcher (if any)
+    /// as `service_name`, mirroring Prometheus's use of the selector labels.
+    async fn eval_absent(
+        &self,
+        plan: &MetricPlan,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        // Evaluate the inner selector (without the absent flag) and collect
+        // the buckets that produced data.
+        let mut inner = plan.clone();
+        inner.absent = false;
+        // A scan over a missing table errors inside eval_plan for some paths;
+        // treat any evaluation as "no data" only via its rows.
+        let present: BTreeSet<i64> = match self
+            .eval_plan(&inner, start, end, step, tenant_slug, dataset_slug)
+            .await
+        {
+            Ok(batches) => {
+                let mut set = BTreeSet::new();
+                for batch in &batches {
+                    for (bucket, _s, _v) in matrix_rows(batch)? {
+                        set.insert(bucket);
+                    }
+                }
+                set
+            }
+            Err(_) => BTreeSet::new(),
+        };
+
+        // The output series label: the value of a `job`/`service` equality
+        // matcher, if the selector has one.
+        let service = plan
+            .matchers
+            .iter()
+            .find(|m| {
+                matches!(m.op, MatchKind::Eq) && column_for_label(&m.name) == Some("service_name")
+            })
+            .map(|m| m.value.clone())
+            .unwrap_or_default();
+
+        // Emit 1 for every step bucket (aligned to the epoch) with no data.
+        let first = start.div_euclid(step) * step;
+        let mut ts = Vec::new();
+        let mut names = Vec::new();
+        let mut services = Vec::new();
+        let mut values = Vec::new();
+        let mut bucket = first;
+        while bucket <= end {
+            if !present.contains(&bucket) {
+                ts.push(bucket);
+                names.push(String::new());
+                services.push(service.clone());
+                values.push(1.0);
+            }
+            bucket += step;
+        }
+
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 "bucket",
@@ -2345,6 +2433,24 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn absent_emits_one_for_empty_buckets() {
+        let service = service_with_data();
+        // reqs exists (bucket 0) → fewer absent buckets than a missing metric.
+        let present = matrix(&service, "absent(reqs)", 1000).await;
+        let missing = matrix(&service, "absent(nope)", 1000).await;
+        assert!(missing.len() > present.len());
+        assert!(missing.iter().all(|(n, _, v)| n.is_empty() && *v == 1.0));
+        // A `job` equality matcher becomes the output service label.
+        let ghost = matrix(&service, r#"absent(reqs{job="ghost"})"#, 1000).await;
+        assert!(!ghost.is_empty());
+        assert!(
+            ghost
+                .iter()
+                .all(|(_, s, v)| s.as_deref() == Some("ghost") && *v == 1.0)
+        );
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -226,6 +226,9 @@ pub struct MetricPlan {
     /// A second aggregation folded over the per-series result, e.g. the outer
     /// `sum` in `sum(avg_over_time(x[5m]))`. The inner reducer is `aggregate`.
     pub outer_agg: Option<(MetricAgg, Grouping)>,
+    /// Set for `absent(v)` / `absent_over_time(v[range])` — emit `1` for each
+    /// step bucket in which the selector matches no series.
+    pub absent: bool,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -394,6 +397,11 @@ pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
 fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
     match expr {
         Expr::Paren(p) => lower(&p.expr),
+        // `absent(v)` / `absent_over_time(v[range])`: emit 1 where the
+        // selector matches nothing.
+        Expr::Call(call) if call.func.name == "absent" || call.func.name == "absent_over_time" => {
+            lower_absent(call)
+        }
         // `histogram_quantile(phi, <selector>)` targets the histogram table.
         Expr::Call(call) if call.func.name == "histogram_quantile" => {
             lower_histogram_quantile(call)
@@ -573,6 +581,7 @@ fn lower_selector(
         histogram_fn: None,
         sequence_fn: None,
         outer_agg: None,
+        absent: false,
     })
 }
 
@@ -705,6 +714,28 @@ fn lower_histogram_scalar(
     };
     let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
     plan.histogram_fn = Some(hf);
+    Ok(plan)
+}
+
+/// Lower `absent(v)` / `absent_over_time(v[range])`. The argument must be a
+/// (possibly range-vector) selector; the plan is flagged so execution emits a
+/// `1`-valued series for each step bucket with no matching data.
+fn lower_absent(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let arg = call.args.args.first().ok_or_else(|| {
+        QuerierError::InvalidInput(format!("{} expects a selector", call.func.name))
+    })?;
+    let vs = match unwrap_paren(arg) {
+        Expr::VectorSelector(vs) => vs,
+        Expr::MatrixSelector(ms) => &ms.vs,
+        _ => {
+            return Err(QuerierError::Unsupported(format!(
+                "{} requires a selector argument",
+                call.func.name
+            )));
+        }
+    };
+    let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
+    plan.absent = true;
     Ok(plan)
 }
 
@@ -1477,6 +1508,15 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn absent_sets_the_flag() {
+        assert!(plan("absent(up)").absent);
+        assert!(plan("absent_over_time(up[5m])").absent);
+        assert!(!plan("up").absent);
+        // The selector's matchers are preserved for labelling the output.
+        assert_eq!(plan(r#"absent(up{job="x"})"#).matchers.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `absent(v)` and `absent_over_time(v[range])` — emit a `1`-valued series for each step bucket in which the selector matched no data. Common for "alert when a metric disappears".

## How

Evaluate the inner selector, collect the buckets that produced rows, and emit `1` over the step-bucket grid's complement. A `job`/`service` equality matcher on the selector labels the output `service_name`, mirroring Prometheus's use of the selector's labels.

## Test

Lowering (`absent_sets_the_flag`) and execution (`absent_emits_one_for_empty_buckets`, incl. the `job` matcher labelling).

Refs #336