### PR TITLE
feat(querier): PromQL timestamp()

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -90,7 +90,8 @@ wrong result.
 | `label_replace`, `label_join` | ❌ |
 | `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
 | `vector`, `scalar` | ❌ |
-| `time`, `timestamp`, `day_of_week`, `hour`, … | ❌ |
+| `timestamp` | ✅ (latest sample time per series, in unix seconds) |
+| `time`, `day_of_week`, `hour`, … | ❌ |
 
 ## Roadmap
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -200,7 +200,20 @@ impl MetricsService {
         // microsecond storage timestamp to nanoseconds first).
         let bucket = bucket_expr(step, plan.offset_ns);
 
-        let df = if let Some(range) = plan.range {
+        let df = if plan.timestamp {
+            // `timestamp(v)`: the value is each series' latest sample time in
+            // seconds, rather than the sample value.
+            let mut group_exprs = vec![bucket, col("metric_name")];
+            group_exprs.extend(group_cols.iter().map(|c| col(*c)));
+            let secs = cast_value_f64(cast(cast_ns(col("timestamp")), DataType::Int64)) / lit(1e9);
+            let df = df
+                .aggregate(group_exprs, vec![max(secs).alias("value")])
+                .map_err(QuerierError::QueryFailed)?;
+            let mut proj = vec![col("bucket"), col("metric_name")];
+            proj.extend(group_cols.iter().map(|c| col(*c)));
+            proj.push(cast_value_f64(col("value")).alias("value"));
+            df.select(proj).map_err(QuerierError::QueryFailed)?
+        } else if let Some(range) = plan.range {
             self.range_query(
                 df,
                 bucket,
@@ -2533,6 +2546,23 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn timestamp_returns_latest_sample_time_in_seconds() {
+        let service = service_with_data();
+        // api's latest sample is at t=200ns → 200e-9 s; web's at 300ns.
+        let out = matrix(&service, "timestamp(reqs)", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .unwrap();
+        assert!((api.2 - 200e-9).abs() < 1e-18, "got {}", api.2);
+        let web = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("web"))
+            .unwrap();
+        assert!((web.2 - 300e-9).abs() < 1e-18, "got {}", web.2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -228,6 +228,9 @@ pub struct MetricPlan {
     /// Set for `absent(v)` / `absent_over_time(v[range])` — emit `1` for each
     /// step bucket in which the selector matches no series.
     pub absent: bool,
+    /// Set for `timestamp(v)` — the result value is each series' latest sample
+    /// timestamp (unix seconds) in the bucket, not the sample value.
+    pub timestamp: bool,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -400,6 +403,15 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
         // selector matches nothing.
         Expr::Call(call) if call.func.name == "absent" || call.func.name == "absent_over_time" => {
             lower_absent(call)
+        }
+        // `timestamp(v)`: the value becomes each sample's timestamp.
+        Expr::Call(call) if call.func.name == "timestamp" => {
+            let arg = call.args.args.first().ok_or_else(|| {
+                QuerierError::InvalidInput("timestamp expects a selector".to_string())
+            })?;
+            let mut plan = lower(unwrap_paren(arg))?;
+            plan.timestamp = true;
+            Ok(plan)
         }
         // `histogram_quantile(phi, <selector>)` targets the histogram table.
         Expr::Call(call) if call.func.name == "histogram_quantile" => {
@@ -581,6 +593,7 @@ fn lower_selector(
         sequence_fn: None,
         outer_agg: None,
         absent: false,
+        timestamp: false,
     })
 }
 
@@ -1550,6 +1563,14 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn timestamp_sets_the_flag() {
+        let p = plan("timestamp(up)");
+        assert!(p.timestamp);
+        assert_eq!(p.metric_name, "up");
+        assert!(!plan("up").timestamp);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `timestamp(v)` — the result value is each series' latest sample time (unix seconds) in the bucket, instead of the sample value.

## How

An `eval_plan` branch aggregates `max(timestamp)` per (bucket, series) and divides by 1e9. `promql.rs` flags the plan with `timestamp`.

## Test

Lowering (`timestamp_sets_the_flag`) and execution (`timestamp_returns_latest_sample_time_in_seconds`).

Refs #336