### PR TITLE
feat(querier): PromQL histogram_fraction(lower, upper, v)

### DIFF
--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -67,7 +67,7 @@ wrong result.
 | `histogram_quantile(phi, metric)` | ✅ (interpolated from OTLP buckets; the argument is the histogram metric name, not `le`-keyed `_bucket` series) |
 | `histogram_quantile(phi, rate(metric[5m]))` | ✅ (interpolates over the per-bucket count delta) |
 | `histogram_count`, `histogram_sum` | ✅ (sum the stored count/sum columns) |
-| `histogram_fraction` | ❌ |
+| `histogram_fraction(lower, upper, metric)` | ✅ (fraction of observations in `(lower, upper]`) |
 
 ## Binary operators
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -167,9 +167,10 @@ impl MetricsService {
         tenant_slug: &str,
         dataset_slug: &str,
     ) -> Result<Vec<RecordBatch>, QuerierError> {
-        // histogram_quantile targets the histogram table with a distinct
-        // (row-wise, interpolated) execution path.
-        if let Some(phi) = plan.quantile {
+        // histogram_quantile / histogram_fraction target the histogram table
+        // with a distinct (row-wise, interpolated) execution path.
+        if plan.quantile.is_some() || plan.histogram_fraction.is_some() {
+            let phi = plan.quantile.unwrap_or(0.0);
             return self
                 .histogram_query(plan, phi, start, end, step, tenant_slug, dataset_slug)
                 .await;
@@ -864,7 +865,10 @@ impl MetricsService {
         let mut services = Vec::with_capacity(groups.len());
         let mut values = Vec::with_capacity(groups.len());
         for ((bucket_ns, metric, service), bounds, counts) in groups {
-            let q = histogram_quantile(phi, &bounds, &counts);
+            let q = match plan.histogram_fraction {
+                Some((lo, hi)) => histogram_fraction(lo, hi, &bounds, &counts),
+                None => histogram_quantile(phi, &bounds, &counts),
+            };
             let val = apply_transforms_f64(q, &plan.transforms);
             // `vector CMP scalar` without `bool`: drop non-matching series.
             if let Some(cmp) = &plan.filter
@@ -1621,6 +1625,45 @@ fn histogram_quantile(phi: f64, bounds: &[f64], counts: &[f64]) -> f64 {
         return bucket_start;
     }
     bucket_start + (bucket_end - bucket_start) * (rank_in_bucket / count_in_bucket)
+}
+
+/// The fraction of a classic histogram's observations in `(lower, upper]`,
+/// via the cumulative distribution (the inverse of [`histogram_quantile`]'s
+/// interpolation): buckets span `(prev_bound, bound]` with the first starting
+/// at 0, observations spread uniformly, and the open `+Inf` bucket sits above
+/// the last finite bound.
+fn histogram_fraction(lower: f64, upper: f64, bounds: &[f64], counts: &[f64]) -> f64 {
+    if bounds.is_empty() || counts.len() != bounds.len() + 1 {
+        return f64::NAN;
+    }
+    let total: f64 = counts.iter().sum();
+    if total <= 0.0 {
+        return f64::NAN;
+    }
+    (hist_cumulative(upper, bounds, counts) - hist_cumulative(lower, bounds, counts)) / total
+}
+
+/// Cumulative count of observations `<= x`, interpolated within the bucket.
+fn hist_cumulative(x: f64, bounds: &[f64], counts: &[f64]) -> f64 {
+    let n = bounds.len();
+    // At or above the top finite bound: all finite-bucket observations count;
+    // the `+Inf` bucket's observations are strictly greater.
+    if x >= bounds[n - 1] {
+        return counts[..n].iter().sum();
+    }
+    // First finite bucket whose upper bound is >= x contains x.
+    let b = bounds.iter().position(|&bd| bd >= x).unwrap_or(0);
+    let bucket_start = if b == 0 { 0.0 } else { bounds[b - 1] };
+    let before: f64 = counts[..b].iter().sum();
+    if x <= bucket_start {
+        return before;
+    }
+    let width = bounds[b] - bucket_start;
+    if width <= 0.0 {
+        return before;
+    }
+    let frac = ((x - bucket_start) / width).clamp(0.0, 1.0);
+    before + counts[b] * frac
 }
 
 /// Re-project a matrix DataFrame with the `value` column transformed by
@@ -2538,6 +2581,19 @@ mod tests {
             "got {}",
             out[0].2
         );
+    }
+
+    #[tokio::test]
+    async fn histogram_fraction_is_cdf_delta() {
+        let service = service_with_histogram();
+        // Merged counts [3,6,9,12] over bounds [1,2,4], total 30.
+        // Observations in (0, 2] = 3+6 = 9 → fraction 0.3.
+        let out = matrix(&service, "histogram_fraction(0, 2, latency)", 1000).await;
+        assert_eq!(out.len(), 1);
+        assert!((out[0].2 - 0.3).abs() < 1e-9, "got {}", out[0].2);
+        // (0, 4] covers three finite buckets = 18/30 = 0.6.
+        let out = matrix(&service, "histogram_fraction(0, 4, latency)", 1000).await;
+        assert!((out[0].2 - 0.6).abs() < 1e-9, "got {}", out[0].2);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -231,6 +231,9 @@ pub struct MetricPlan {
     /// Set for `timestamp(v)` — the result value is each series' latest sample
     /// timestamp (unix seconds) in the bucket, not the sample value.
     pub timestamp: bool,
+    /// Set for `histogram_fraction(lower, upper, v)` — the fraction of a
+    /// stored histogram's observations that fall in `(lower, upper]`.
+    pub histogram_fraction: Option<(f64, f64)>,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -425,6 +428,11 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
         Expr::Call(call) if call.func.name == "histogram_sum" => {
             lower_histogram_scalar(call, HistogramFn::Sum)
         }
+        // `histogram_fraction(lower, upper, v)` — fraction of observations in
+        // (lower, upper].
+        Expr::Call(call) if call.func.name == "histogram_fraction" => {
+            lower_histogram_fraction(call)
+        }
         // A math function wrapping a vector: `abs(...)`, `clamp_min(..., 0)`.
         Expr::Call(call) if is_math_fn(call.func.name) => lower_math_call(call),
         // Bare selector or bare range function.
@@ -594,6 +602,7 @@ fn lower_selector(
         outer_agg: None,
         absent: false,
         timestamp: false,
+        histogram_fraction: None,
     })
 }
 
@@ -761,6 +770,32 @@ fn lower_histogram_scalar(
     };
     let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
     plan.histogram_fn = Some(hf);
+    Ok(plan)
+}
+
+/// Lower `histogram_fraction(lower, upper, v)`. `lower`/`upper` must be numeric
+/// literals and the argument a plain histogram selector.
+fn lower_histogram_fraction(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let num = |i: usize| match call.args.args.get(i).map(|a| unwrap_paren(a)) {
+        Some(Expr::NumberLiteral(n)) => Ok(n.val),
+        _ => Err(QuerierError::Unsupported(
+            "histogram_fraction requires numeric literal lower/upper bounds".to_string(),
+        )),
+    };
+    let lower = num(0)?;
+    let upper = num(1)?;
+    let inner = call.args.args.get(2).ok_or_else(|| {
+        QuerierError::InvalidInput(
+            "histogram_fraction expects (lower, upper, selector)".to_string(),
+        )
+    })?;
+    let Expr::VectorSelector(vs) = unwrap_paren(inner) else {
+        return Err(QuerierError::Unsupported(
+            "histogram_fraction over rate()/aggregations is not supported yet (#335)".to_string(),
+        ));
+    };
+    let mut plan = lower_selector(vs, MetricAgg::Last, Grouping::Natural, None)?;
+    plan.histogram_fraction = Some((lower, upper));
     Ok(plan)
 }
 
@@ -1580,6 +1615,14 @@ mod tests {
         assert!(!plan("up").absent);
         // The selector's matchers are preserved for labelling the output.
         assert_eq!(plan(r#"absent(up{job="x"})"#).matchers.len(), 1);
+    }
+
+    #[test]
+    fn histogram_fraction_sets_bounds() {
+        let p = plan("histogram_fraction(0, 0.5, latency)");
+        assert_eq!(p.histogram_fraction, Some((0.0, 0.5)));
+        assert_eq!(p.metric_name, "latency");
+        assert!(p.quantile.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `histogram_fraction(lower, upper, v)` — the fraction of a stored histogram's observations in `(lower, upper]`. Powers SLO queries ("what fraction of requests were faster than X"). Completes the histogram set: quantile, count, sum, **fraction**.

## How

Cumulative distribution `hist_cumulative(x)` — the inverse of `histogram_quantile`'s interpolation (buckets span `(prev_bound, bound]` from 0, uniform spread, open `+Inf` above the last finite bound). `histogram_fraction = (cdf(upper) − cdf(lower)) / total`.

## Test

Lowering (`histogram_fraction_sets_bounds`) and execution (`histogram_fraction_is_cdf_delta`: `(0,2]`→0.3, `(0,4]`→0.6 over the fixture).

Refs #336