### PR TITLE
feat(querier): PromQL histogram_quantile(phi, rate(metric[5m]))

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -65,7 +65,7 @@ wrong result.
 | Function | Status |
 |----------|--------|
 | `histogram_quantile(phi, metric)` | ✅ (interpolated from OTLP buckets; the argument is the histogram metric name, not `le`-keyed `_bucket` series) |
-| `histogram_quantile(phi, rate(metric[5m]))` | ❌ |
+| `histogram_quantile(phi, rate(metric[5m]))` | ✅ (interpolates over the per-bucket count delta) |
 | `histogram_count`, `histogram_sum` | ✅ (sum the stored count/sum columns) |
 | `histogram_fraction` | ❌ |
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -666,6 +666,10 @@ impl MetricsService {
             return Ok(vec![]);
         };
         let df = apply_filters(df, plan, start - plan.offset_ns, end - plan.offset_ns)?;
+        // `histogram_quantile(phi, rate(metric[range]))` rates the buckets:
+        // the quantile is scale-invariant, so the per-series delta of counts
+        // (last − first, ordered by time) suffices — the ÷seconds cancels.
+        let rate_mode = plan.range.is_some();
         let batches = df
             .select(vec![
                 bucket_expr(step, plan.offset_ns),
@@ -673,15 +677,17 @@ impl MetricsService {
                 col("service_name"),
                 col("bucket_counts"),
                 col("explicit_bounds"),
+                cast_ns(col("timestamp")).alias("ts"),
             ])
             .map_err(QuerierError::QueryFailed)?
             .collect()
             .await
             .map_err(QuerierError::QueryFailed)?;
 
-        // Merge histogram data points per (bucket, metric_name, service_name).
-        // BTreeMap keeps the output sorted by bucket, then series.
-        let mut groups: BTreeMap<(i64, String, String), HistogramAcc> = BTreeMap::new();
+        // Per (bucket, metric_name, service_name): merged counts (instant) or
+        // first/last counts (rate). BTreeMap keeps output sorted.
+        let mut merged: BTreeMap<(i64, String, String), HistogramAcc> = BTreeMap::new();
+        let mut rated: BTreeMap<(i64, String, String), RateHistAcc> = BTreeMap::new();
         for batch in &batches {
             let bucket = batch
                 .column_by_name("bucket")
@@ -693,6 +699,12 @@ impl MetricsService {
             let service = string_column(batch, "service_name")?;
             let counts = string_column(batch, "bucket_counts")?;
             let bounds = string_column(batch, "explicit_bounds")?;
+            let sample_ts = batch
+                .column_by_name("ts")
+                .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+                .ok_or_else(|| {
+                    QuerierError::InvalidInput("ts column is not a timestamp".to_string())
+                })?;
             for i in 0..batch.num_rows() {
                 if bucket.is_null(i) || counts.is_null(i) || bounds.is_null(i) {
                     continue;
@@ -712,19 +724,46 @@ impl MetricsService {
                     name.value(i).to_string(),
                     service.value(i).to_string(),
                 );
-                groups
-                    .entry(key)
-                    .or_insert_with(|| HistogramAcc::new(row_bounds, row_counts.len()))
-                    .merge(&row_counts);
+                if rate_mode {
+                    let t = if sample_ts.is_null(i) {
+                        0
+                    } else {
+                        sample_ts.value(i)
+                    };
+                    rated
+                        .entry(key)
+                        .or_insert_with(|| RateHistAcc::new(row_bounds, t, row_counts.clone()))
+                        .observe(t, &row_counts);
+                } else {
+                    merged
+                        .entry(key)
+                        .or_insert_with(|| HistogramAcc::new(row_bounds, row_counts.len()))
+                        .merge(&row_counts);
+                }
             }
         }
+
+        // Normalize both modes to (key, bounds, counts) for interpolation.
+        // (bucket, metric, service), bounds, counts-for-interpolation.
+        type HistGroup = ((i64, String, String), Vec<f64>, Vec<f64>);
+        let groups: Vec<HistGroup> = if rate_mode {
+            rated
+                .into_iter()
+                .map(|(k, acc)| (k, acc.bounds.clone(), acc.delta()))
+                .collect()
+        } else {
+            merged
+                .into_iter()
+                .map(|(k, acc)| (k, acc.bounds, acc.counts))
+                .collect()
+        };
 
         let mut ts = Vec::with_capacity(groups.len());
         let mut names = Vec::with_capacity(groups.len());
         let mut services = Vec::with_capacity(groups.len());
         let mut values = Vec::with_capacity(groups.len());
-        for ((bucket_ns, metric, service), acc) in groups {
-            let q = histogram_quantile(phi, &acc.bounds, &acc.counts);
+        for ((bucket_ns, metric, service), bounds, counts) in groups {
+            let q = histogram_quantile(phi, &bounds, &counts);
             let val = apply_transforms_f64(q, &plan.transforms);
             // `vector CMP scalar` without `bool`: drop non-matching series.
             if let Some(cmp) = &plan.filter
@@ -1368,6 +1407,52 @@ impl HistogramAcc {
                 *acc += add;
             }
         }
+    }
+}
+
+/// Tracks the first and last histogram data points (by timestamp) for a
+/// series in a bucket, so `histogram_quantile(phi, rate(metric[range]))` can
+/// interpolate over the per-bucket count delta.
+struct RateHistAcc {
+    bounds: Vec<f64>,
+    first_ts: i64,
+    first: Vec<f64>,
+    last_ts: i64,
+    last: Vec<f64>,
+}
+
+impl RateHistAcc {
+    fn new(bounds: Vec<f64>, ts: i64, counts: Vec<f64>) -> Self {
+        Self {
+            bounds,
+            first_ts: ts,
+            first: counts.clone(),
+            last_ts: ts,
+            last: counts,
+        }
+    }
+
+    fn observe(&mut self, ts: i64, counts: &[f64]) {
+        if counts.len() != self.first.len() {
+            return;
+        }
+        if ts <= self.first_ts {
+            self.first_ts = ts;
+            self.first = counts.to_vec();
+        }
+        if ts >= self.last_ts {
+            self.last_ts = ts;
+            self.last = counts.to_vec();
+        }
+    }
+
+    /// Per-bucket increase, clamped to ≥ 0 (a decrease means a counter reset).
+    fn delta(&self) -> Vec<f64> {
+        self.last
+            .iter()
+            .zip(&self.first)
+            .map(|(l, f)| (l - f).max(0.0))
+            .collect()
     }
 }
 
@@ -2300,12 +2385,13 @@ mod tests {
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(TimestampNanosecondArray::from(vec![100, 100])),
+                // Two cumulative data points in one step bucket at t=100/200.
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200])),
                 Arc::new(StringArray::from(vec!["api", "api"])),
                 Arc::new(StringArray::from(vec!["latency", "latency"])),
                 Arc::new(datafusion::arrow::array::Int64Array::from(vec![10, 10])),
                 Arc::new(Float64Array::from(vec![55.0, 55.0])),
-                Arc::new(StringArray::from(vec!["[1,2,3,4]", "[1,2,3,4]"])),
+                Arc::new(StringArray::from(vec!["[1,2,3,4]", "[2,4,6,8]"])),
                 Arc::new(StringArray::from(vec!["[1,2,4]", "[1,2,4]"])),
                 Arc::new(StringArray::from(vec!["{}", "{}"])),
                 Arc::new(StringArray::from(vec!["{}", "{}"])),
@@ -2336,6 +2422,20 @@ mod tests {
         assert!(
             (value - (2.0 + 2.0 * 2.0 / 3.0)).abs() < 1e-9,
             "got {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn histogram_quantile_over_rate_uses_bucket_delta() {
+        let service = service_with_histogram();
+        // counts go [1,2,3,4] → [2,4,6,8] over the bucket; the delta [1,2,3,4]
+        // has the same shape, so the 0.5-quantile is the same 3.333….
+        let out = matrix(&service, "histogram_quantile(0.5, rate(latency[5m]))", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert!(
+            (out[0].2 - (2.0 + 2.0 * 2.0 / 3.0)).abs() < 1e-9,
+            "got {}",
+            out[0].2
         );
     }
 

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -30,9 +30,8 @@
 //! modifier) filter the result or map it to 1/0. Vector-to-vector arithmetic
 //! (`a / b`), comparison (`a > b`), and set ops (`and`/`or`/`unless`) match
 //! series one-to-one on their shared materialized label. Explicit
-//! `on`/`ignoring`/`group_left` matching, subqueries, and `histogram_quantile`
-//! over an inner `rate()`/aggregation are not lowered yet and return
-//! [`QuerierError::Unsupported`] (#335).
+//! `on`/`ignoring`/`group_left` matching and subqueries are not lowered yet
+//! and return [`QuerierError::Unsupported`] (#335).
 //!
 //! Like the log path, range aggregations use fixed step-aligned buckets
 //! (`date_bin`), not Prometheus's sliding window — exact when the step
@@ -670,14 +669,49 @@ fn lower_histogram_quantile(call: &parser::Call) -> Result<MetricPlan, QuerierEr
     let inner = call.args.args.get(1).ok_or_else(|| {
         QuerierError::InvalidInput("histogram_quantile expects (phi, selector)".to_string())
     })?;
-    let Expr::VectorSelector(vs) = unwrap_paren(inner) else {
-        return Err(QuerierError::Unsupported(
-            "histogram_quantile over rate()/aggregations is not supported yet (#335); \
-             use histogram_quantile(phi, metric)"
-                .to_string(),
-        ));
+    let mut plan = match unwrap_paren(inner) {
+        // `histogram_quantile(phi, metric)` — interpolate over the merged
+        // buckets of each series.
+        Expr::VectorSelector(vs) => lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?,
+        // `histogram_quantile(phi, rate(metric[range]))` — the buckets are
+        // rated over the window before interpolation.
+        Expr::Call(inner_call)
+            if inner_call.func.name == "rate" || inner_call.func.name == "increase" =>
+        {
+            let arg = inner_call.args.args.first().ok_or_else(|| {
+                QuerierError::InvalidInput(format!(
+                    "{} expects a range selector",
+                    inner_call.func.name
+                ))
+            })?;
+            let Expr::MatrixSelector(ms) = unwrap_paren(arg) else {
+                return Err(QuerierError::Unsupported(
+                    "histogram_quantile's inner rate() needs a range-vector selector".to_string(),
+                ));
+            };
+            let function = if inner_call.func.name == "rate" {
+                RangeFn::Rate
+            } else {
+                RangeFn::Increase
+            };
+            lower_selector(
+                &ms.vs,
+                MetricAgg::Last,
+                Grouping::Natural,
+                Some(RangeSpec {
+                    function,
+                    seconds: ms.range.as_secs_f64(),
+                }),
+            )?
+        }
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "histogram_quantile over aggregations is not supported yet (#335); \
+                 use histogram_quantile(phi, metric) or histogram_quantile(phi, rate(metric[5m]))"
+                    .to_string(),
+            ));
+        }
     };
-    let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
     plan.quantile = Some(phi);
     Ok(plan)
 }
@@ -1462,11 +1496,19 @@ mod tests {
     fn unsupported_shapes() {
         // A bare MetricPlan can't represent vector-to-vector arithmetic.
         assert!(matches!(err(r#"x + y"#), QuerierError::Unsupported(_)));
-        // histogram_quantile over an inner rate() is not lowered yet.
+        // histogram_quantile over an aggregation (not rate) is not lowered.
         assert!(matches!(
-            err(r#"histogram_quantile(0.9, rate(x[5m]))"#),
+            err(r#"histogram_quantile(0.9, sum(x))"#),
             QuerierError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn histogram_quantile_over_rate_sets_range() {
+        let p = plan(r#"histogram_quantile(0.95, rate(latency[5m]))"#);
+        assert_eq!(p.metric_name, "latency");
+        assert_eq!(p.quantile, Some(0.95));
+        assert_eq!(p.range.map(|r| r.function), Some(RangeFn::Rate));
     }
 
     #[test]


### PR DESCRIPTION
## What

Supports the standard latency-percentile query, e.g. `histogram_quantile(0.95, rate(http_request_duration_seconds[5m]))` — previously `Unsupported`.

## How

`histogram_quantile` is scale-invariant, so rating reduces to the per-series **count delta**: `histogram_query` tracks the first and last `bucket_counts` (by timestamp) per (bucket, series) and interpolates over `(last − first)`, clamped ≥ 0. The lowering accepts an inner `rate()`/`increase()` over a range-vector selector.

## Test

Lowering (`histogram_quantile_over_rate_sets_range`) and execution (`histogram_quantile_over_rate_uses_bucket_delta`; the fixture gains distinct timestamps + cumulative counts so the delta is meaningful — the quantile stays scale-invariant, so the instant test is unchanged).

Refs #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `histogram_quantile()` with `rate()` and `increase()` range expressions.
  * Histogram quantiles now correctly use bucket changes over time for rate-based queries.

* **Documentation**
  * Updated PromQL support documentation to mark `histogram_quantile(phi, rate(metric[5m]))` as supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->