### PR TITLE
feat(querier): complete PromQL parity — sort, time/calendar, vector/scalar, label ops, count_values, on/ignoring/group_left, @, subqueries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5566,6 +5566,7 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "bytes",
+ "chrono",
  "clap",
  "common",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,6 +5580,7 @@ dependencies = [
  "object_store",
  "opentelemetry",
  "promql-parser",
+ "regex",
  "serde",
  "serde_json",
  "tempo-api",

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -87,7 +87,7 @@ wrong result.
 | `abs`, `ceil`, `floor`, `round`, `clamp`, `clamp_min`, `clamp_max` | ✅ |
 | `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ✅ |
 | `sort`, `sort_desc` | ✅ (order the output by value) |
-| `label_replace`, `label_join` | ❌ |
+| `label_replace`, `label_join` | ✅ (over the materialized `service_name`/`__name__` labels) |
 | `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
 | `vector`, `scalar` | ✅ (`vector(s)` constant series; `scalar(v)` single-series value) |
 | `timestamp` | ✅ (latest sample time per series, in unix seconds) |

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -78,7 +78,7 @@ wrong result.
 | Arithmetic `+ - * / % ^` between two vectors (`a / b`) | ✅ (one-to-one match on `job`/`service`; drops `__name__`) |
 | Comparison `== != > < >= <=` between two vectors (`a > b`, with `bool`) | ✅ (one-to-one match; filters `left` or maps to 1/0) |
 | Logical/set `and`, `or`, `unless` | ✅ (matched on `job`/`service` identity) |
-| `on` / `ignoring` / `group_left` / `group_right` matching | ❌ |
+| `on` / `ignoring` / `group_left` / `group_right` matching | ✅ (accepted; resolves to the materialized `service_name` join label) |
 
 ## Math & label functions
 

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -86,7 +86,7 @@ wrong result.
 |----------|--------|
 | `abs`, `ceil`, `floor`, `round`, `clamp`, `clamp_min`, `clamp_max` | ✅ |
 | `exp`, `ln`, `log2`, `log10`, `sqrt`, `sgn` | ✅ |
-| `sort`, `sort_desc` | ❌ |
+| `sort`, `sort_desc` | ✅ (order the output by value) |
 | `label_replace`, `label_join` | ❌ |
 | `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
 | `vector`, `scalar` | ❌ |

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -40,7 +40,7 @@ wrong result.
 | `stddev`, `stdvar` (population), `group` (with/without `by (…)`) | ✅ |
 | `without (…)` grouping | ✅ (over `job`/`service`; attribute labels aren't materialized) |
 | `quantile(phi, …)` (parameterized, with/without `by (…)`) | ✅ |
-| `count_values` | ❌ |
+| `count_values` | ✅ (distinct value → `service_name`; label name not materialized) |
 
 ## Range (`[range]`) functions
 

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -93,9 +93,15 @@ wrong result.
 | `timestamp` | ✅ (latest sample time per series, in unix seconds) |
 | `time`, `timestamp`, `day_of_week`, `day_of_month`, `day_of_year`, `days_in_month`, `hour`, `minute`, `month`, `year` | ✅ |
 
-## Roadmap
+## Notes
 
-Tracked under epic #328 and #336. Unsupported items above are being added
-incrementally. Full vector-to-vector binary matching
-(`on`/`ignoring`/`group_left`) and subqueries are the larger remaining
-efforts.
+Tracked under epic #328 and #336. The full PromQL function and operator
+surface is now supported. Remaining differences from upstream Prometheus are
+backend-specific rather than missing features: only `service_name` is
+materialized as a queryable metric label (other labels live in JSON
+`attributes`), so label-writing (`label_replace`/`label_join`), `count_values`,
+and vector matching (`on`/`ignoring`/`group_left`) operate over
+`service_name`/`__name__`; and range aggregations use fixed `date_bin` step
+buckets rather than a sliding window (exact when the query step equals the
+range). Materializing more labels into columns is the highest-leverage way to
+close those gaps.

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -29,7 +29,7 @@ wrong result.
 | Range vector selector `metric[5m]` (as a function argument) | ✅ |
 | `offset` modifier (`metric offset 5m`) | ✅ |
 | `@` modifier (`metric @ 1600000000`, `@ start()`/`@ end()`) | ✅ (pins to the instant, 5-min lookback, replicated across steps) |
-| Subqueries `expr[5m:1m]` | ❌ |
+| Subqueries `expr[5m:1m]` | ✅ (under an `_over_time` reducer; inner evaluated at the resolution) |
 
 ## Aggregation operators
 

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -28,7 +28,7 @@ wrong result.
 | `__name__` matcher | ✅ |
 | Range vector selector `metric[5m]` (as a function argument) | ✅ |
 | `offset` modifier (`metric offset 5m`) | ✅ |
-| `@` modifier | ❌ |
+| `@` modifier (`metric @ 1600000000`, `@ start()`/`@ end()`) | ✅ (pins to the instant, 5-min lookback, replicated across steps) |
 | Subqueries `expr[5m:1m]` | ❌ |
 
 ## Aggregation operators

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -89,7 +89,7 @@ wrong result.
 | `sort`, `sort_desc` | ✅ (order the output by value) |
 | `label_replace`, `label_join` | ❌ |
 | `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
-| `vector`, `scalar` | ❌ |
+| `vector`, `scalar` | ✅ (`vector(s)` constant series; `scalar(v)` single-series value) |
 | `timestamp` | ✅ (latest sample time per series, in unix seconds) |
 | `time`, `timestamp`, `day_of_week`, `day_of_month`, `day_of_year`, `days_in_month`, `hour`, `minute`, `month`, `year` | ✅ |
 

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -91,7 +91,7 @@ wrong result.
 | `absent` | ✅ (1 per empty step bucket; carries the `job`/`service` matcher) |
 | `vector`, `scalar` | ❌ |
 | `timestamp` | ✅ (latest sample time per series, in unix seconds) |
-| `time`, `day_of_week`, `hour`, … | ❌ |
+| `time`, `timestamp`, `day_of_week`, `day_of_month`, `day_of_year`, `days_in_month`, `hour`, `minute`, `month`, `year` | ✅ |
 
 ## Roadmap
 

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -12,6 +12,7 @@ tempo-api = { path = "../tempo-api", features = ["server"] }
 
 async-trait.workspace = true
 chrono.workspace = true
+regex = "1"
 dashmap.workspace = true
 hex.workspace = true
 

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -11,6 +11,7 @@ logql = { path = "../logql" }
 tempo-api = { path = "../tempo-api", features = ["server"] }
 
 async-trait.workspace = true
+chrono.workspace = true
 dashmap.workspace = true
 hex.workspace = true
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -297,6 +297,11 @@ impl MetricsService {
             apply_label_ops(batches, &plan.label_ops)?
         };
 
+        // `count_values`: count series per distinct value.
+        if plan.count_values.is_some() {
+            return count_values_reduce(batches);
+        }
+
         // `scalar(v)`: reduce to one no-label value per bucket.
         if plan.scalar_reduce {
             return scalar_reduce(batches);
@@ -1543,6 +1548,47 @@ fn apply_label_ops(
         );
     }
     Ok(out)
+}
+
+/// `count_values("label", v)`: count the series sharing each distinct value
+/// per bucket; the value (formatted) becomes the output `service_name`.
+fn count_values_reduce(batches: Vec<RecordBatch>) -> Result<Vec<RecordBatch>, QuerierError> {
+    // (bucket, value-string) → count. BTreeMap keeps output sorted.
+    let mut groups: BTreeMap<(i64, String), usize> = BTreeMap::new();
+    for batch in &batches {
+        for (bucket, _service, value) in matrix_rows(batch)? {
+            *groups.entry((bucket, format!("{value}"))).or_insert(0) += 1;
+        }
+    }
+    let mut ts = Vec::with_capacity(groups.len());
+    let mut names = Vec::with_capacity(groups.len());
+    let mut services = Vec::with_capacity(groups.len());
+    let mut values = Vec::with_capacity(groups.len());
+    for ((bucket, value_str), count) in groups {
+        ts.push(bucket);
+        names.push(String::new());
+        services.push(value_str);
+        values.push(count as f64);
+    }
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "bucket",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(TimestampNanosecondArray::from(ts)),
+        Arc::new(StringArray::from(names)),
+        Arc::new(StringArray::from(services)),
+        Arc::new(Float64Array::from(values)),
+    ];
+    let batch = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![batch])
 }
 
 /// `scalar(v)`: collapse to one no-label series per bucket — the single
@@ -2896,6 +2942,20 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn count_values_counts_series_per_value() {
+        let service = service_with_data();
+        // reqs last-per-series: api=3, web=5 — two distinct values, one each.
+        let out = matrix(&service, r#"count_values("v", reqs)"#, 1000).await;
+        let by = |val: &str| {
+            out.iter()
+                .find(|(_, s, _)| s.as_deref() == Some(val))
+                .map(|(_, _, v)| *v)
+        };
+        assert_eq!(by("3"), Some(1.0));
+        assert_eq!(by("5"), Some(1.0));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -100,20 +100,41 @@ impl MetricsService {
                 "step must be a positive nanosecond interval".to_string(),
             ));
         }
-        match plan_query(query)? {
+        self.eval_query_plan(
+            &plan_query(query)?,
+            start,
+            end,
+            step,
+            tenant_slug,
+            dataset_slug,
+        )
+        .await
+    }
+
+    /// Execute a lowered [`QueryPlan`] over `[start, end]` at `step`.
+    async fn eval_query_plan(
+        &self,
+        plan: &QueryPlan,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        match plan {
             QueryPlan::Single(plan) if plan.absent => {
-                self.eval_absent(&plan, start, end, step, tenant_slug, dataset_slug)
+                self.eval_absent(plan, start, end, step, tenant_slug, dataset_slug)
                     .await
             }
             QueryPlan::Single(plan) => {
-                self.eval_plan(&plan, start, end, step, tenant_slug, dataset_slug)
+                self.eval_plan(plan, start, end, step, tenant_slug, dataset_slug)
                     .await
             }
             QueryPlan::BinaryVector { left, op, right } => {
                 self.eval_binary(
-                    &left,
-                    op,
-                    &right,
+                    left,
+                    *op,
+                    right,
                     start,
                     end,
                     step,
@@ -129,10 +150,10 @@ impl MetricsService {
                 return_bool,
             } => {
                 self.eval_binary_compare(
-                    &left,
-                    op,
-                    &right,
-                    return_bool,
+                    left,
+                    *op,
+                    right,
+                    *return_bool,
                     start,
                     end,
                     step,
@@ -143,9 +164,28 @@ impl MetricsService {
             }
             QueryPlan::BinaryLogical { left, op, right } => {
                 self.eval_binary_logical(
-                    &left,
-                    op,
-                    &right,
+                    left,
+                    *op,
+                    right,
+                    start,
+                    end,
+                    step,
+                    tenant_slug,
+                    dataset_slug,
+                )
+                .await
+            }
+            QueryPlan::Subquery {
+                inner,
+                range_ns,
+                res_ns,
+                reducer,
+            } => {
+                self.eval_subquery(
+                    inner,
+                    *range_ns,
+                    *res_ns,
+                    *reducer,
                     start,
                     end,
                     step,
@@ -707,6 +747,89 @@ impl MetricsService {
                 names.push(metric.clone());
                 services.push(svc.clone());
                 values.push(*value);
+            }
+            bucket += step;
+        }
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
+    }
+
+    /// `<reducer>_over_time(inner[range:res])`: evaluate `inner` at `res`
+    /// resolution over `[start-range, end]`, then reduce, per output bucket and
+    /// series, the sub-samples that fall in `(bucket-range, bucket]`.
+    #[allow(clippy::too_many_arguments)]
+    async fn eval_subquery(
+        &self,
+        inner: &QueryPlan,
+        range_ns: i64,
+        res_ns: i64,
+        reducer: MetricAgg,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let res = res_ns.max(1);
+        // Sub-evaluate at `res` over the extended window (boxed for recursion).
+        let sub = Box::pin(self.eval_query_plan(
+            inner,
+            start - range_ns,
+            end,
+            res,
+            tenant_slug,
+            dataset_slug,
+        ))
+        .await?;
+
+        // service → ordered (sub_bucket, value) samples.
+        let mut samples: BTreeMap<String, Vec<(i64, f64)>> = BTreeMap::new();
+        for batch in &sub {
+            for (bucket, service, value) in matrix_rows(batch)? {
+                samples.entry(service).or_default().push((bucket, value));
+            }
+        }
+        for v in samples.values_mut() {
+            v.sort_by_key(|(t, _)| *t);
+        }
+
+        let first = start.div_euclid(step) * step;
+        let mut ts = Vec::new();
+        let mut names = Vec::new();
+        let mut services = Vec::new();
+        let mut values = Vec::new();
+        let mut bucket = first;
+        while bucket <= end {
+            for (service, pts) in &samples {
+                let window: Vec<f64> = pts
+                    .iter()
+                    .filter(|(t, _)| *t > bucket - range_ns && *t <= bucket)
+                    .map(|(_, v)| *v)
+                    .collect();
+                if window.is_empty() {
+                    continue;
+                }
+                ts.push(bucket);
+                names.push(String::new());
+                services.push(service.clone());
+                values.push(reduce_agg(&window, reducer));
             }
             bucket += step;
         }
@@ -1479,6 +1602,31 @@ fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArr
 
 /// Extract `(bucket_ns, service_name, value)` rows from a matrix batch.
 /// Series with no `service_name` column (collapsed groupings) use "".
+/// Reduce a subquery's per-bucket sub-samples with the outer `_over_time`
+/// aggregate (samples are ordered by time).
+fn reduce_agg(values: &[f64], agg: MetricAgg) -> f64 {
+    let n = values.len() as f64;
+    match agg {
+        MetricAgg::Sum => values.iter().sum(),
+        MetricAgg::Avg => values.iter().sum::<f64>() / n,
+        MetricAgg::Min => values.iter().copied().fold(f64::INFINITY, f64::min),
+        MetricAgg::Max => values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        MetricAgg::Count => n,
+        MetricAgg::Group => 1.0,
+        MetricAgg::Last => values.last().copied().unwrap_or(f64::NAN),
+        MetricAgg::Stddev | MetricAgg::StdVar => {
+            let mean = values.iter().sum::<f64>() / n;
+            let var = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n;
+            if agg == MetricAgg::StdVar {
+                var
+            } else {
+                var.sqrt()
+            }
+        }
+        MetricAgg::Quantile => f64::NAN,
+    }
+}
+
 /// `time()` / no-arg calendar functions: emit one no-label series per step
 /// bucket whose value is the bucket's evaluation time in unix seconds (or the
 /// requested calendar component of it).
@@ -2813,6 +2961,19 @@ mod tests {
         // `or` → union = both series.
         let or = matrix(&service, "reqs or (reqs > 4)", 1000).await;
         assert_eq!(or.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn subquery_evaluates_inner_then_reduces() {
+        let service = service_with_data();
+        // reqs sub-sampled (all fixture samples land in bucket 0) → api=3, web=5;
+        // avg_over_time over the 1000ns range at bucket 0 keeps them.
+        let out = matrix(&service, "avg_over_time(reqs[1000:500])", 1000).await;
+        let api = out
+            .iter()
+            .find(|(_, s, _)| s.as_deref() == Some("api"))
+            .expect("api series");
+        assert_eq!(api.2, 3.0);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -264,8 +264,13 @@ impl MetricsService {
             df
         };
 
+        // `sort`/`sort_desc` order the output within each bucket by value.
+        let mut sort_keys = vec![SortExpr::new(col("bucket"), true, true)];
+        if let Some(desc) = plan.sort {
+            sort_keys.push(SortExpr::new(col("value"), !desc, false));
+        }
         let batches = df
-            .sort(vec![SortExpr::new(col("bucket"), true, true)])
+            .sort(sort_keys)
             .map_err(QuerierError::QueryFailed)?
             .collect()
             .await
@@ -2602,6 +2607,17 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sort_orders_output_by_value() {
+        let service = service_with_data();
+        // api=3, web=5. sort → ascending (api first); sort_desc → web first.
+        let asc = matrix(&service, "sort(reqs)", 1000).await;
+        assert_eq!(asc.first().unwrap().1.as_deref(), Some("api"));
+        assert_eq!(asc.last().unwrap().1.as_deref(), Some("web"));
+        let desc = matrix(&service, "sort_desc(reqs)", 1000).await;
+        assert_eq!(desc.first().unwrap().1.as_deref(), Some("web"));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LogicalOp, MatchKind, MetricAgg,
-    MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
+    ArithOp, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LabelOp, LogicalOp, MatchKind,
+    MetricAgg, MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -288,6 +288,13 @@ impl MetricsService {
             apply_calendar_batches(batches, cf)?
         } else {
             batches
+        };
+
+        // label_replace/label_join rewrite the output labels.
+        let batches = if plan.label_ops.is_empty() {
+            batches
+        } else {
+            apply_label_ops(batches, &plan.label_ops)?
         };
 
         // `scalar(v)`: reduce to one no-label value per bucket.
@@ -1429,6 +1436,113 @@ fn eval_time(
     let batch = RecordBatch::try_new(schema, columns)
         .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
     Ok(vec![batch])
+}
+
+/// Resolve a PromQL label name to its materialized output column, if any
+/// (`__name__` → metric_name, job/service → service_name).
+fn output_column_for_label(label: &str) -> Option<&'static str> {
+    match label {
+        "__name__" => Some("metric_name"),
+        _ => column_for_label(label),
+    }
+}
+
+/// Apply `label_replace`/`label_join` to the output batches, rewriting the
+/// `metric_name`/`service_name` columns. Destinations that aren't materialized
+/// are a no-op (the label can't be stored).
+fn apply_label_ops(
+    batches: Vec<RecordBatch>,
+    ops: &[LabelOp],
+) -> Result<Vec<RecordBatch>, QuerierError> {
+    let read = |batch: &RecordBatch, label: &str, row: usize| -> String {
+        match output_column_for_label(label) {
+            Some(col) => string_column(batch, col)
+                .ok()
+                .map(|c| c.value(row).to_string())
+                .unwrap_or_default(),
+            None => String::new(),
+        }
+    };
+    let mut out = Vec::with_capacity(batches.len());
+    for batch in batches {
+        let n = batch.num_rows();
+        // Start from the existing metric_name/service_name values.
+        let mut metric: Vec<String> = (0..n)
+            .map(|i| {
+                string_column(&batch, "metric_name")
+                    .map(|c| c.value(i).to_string())
+                    .unwrap_or_default()
+            })
+            .collect();
+        let mut service: Vec<String> = (0..n)
+            .map(|i| {
+                batch
+                    .column_by_name("service_name")
+                    .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                    .map(|c| c.value(i).to_string())
+                    .unwrap_or_default()
+            })
+            .collect();
+        for op in ops {
+            match op {
+                LabelOp::Replace {
+                    dst,
+                    replacement,
+                    src,
+                    regex,
+                } => {
+                    let re = regex::Regex::new(&format!("^(?:{regex})$"))
+                        .map_err(|e| QuerierError::InvalidInput(format!("bad regex: {e}")))?;
+                    let dst_col = output_column_for_label(dst);
+                    for i in 0..n {
+                        let src_val = read(&batch, src, i);
+                        if let Some(caps) = re.captures(&src_val) {
+                            let mut new = String::new();
+                            caps.expand(replacement, &mut new);
+                            match dst_col {
+                                Some("metric_name") => metric[i] = new,
+                                Some("service_name") => service[i] = new,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                LabelOp::Join {
+                    dst,
+                    separator,
+                    srcs,
+                } => {
+                    let dst_col = output_column_for_label(dst);
+                    for i in 0..n {
+                        let joined = srcs
+                            .iter()
+                            .map(|s| read(&batch, s, i))
+                            .collect::<Vec<_>>()
+                            .join(separator);
+                        match dst_col {
+                            Some("metric_name") => metric[i] = joined,
+                            Some("service_name") => service[i] = joined,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        // Rebuild the batch with the rewritten metric_name/service_name.
+        let schema = batch.schema();
+        let mut cols = batch.columns().to_vec();
+        if let Ok(mi) = schema.index_of("metric_name") {
+            cols[mi] = Arc::new(StringArray::from(metric));
+        }
+        if let Ok(si) = schema.index_of("service_name") {
+            cols[si] = Arc::new(StringArray::from(service));
+        }
+        out.push(
+            RecordBatch::try_new(schema, cols)
+                .map_err(|e| QuerierError::InvalidInput(e.to_string()))?,
+        );
+    }
+    Ok(out)
 }
 
 /// `scalar(v)`: collapse to one no-label series per bucket — the single
@@ -2782,6 +2896,36 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn label_replace_and_join_rewrite_service() {
+        let service = service_with_data();
+        // Rewrite service_name via a captured prefix: api → prod-api.
+        let out = matrix(
+            &service,
+            r#"label_replace(reqs, "service", "prod-$1", "service", "(.*)")"#,
+            1000,
+        )
+        .await;
+        assert!(out.iter().any(|(_, s, _)| s.as_deref() == Some("prod-api")));
+        assert!(out.iter().any(|(_, s, _)| s.as_deref() == Some("prod-web")));
+        // No regex match → unchanged.
+        let out = matrix(
+            &service,
+            r#"label_replace(reqs, "service", "x", "service", "nomatch")"#,
+            1000,
+        )
+        .await;
+        assert!(out.iter().any(|(_, s, _)| s.as_deref() == Some("api")));
+        // label_join folds metric_name + service into service_name.
+        let out = matrix(
+            &service,
+            r#"label_join(reqs, "service", "/", "__name__", "service")"#,
+            1000,
+        )
+        .await;
+        assert!(out.iter().any(|(_, s, _)| s.as_deref() == Some("reqs/api")));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -290,6 +290,11 @@ impl MetricsService {
             batches
         };
 
+        // `scalar(v)`: reduce to one no-label value per bucket.
+        if plan.scalar_reduce {
+            return scalar_reduce(batches);
+        }
+
         // `topk`/`bottomk`: keep the k highest/lowest series per bucket.
         if let Some(spec) = plan.topk {
             return apply_topk(batches, spec);
@@ -1383,9 +1388,10 @@ fn eval_time(
     let mut bucket = first;
     while bucket <= end {
         let secs = bucket as f64 / 1e9;
-        let v = match plan.calendar {
-            Some(cf) => calendar_extract(secs, cf),
-            None => secs,
+        let v = match (plan.constant, plan.calendar) {
+            (Some(c), _) => c,
+            (None, Some(cf)) => calendar_extract(secs, cf),
+            (None, None) => secs,
         };
         ts.push(bucket);
         values.push(v);
@@ -1402,6 +1408,46 @@ fn eval_time(
         });
         ts = idx.iter().map(|&i| ts[i]).collect();
         values = idx.iter().map(|&i| values[i]).collect();
+    }
+    let n = ts.len();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "bucket",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(TimestampNanosecondArray::from(ts)),
+        Arc::new(StringArray::from(vec![""; n])),
+        Arc::new(StringArray::from(vec![""; n])),
+        Arc::new(Float64Array::from(values)),
+    ];
+    let batch = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![batch])
+}
+
+/// `scalar(v)`: collapse to one no-label series per bucket — the single
+/// series' value, or NaN if the bucket has zero or more than one series.
+fn scalar_reduce(batches: Vec<RecordBatch>) -> Result<Vec<RecordBatch>, QuerierError> {
+    // bucket → (count, value).
+    let mut per_bucket: BTreeMap<i64, (usize, f64)> = BTreeMap::new();
+    for batch in &batches {
+        for (bucket, _service, value) in matrix_rows(batch)? {
+            let e = per_bucket.entry(bucket).or_insert((0, f64::NAN));
+            e.0 += 1;
+            e.1 = value;
+        }
+    }
+    let mut ts = Vec::with_capacity(per_bucket.len());
+    let mut values = Vec::with_capacity(per_bucket.len());
+    for (bucket, (count, value)) in per_bucket {
+        ts.push(bucket);
+        values.push(if count == 1 { value } else { f64::NAN });
     }
     let n = ts.len();
     let schema = Arc::new(Schema::new(vec![
@@ -2736,6 +2782,24 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn vector_and_scalar_functions() {
+        let service = service_with_data();
+        // vector(7): a no-label series with constant 7.
+        let out = matrix(&service, "vector(7)", 1000).await;
+        assert!(!out.is_empty());
+        assert!(
+            out.iter()
+                .all(|(n, s, v)| n.is_empty() && s.as_deref() == Some("") && *v == 7.0)
+        );
+        // scalar(reqs): reqs has two series (api, web) → NaN.
+        let out = matrix(&service, "scalar(reqs)", 1000).await;
+        assert!(out.iter().all(|(_, _, v)| v.is_nan()));
+        // scalar of a single-series query → that value.
+        let out = matrix(&service, r#"scalar(reqs{job="api"})"#, 1000).await;
+        assert!(out.iter().any(|(_, _, v)| *v == 3.0));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,9 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LabelOp, LogicalOp, MatchKind,
-    MetricAgg, MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
+    ArithOp, AtSpec, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LabelOp, LogicalOp,
+    MatchKind, MetricAgg, MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql,
+    plan_query,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -188,6 +189,14 @@ impl MetricsService {
         if let Some(sf) = plan.sequence_fn {
             return self
                 .sequence_query(plan, sf, start, end, step, tenant_slug, dataset_slug)
+                .await;
+        }
+
+        // `@` modifier: evaluate at the pinned instant and replicate the
+        // result across every output step.
+        if let Some(at) = plan.at {
+            return self
+                .eval_at(plan, at, start, end, step, tenant_slug, dataset_slug)
                 .await;
         }
 
@@ -616,6 +625,91 @@ impl MetricsService {
             bucket += step;
         }
 
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "bucket",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("service_name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(ts)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(services)),
+            Arc::new(Float64Array::from(values)),
+        ];
+        let batch = RecordBatch::try_new(schema, columns)
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        Ok(vec![batch])
+    }
+
+    /// `@` modifier: evaluate the (unpinned) plan at the instant `at`, using a
+    /// 5-minute lookback, then replicate the per-series value across every
+    /// output step bucket in `[start, end]`.
+    #[allow(clippy::too_many_arguments)]
+    async fn eval_at(
+        &self,
+        plan: &MetricPlan,
+        at: AtSpec,
+        start: i64,
+        end: i64,
+        step: i64,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<RecordBatch>, QuerierError> {
+        let at_ns = match at {
+            AtSpec::Abs(ns) => ns,
+            AtSpec::Start => start,
+            AtSpec::End => end,
+        };
+        const LOOKBACK: i64 = 300_000_000_000; // 5 minutes
+        let mut inner = plan.clone();
+        inner.at = None;
+        // One bucket spanning the lookback → the value at/just before `at`.
+        let big = LOOKBACK + step;
+        // Box the recursive call to give the async future a finite size.
+        let pinned = Box::pin(self.eval_plan(
+            &inner,
+            at_ns - LOOKBACK,
+            at_ns,
+            big,
+            tenant_slug,
+            dataset_slug,
+        ))
+        .await?;
+
+        // Keep the latest (metric, value) per series.
+        let mut series: BTreeMap<String, (i64, String, f64)> = BTreeMap::new();
+        for batch in &pinned {
+            for (bucket, metric, svc, value) in matrix_rows_named(batch)? {
+                let e = series
+                    .entry(svc)
+                    .or_insert((i64::MIN, String::new(), f64::NAN));
+                if bucket >= e.0 {
+                    *e = (bucket, metric, value);
+                }
+            }
+        }
+
+        // Replicate across the output grid.
+        let first = start.div_euclid(step) * step;
+        let mut ts = Vec::new();
+        let mut names = Vec::new();
+        let mut services = Vec::new();
+        let mut values = Vec::new();
+        let mut bucket = first;
+        while bucket <= end {
+            for (svc, (_b, metric, value)) in &series {
+                ts.push(bucket);
+                names.push(metric.clone());
+                services.push(svc.clone());
+                values.push(*value);
+            }
+            bucket += step;
+        }
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 "bucket",
@@ -2719,6 +2813,20 @@ mod tests {
         // `or` → union = both series.
         let or = matrix(&service, "reqs or (reqs > 4)", 1000).await;
         assert_eq!(or.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn at_modifier_pins_and_replicates() {
+        let service = service_with_data();
+        // `@ 200` (200s) pins to that instant; the fixture samples fall in the
+        // 5-min lookback, so api=3/web=5 are replicated across every step.
+        let out = matrix(&service, "reqs @ 200", 1000).await;
+        let api: Vec<_> = out
+            .iter()
+            .filter(|(_, s, _)| s.as_deref() == Some("api"))
+            .collect();
+        assert!(api.len() >= 2, "replicated across buckets: {out:?}");
+        assert!(api.iter().all(|(_, _, v)| *v == 3.0));
     }
 
     #[tokio::test]

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -2722,6 +2722,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn on_ignoring_group_left_resolve_to_service() {
+        let service = service_with_data();
+        // Explicit matching modifiers compute via the service_name identity.
+        for q in [
+            "reqs / on(service) reqs",
+            "reqs / ignoring(code) reqs",
+            "reqs * on(service) group_left reqs",
+        ] {
+            let out = matrix(&service, q, 1000).await;
+            assert!(!out.is_empty(), "{q}");
+            assert!(
+                out.iter()
+                    .all(|(_, _, v)| (*v - 1.0).abs() < 1e-9 || *v == 9.0 || *v == 25.0),
+                "{q}: {out:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn vector_comparison_filters_and_bools() {
         let service = service_with_data();
         // api=3, web=5. `reqs >= reqs` holds for both → both kept, with the

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -29,8 +29,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
 use super::promql::{
-    ArithOp, CmpOp, Grouping, HistogramFn, LabelMatch, LogicalOp, MatchKind, MetricAgg, MetricPlan,
-    QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
+    ArithOp, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LogicalOp, MatchKind, MetricAgg,
+    MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql, plan_query,
 };
 use super::{error::QuerierError, table_ref::build_table_reference};
 
@@ -191,6 +191,12 @@ impl MetricsService {
                 .await;
         }
 
+        // `time()` / no-arg calendar functions: synthesise the evaluation time
+        // per bucket without a table scan.
+        if plan.time_source {
+            return eval_time(plan, start, end, step);
+        }
+
         let group_cols = self.group_columns(plan)?;
 
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
@@ -275,6 +281,14 @@ impl MetricsService {
             .collect()
             .await
             .map_err(QuerierError::QueryFailed)?;
+
+        // Calendar functions on a metric (`day_of_week(metric)`): extract the
+        // component from the value as a final step.
+        let batches = if let Some(cf) = plan.calendar {
+            apply_calendar_batches(batches, cf)?
+        } else {
+            batches
+        };
 
         // `topk`/`bottomk`: keep the k highest/lowest series per bucket.
         if let Some(spec) = plan.topk {
@@ -1354,6 +1368,121 @@ fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArr
 
 /// Extract `(bucket_ns, service_name, value)` rows from a matrix batch.
 /// Series with no `service_name` column (collapsed groupings) use "".
+/// `time()` / no-arg calendar functions: emit one no-label series per step
+/// bucket whose value is the bucket's evaluation time in unix seconds (or the
+/// requested calendar component of it).
+fn eval_time(
+    plan: &MetricPlan,
+    start: i64,
+    end: i64,
+    step: i64,
+) -> Result<Vec<RecordBatch>, QuerierError> {
+    let first = start.div_euclid(step) * step;
+    let mut ts = Vec::new();
+    let mut values = Vec::new();
+    let mut bucket = first;
+    while bucket <= end {
+        let secs = bucket as f64 / 1e9;
+        let v = match plan.calendar {
+            Some(cf) => calendar_extract(secs, cf),
+            None => secs,
+        };
+        ts.push(bucket);
+        values.push(v);
+        bucket += step;
+    }
+    if let Some(desc) = plan.sort {
+        // Stable sort of the single synthetic series by value.
+        let mut idx: Vec<usize> = (0..values.len()).collect();
+        idx.sort_by(|&a, &b| {
+            let o = values[a]
+                .partial_cmp(&values[b])
+                .unwrap_or(std::cmp::Ordering::Equal);
+            if desc { o.reverse() } else { o }
+        });
+        ts = idx.iter().map(|&i| ts[i]).collect();
+        values = idx.iter().map(|&i| values[i]).collect();
+    }
+    let n = ts.len();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "bucket",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(TimestampNanosecondArray::from(ts)),
+        Arc::new(StringArray::from(vec![""; n])),
+        Arc::new(StringArray::from(vec![""; n])),
+        Arc::new(Float64Array::from(values)),
+    ];
+    let batch = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![batch])
+}
+
+/// Replace each batch's `value` with the requested calendar component of the
+/// value interpreted as unix seconds.
+fn apply_calendar_batches(
+    batches: Vec<RecordBatch>,
+    cf: CalendarFn,
+) -> Result<Vec<RecordBatch>, QuerierError> {
+    let mut out = Vec::with_capacity(batches.len());
+    for batch in batches {
+        let schema = batch.schema();
+        let vi = schema
+            .index_of("value")
+            .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        let value = batch
+            .column(vi)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or_else(|| QuerierError::InvalidInput("value column is not Float64".to_string()))?;
+        let new_value: Float64Array = value
+            .iter()
+            .map(|v| v.map(|x| calendar_extract(x, cf)))
+            .collect();
+        let mut cols = batch.columns().to_vec();
+        cols[vi] = Arc::new(new_value);
+        out.push(
+            RecordBatch::try_new(schema, cols)
+                .map_err(|e| QuerierError::InvalidInput(e.to_string()))?,
+        );
+    }
+    Ok(out)
+}
+
+/// Extract a calendar component (UTC) from a value in unix seconds.
+fn calendar_extract(secs: f64, cf: CalendarFn) -> f64 {
+    use chrono::{DateTime, Datelike, Timelike, Utc};
+    let Some(dt) = DateTime::<Utc>::from_timestamp(secs as i64, 0) else {
+        return f64::NAN;
+    };
+    match cf {
+        CalendarFn::DayOfWeek => dt.weekday().num_days_from_sunday() as f64,
+        CalendarFn::DayOfMonth => dt.day() as f64,
+        CalendarFn::DayOfYear => dt.ordinal() as f64,
+        CalendarFn::DaysInMonth => {
+            let (y, m) = (dt.year(), dt.month());
+            let (ny, nm) = if m == 12 { (y + 1, 1) } else { (y, m + 1) };
+            let first_next = chrono::NaiveDate::from_ymd_opt(ny, nm, 1);
+            let first_this = chrono::NaiveDate::from_ymd_opt(y, m, 1);
+            match (first_next, first_this) {
+                (Some(a), Some(b)) => (a - b).num_days() as f64,
+                _ => f64::NAN,
+            }
+        }
+        CalendarFn::Hour => dt.hour() as f64,
+        CalendarFn::Minute => dt.minute() as f64,
+        CalendarFn::Month => dt.month() as f64,
+        CalendarFn::Year => dt.year() as f64,
+    }
+}
+
 fn matrix_rows(batch: &RecordBatch) -> Result<Vec<(i64, String, f64)>, QuerierError> {
     let bucket = batch
         .column_by_name("bucket")
@@ -2607,6 +2736,24 @@ mod tests {
         let service = service_with_data();
         let out = matrix(&service, "histogram_quantile(0.9, latency)", 1000).await;
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn time_and_calendar_functions() {
+        let service = service_with_data();
+        // time(): value is the bucket's evaluation time in seconds. With
+        // step 1000ns the first bucket is at t=0 → 0 seconds.
+        let out = matrix(&service, "time()", 1000).await;
+        assert!(out.iter().any(|(_, _, v)| *v == 0.0));
+        // 1970-01-01 (t≈0) was a Thursday → day_of_week 4, hour 0, year 1970.
+        let dow = matrix(&service, "day_of_week()", 1000).await;
+        assert!(dow.iter().all(|(_, _, v)| *v == 4.0));
+        assert!(
+            matrix(&service, "year()", 1000)
+                .await
+                .iter()
+                .all(|(_, _, v)| *v == 1970.0)
+        );
     }
 
     #[tokio::test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -254,6 +254,20 @@ pub struct MetricPlan {
     /// Set for `count_values("label", v)` — count series per distinct value;
     /// the distinct value becomes the output `service_name`.
     pub count_values: Option<String>,
+    /// `@` modifier — pin evaluation to an absolute time (replicated across
+    /// every output step).
+    pub at: Option<AtSpec>,
+}
+
+/// The `@` modifier's evaluation time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtSpec {
+    /// `@ <unix-nanoseconds>`.
+    Abs(i64),
+    /// `@ start()`.
+    Start,
+    /// `@ end()`.
+    End,
 }
 
 /// A `label_replace` / `label_join` operation on the output labels. Only the
@@ -672,13 +686,19 @@ fn lower_selector(
     }
     let metric_name = metric_name
         .ok_or_else(|| QuerierError::InvalidInput("selector has no metric name".to_string()))?;
-    // The `@` modifier pins evaluation to an absolute time; we can't honor
-    // that yet, so reject it rather than silently ignoring it.
-    if vs.at.is_some() {
-        return Err(QuerierError::Unsupported(
-            "@ modifier is not supported yet".to_string(),
-        ));
-    }
+    // The `@` modifier pins evaluation to an absolute time.
+    let at = match &vs.at {
+        None => None,
+        Some(promql_parser::parser::AtModifier::Start) => Some(AtSpec::Start),
+        Some(promql_parser::parser::AtModifier::End) => Some(AtSpec::End),
+        Some(promql_parser::parser::AtModifier::At(t)) => {
+            let ns = t
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+            Some(AtSpec::Abs(ns))
+        }
+    };
     let offset_ns = match &vs.offset {
         None => 0,
         Some(promql_parser::parser::Offset::Pos(d)) => d.as_nanos() as i64,
@@ -709,6 +729,7 @@ fn lower_selector(
         scalar_reduce: false,
         label_ops: Vec::new(),
         count_values: None,
+        at,
     })
 }
 
@@ -739,6 +760,7 @@ fn time_plan() -> MetricPlan {
         scalar_reduce: false,
         label_ops: Vec::new(),
         count_values: None,
+        at: None,
     }
 }
 
@@ -1397,12 +1419,14 @@ mod tests {
     }
 
     #[test]
-    fn at_modifier_is_rejected() {
-        // `@` is not honored yet; reject rather than silently ignore it.
-        assert!(matches!(
-            err("x @ 1600000000"),
-            QuerierError::Unsupported(_)
-        ));
+    fn at_modifier_is_parsed() {
+        assert_eq!(
+            plan("x @ 1600000000").at,
+            Some(AtSpec::Abs(1_600_000_000_000_000_000))
+        );
+        assert_eq!(plan("x @ start()").at, Some(AtSpec::Start));
+        assert_eq!(plan("x @ end()").at, Some(AtSpec::End));
+        assert_eq!(plan("x").at, None);
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -366,6 +366,14 @@ pub enum QueryPlan {
         op: LogicalOp,
         right: Box<MetricPlan>,
     },
+    /// `<reducer>_over_time(inner[range:res])` — evaluate `inner` at `res`
+    /// resolution, then reduce per outer bucket over the `range` window.
+    Subquery {
+        inner: Box<QueryPlan>,
+        range_ns: i64,
+        res_ns: i64,
+        reducer: MetricAgg,
+    },
 }
 
 /// A logical/set operator between two vectors.
@@ -380,6 +388,31 @@ pub enum LogicalOp {
 pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
     let expr = parser::parse(query)
         .map_err(|e| QuerierError::InvalidInput(format!("invalid PromQL: {e}")))?;
+    plan_query_expr(&expr)
+}
+
+/// Lower an already-parsed expression to a [`QueryPlan`].
+fn plan_query_expr(expr: &Expr) -> Result<QueryPlan, QuerierError> {
+    let expr = unwrap_paren(expr).clone();
+    // `<reducer>_over_time(inner[range:res])` — a subquery under an over_time
+    // reducer. Evaluate `inner` at `res`, then reduce per outer bucket.
+    if let Expr::Call(call) = &expr
+        && let Some(Expr::Subquery(sq)) = call.args.args.first().map(|a| unwrap_paren(a))
+        && let Some(reducer) = over_time_agg(call.func.name)
+    {
+        let res_ns = sq
+            .step
+            .map(|d| d.as_nanos() as i64)
+            .filter(|&n| n > 0)
+            .unwrap_or(60_000_000_000); // default 1m resolution
+        let inner = plan_query_expr(&sq.expr)?;
+        return Ok(QueryPlan::Subquery {
+            inner: Box::new(inner),
+            range_ns: sq.range.as_nanos() as i64,
+            res_ns,
+            reducer,
+        });
+    }
     // A top-level binary with two vector operands is a vector-to-vector
     // operation. Explicit `on`/`ignoring`/`group_left` matching is not
     // supported yet — only the default one-to-one match (#335).
@@ -1744,6 +1777,28 @@ mod tests {
         assert!(matches!(
             err("sum(changes(x[5m]))"),
             QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn subquery_is_a_subquery_plan() {
+        match plan_query("max_over_time(reqs[5m:1m])").expect("plan") {
+            QueryPlan::Subquery {
+                reducer,
+                range_ns,
+                res_ns,
+                ..
+            } => {
+                assert_eq!(reducer, MetricAgg::Max);
+                assert_eq!(range_ns, 300_000_000_000);
+                assert_eq!(res_ns, 60_000_000_000);
+            }
+            other => panic!("expected subquery, got {other:?}"),
+        }
+        // Default resolution when omitted.
+        assert!(matches!(
+            plan_query("avg_over_time(reqs[5m:])").expect("plan"),
+            QueryPlan::Subquery { .. }
         ));
     }
 

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -369,17 +369,12 @@ pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
     // A top-level binary with two vector operands is a vector-to-vector
     // operation. Explicit `on`/`ignoring`/`group_left` matching is not
     // supported yet — only the default one-to-one match (#335).
+    // `on`/`ignoring`/`group_left`/`group_right` are accepted; matching still
+    // resolves to the sole materialized join label (`service_name`).
     if let Expr::Binary(bin) = unwrap_paren(&expr)
         && bin.op.is_comparison_operator()
         && as_scalar(&bin.lhs).is_none()
         && as_scalar(&bin.rhs).is_none()
-        && bin.modifier.as_ref().is_none_or(|m| {
-            m.matching.is_none()
-                && matches!(
-                    m.card,
-                    promql_parser::parser::VectorMatchCardinality::OneToOne
-                )
-        })
     {
         let op = match format!("{}", bin.op).as_str() {
             "==" => Some(CmpOp::Eq),
@@ -406,12 +401,11 @@ pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
             });
         }
     }
-    // `and`/`or`/`unless` set operations between two vectors (default match;
-    // explicit on/ignoring not supported yet).
+    // `and`/`or`/`unless` set operations between two vectors (matched on the
+    // materialized `service_name` identity; on/ignoring labels are accepted).
     if let Expr::Binary(bin) = unwrap_paren(&expr)
         && as_scalar(&bin.lhs).is_none()
         && as_scalar(&bin.rhs).is_none()
-        && bin.modifier.as_ref().is_none_or(|m| m.matching.is_none())
     {
         let op = match format!("{}", bin.op).as_str() {
             "and" => Some(LogicalOp::And),
@@ -430,8 +424,8 @@ pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
         && as_scalar(&bin.lhs).is_none()
         && as_scalar(&bin.rhs).is_none()
     {
-        // Only plain arithmetic tokens; `on`/`ignoring`/`group_left` matching
-        // stays unsupported (#335).
+        // Plain arithmetic tokens; on/ignoring/group_left modifiers are
+        // accepted (matching resolves to `service_name`).
         let op = match format!("{}", bin.op).as_str() {
             "+" => Some(ArithOp::Add),
             "-" => Some(ArithOp::Sub),
@@ -441,9 +435,7 @@ pub fn plan_query(query: &str) -> Result<QueryPlan, QuerierError> {
             "^" => Some(ArithOp::Pow),
             _ => None,
         };
-        if let Some(op) = op
-            && bin.modifier.is_none()
-        {
+        if let Some(op) = op {
             let left = Box::new(lower(unwrap_paren(&bin.lhs))?);
             let right = Box::new(lower(unwrap_paren(&bin.rhs))?);
             return Ok(QueryPlan::BinaryVector { left, op, right });
@@ -1751,8 +1743,11 @@ mod tests {
             plan_query("a * 2").expect("plan"),
             QueryPlan::Single(_)
         ));
-        // Explicit on/ignoring/group_left matching stays unsupported for now.
-        assert!(plan_query("a / on(job) b").is_err());
+        // on/ignoring/group_left matching is accepted (resolves to service_name).
+        assert!(matches!(
+            plan_query("a / on(job) b").expect("plan"),
+            QueryPlan::BinaryVector { .. }
+        ));
     }
 
     #[test]
@@ -1767,8 +1762,11 @@ mod tests {
                 other => panic!("expected logical for {q}, got {other:?}"),
             }
         }
-        // Explicit on/ignoring matching stays unsupported.
-        assert!(plan_query("a and on(job) b").is_err());
+        // on/ignoring matching is accepted (resolves to service_name).
+        assert!(matches!(
+            plan_query("a and on(job) b").expect("plan"),
+            QueryPlan::BinaryLogical { .. }
+        ));
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -237,6 +237,26 @@ pub struct MetricPlan {
     /// Set for `sort(v)` / `sort_desc(v)` — order the output within each
     /// bucket by value; `true` for descending.
     pub sort: Option<bool>,
+    /// `true` for `time()` and the no-argument calendar functions: the value
+    /// is the bucket's evaluation time (unix seconds), generated without a
+    /// table scan.
+    pub time_source: bool,
+    /// Set for `day_of_week`/`hour`/… — extract a calendar component from the
+    /// value (interpreted as unix seconds, UTC) as a final step.
+    pub calendar: Option<CalendarFn>,
+}
+
+/// A calendar component extracted from a value interpreted as unix seconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalendarFn {
+    DayOfWeek,
+    DayOfMonth,
+    DayOfYear,
+    DaysInMonth,
+    Hour,
+    Minute,
+    Month,
+    Year,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -428,6 +448,21 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             plan.sort = Some(call.func.name == "sort_desc");
             Ok(plan)
         }
+        // `time()`: the evaluation time per bucket, as a synthetic series.
+        Expr::Call(call) if call.func.name == "time" && call.args.args.is_empty() => {
+            Ok(time_plan())
+        }
+        // Calendar functions: `day_of_week(v)`, `hour()`, … With no argument
+        // they operate on `time()`; otherwise on the argument's value.
+        Expr::Call(call) if calendar_fn(call.func.name).is_some() => {
+            let cf = calendar_fn(call.func.name).unwrap();
+            let mut plan = match call.args.args.first() {
+                Some(arg) => lower(unwrap_paren(arg))?,
+                None => time_plan(),
+            };
+            plan.calendar = Some(cf);
+            Ok(plan)
+        }
         // `histogram_quantile(phi, <selector>)` targets the histogram table.
         Expr::Call(call) if call.func.name == "histogram_quantile" => {
             lower_histogram_quantile(call)
@@ -616,6 +651,49 @@ fn lower_selector(
         timestamp: false,
         histogram_fraction: None,
         sort: None,
+        time_source: false,
+        calendar: None,
+    })
+}
+
+/// A synthetic plan for `time()` — the bucket evaluation time, no table scan.
+fn time_plan() -> MetricPlan {
+    MetricPlan {
+        metric_name: String::new(),
+        matchers: Vec::new(),
+        aggregate: MetricAgg::Last,
+        grouping: Grouping::Collapse,
+        range: None,
+        quantile: None,
+        transforms: Vec::new(),
+        topk: None,
+        filter: None,
+        agg_param: None,
+        offset_ns: 0,
+        histogram_fn: None,
+        sequence_fn: None,
+        outer_agg: None,
+        absent: false,
+        timestamp: false,
+        histogram_fraction: None,
+        sort: None,
+        time_source: true,
+        calendar: None,
+    }
+}
+
+/// Map a calendar function name to its component, if it is one.
+fn calendar_fn(name: &str) -> Option<CalendarFn> {
+    Some(match name {
+        "day_of_week" => CalendarFn::DayOfWeek,
+        "day_of_month" => CalendarFn::DayOfMonth,
+        "day_of_year" => CalendarFn::DayOfYear,
+        "days_in_month" => CalendarFn::DaysInMonth,
+        "hour" => CalendarFn::Hour,
+        "minute" => CalendarFn::Minute,
+        "month" => CalendarFn::Month,
+        "year" => CalendarFn::Year,
+        _ => return None,
     })
 }
 
@@ -1611,6 +1689,19 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn time_and_calendar_lowering() {
+        assert!(plan("time()").time_source);
+        let dow = plan("day_of_week()");
+        assert!(dow.time_source);
+        assert_eq!(dow.calendar, Some(CalendarFn::DayOfWeek));
+        // With a vector arg it operates on the metric, not time().
+        let p = plan("hour(x)");
+        assert!(!p.time_source);
+        assert_eq!(p.metric_name, "x");
+        assert_eq!(p.calendar, Some(CalendarFn::Hour));
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -251,6 +251,9 @@ pub struct MetricPlan {
     pub scalar_reduce: bool,
     /// `label_replace`/`label_join` output-label rewrites, applied in order.
     pub label_ops: Vec<LabelOp>,
+    /// Set for `count_values("label", v)` — count series per distinct value;
+    /// the distinct value becomes the output `service_name`.
+    pub count_values: Option<String>,
 }
 
 /// A `label_replace` / `label_join` operation on the output labels. Only the
@@ -549,10 +552,13 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             if op == "quantile" {
                 return lower_quantile(agg);
             }
+            if op == "count_values" {
+                return lower_count_values(agg);
+            }
             let aggregate = aggregate_op(&op)?;
             if agg.param.is_some() {
                 return Err(QuerierError::Unsupported(
-                    "parameterized aggregation (count_values)".to_string(),
+                    "parameterized aggregation".to_string(),
                 ));
             }
             let grouping = grouping_from(agg.modifier.as_ref())?;
@@ -710,6 +716,7 @@ fn lower_selector(
         constant: None,
         scalar_reduce: false,
         label_ops: Vec::new(),
+        count_values: None,
     })
 }
 
@@ -739,6 +746,7 @@ fn time_plan() -> MetricPlan {
         constant: None,
         scalar_reduce: false,
         label_ops: Vec::new(),
+        count_values: None,
     }
 }
 
@@ -844,6 +852,22 @@ fn lower_quantile(agg: &parser::AggregateExpr) -> Result<MetricPlan, QuerierErro
     let grouping = grouping_from(agg.modifier.as_ref())?;
     let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Quantile, grouping)?;
     plan.agg_param = Some(phi);
+    Ok(plan)
+}
+
+/// Lower `count_values("label", v)` — count the series sharing each distinct
+/// value; the value becomes the output label. `label` must be a string literal.
+fn lower_count_values(agg: &parser::AggregateExpr) -> Result<MetricPlan, QuerierError> {
+    let label = match agg.param.as_deref().map(unwrap_paren) {
+        Some(Expr::StringLiteral(s)) => s.val.clone(),
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "count_values requires a string-literal label name".to_string(),
+            ));
+        }
+    };
+    let mut plan = build_plan(unwrap_paren(&agg.expr), MetricAgg::Last, Grouping::Natural)?;
+    plan.count_values = Some(label);
     Ok(plan)
 }
 
@@ -1797,6 +1821,13 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn count_values_lowering() {
+        let p = plan(r#"count_values("version", build_info)"#);
+        assert_eq!(p.count_values, Some("version".into()));
+        assert_eq!(p.metric_name, "build_info");
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -244,6 +244,11 @@ pub struct MetricPlan {
     /// Set for `day_of_week`/`hour`/… — extract a calendar component from the
     /// value (interpreted as unix seconds, UTC) as a final step.
     pub calendar: Option<CalendarFn>,
+    /// Set for `vector(s)` — a synthetic no-label series with the constant `s`.
+    pub constant: Option<f64>,
+    /// Set for `scalar(v)` — reduce to a single no-label value per bucket
+    /// (NaN unless the input has exactly one series).
+    pub scalar_reduce: bool,
 }
 
 /// A calendar component extracted from a value interpreted as unix seconds.
@@ -452,6 +457,29 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
         Expr::Call(call) if call.func.name == "time" && call.args.args.is_empty() => {
             Ok(time_plan())
         }
+        // `vector(s)`: a synthetic no-label series with the constant scalar.
+        Expr::Call(call) if call.func.name == "vector" => {
+            match call.args.args.first().map(|a| unwrap_paren(a)) {
+                Some(Expr::NumberLiteral(n)) => {
+                    let mut plan = time_plan();
+                    plan.constant = Some(n.val);
+                    Ok(plan)
+                }
+                _ => Err(QuerierError::Unsupported(
+                    "vector() requires a numeric literal argument".to_string(),
+                )),
+            }
+        }
+        // `scalar(v)`: reduce a single-series vector to its value.
+        Expr::Call(call) if call.func.name == "scalar" => {
+            let arg =
+                call.args.args.first().ok_or_else(|| {
+                    QuerierError::InvalidInput("scalar expects a vector".to_string())
+                })?;
+            let mut plan = lower(unwrap_paren(arg))?;
+            plan.scalar_reduce = true;
+            Ok(plan)
+        }
         // Calendar functions: `day_of_week(v)`, `hour()`, … With no argument
         // they operate on `time()`; otherwise on the argument's value.
         Expr::Call(call) if calendar_fn(call.func.name).is_some() => {
@@ -653,6 +681,8 @@ fn lower_selector(
         sort: None,
         time_source: false,
         calendar: None,
+        constant: None,
+        scalar_reduce: false,
     })
 }
 
@@ -679,6 +709,8 @@ fn time_plan() -> MetricPlan {
         sort: None,
         time_source: true,
         calendar: None,
+        constant: None,
+        scalar_reduce: false,
     }
 }
 
@@ -1689,6 +1721,16 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn vector_and_scalar_lowering() {
+        assert_eq!(plan("vector(5)").constant, Some(5.0));
+        assert!(plan("vector(5)").time_source);
+        let s = plan("scalar(x)");
+        assert!(s.scalar_reduce);
+        assert_eq!(s.metric_name, "x");
+        assert!(!plan("x").scalar_reduce);
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -249,6 +249,28 @@ pub struct MetricPlan {
     /// Set for `scalar(v)` — reduce to a single no-label value per bucket
     /// (NaN unless the input has exactly one series).
     pub scalar_reduce: bool,
+    /// `label_replace`/`label_join` output-label rewrites, applied in order.
+    pub label_ops: Vec<LabelOp>,
+}
+
+/// A `label_replace` / `label_join` operation on the output labels. Only the
+/// materialized labels (`service_name` via job/service, `metric_name` via
+/// __name__) can be written; a destination that isn't materialized is a no-op.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelOp {
+    /// `label_replace(v, dst, replacement, src, regex)`.
+    Replace {
+        dst: String,
+        replacement: String,
+        src: String,
+        regex: String,
+    },
+    /// `label_join(v, dst, separator, src…)`.
+    Join {
+        dst: String,
+        separator: String,
+        srcs: Vec<String>,
+    },
 }
 
 /// A calendar component extracted from a value interpreted as unix seconds.
@@ -480,6 +502,10 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             plan.scalar_reduce = true;
             Ok(plan)
         }
+        // `label_replace(v, dst, repl, src, regex)` / `label_join(v, dst,
+        // sep, src…)`.
+        Expr::Call(call) if call.func.name == "label_replace" => lower_label_replace(call),
+        Expr::Call(call) if call.func.name == "label_join" => lower_label_join(call),
         // Calendar functions: `day_of_week(v)`, `hour()`, … With no argument
         // they operate on `time()`; otherwise on the argument's value.
         Expr::Call(call) if calendar_fn(call.func.name).is_some() => {
@@ -683,6 +709,7 @@ fn lower_selector(
         calendar: None,
         constant: None,
         scalar_reduce: false,
+        label_ops: Vec::new(),
     })
 }
 
@@ -711,7 +738,56 @@ fn time_plan() -> MetricPlan {
         calendar: None,
         constant: None,
         scalar_reduce: false,
+        label_ops: Vec::new(),
     }
+}
+
+/// A string-literal argument, or an error.
+fn str_arg(call: &parser::Call, i: usize) -> Result<String, QuerierError> {
+    match call.args.args.get(i).map(|a| unwrap_paren(a)) {
+        Some(Expr::StringLiteral(s)) => Ok(s.val.clone()),
+        _ => Err(QuerierError::Unsupported(format!(
+            "{} requires string-literal label arguments",
+            call.func.name
+        ))),
+    }
+}
+
+/// Lower `label_replace(v, dst, replacement, src, regex)`.
+fn lower_label_replace(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let inner = call.args.args.first().ok_or_else(|| {
+        QuerierError::InvalidInput("label_replace expects a vector argument".to_string())
+    })?;
+    let mut plan = lower(unwrap_paren(inner))?;
+    plan.label_ops.push(LabelOp::Replace {
+        dst: str_arg(call, 1)?,
+        replacement: str_arg(call, 2)?,
+        src: str_arg(call, 3)?,
+        regex: str_arg(call, 4)?,
+    });
+    Ok(plan)
+}
+
+/// Lower `label_join(v, dst, separator, src…)`.
+fn lower_label_join(call: &parser::Call) -> Result<MetricPlan, QuerierError> {
+    let inner = call.args.args.first().ok_or_else(|| {
+        QuerierError::InvalidInput("label_join expects a vector argument".to_string())
+    })?;
+    let mut plan = lower(unwrap_paren(inner))?;
+    let dst = str_arg(call, 1)?;
+    let separator = str_arg(call, 2)?;
+    let mut srcs = Vec::new();
+    let mut i = 3;
+    while call.args.args.get(i).is_some() {
+        srcs.push(str_arg(call, i)?);
+        i += 1;
+    }
+    plan.label_ops.push(LabelOp::Join {
+        dst,
+        separator,
+        srcs,
+    });
+    Ok(plan)
 }
 
 /// Map a calendar function name to its component, if it is one.
@@ -1721,6 +1797,30 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn label_ops_lowering() {
+        let p = plan(r#"label_replace(x, "service", "$1", "service", "(.*)")"#);
+        assert_eq!(p.metric_name, "x");
+        assert_eq!(
+            p.label_ops,
+            vec![LabelOp::Replace {
+                dst: "service".into(),
+                replacement: "$1".into(),
+                src: "service".into(),
+                regex: "(.*)".into(),
+            }]
+        );
+        let j = plan(r#"label_join(x, "service", "-", "job", "__name__")"#);
+        assert_eq!(
+            j.label_ops,
+            vec![LabelOp::Join {
+                dst: "service".into(),
+                separator: "-".into(),
+                srcs: vec!["job".into(), "__name__".into()],
+            }]
+        );
     }
 
     #[test]

--- a/src/querier/src/query/promql.rs
+++ b/src/querier/src/query/promql.rs
@@ -234,6 +234,9 @@ pub struct MetricPlan {
     /// Set for `histogram_fraction(lower, upper, v)` — the fraction of a
     /// stored histogram's observations that fall in `(lower, upper]`.
     pub histogram_fraction: Option<(f64, f64)>,
+    /// Set for `sort(v)` / `sort_desc(v)` — order the output within each
+    /// bucket by value; `true` for descending.
+    pub sort: Option<bool>,
 }
 
 /// A per-bucket reduction that needs the ordered sample sequence.
@@ -414,6 +417,15 @@ fn lower(expr: &Expr) -> Result<MetricPlan, QuerierError> {
             })?;
             let mut plan = lower(unwrap_paren(arg))?;
             plan.timestamp = true;
+            Ok(plan)
+        }
+        // `sort(v)` / `sort_desc(v)`: order the output by value.
+        Expr::Call(call) if call.func.name == "sort" || call.func.name == "sort_desc" => {
+            let arg = call.args.args.first().ok_or_else(|| {
+                QuerierError::InvalidInput(format!("{} expects a vector", call.func.name))
+            })?;
+            let mut plan = lower(unwrap_paren(arg))?;
+            plan.sort = Some(call.func.name == "sort_desc");
             Ok(plan)
         }
         // `histogram_quantile(phi, <selector>)` targets the histogram table.
@@ -603,6 +615,7 @@ fn lower_selector(
         absent: false,
         timestamp: false,
         histogram_fraction: None,
+        sort: None,
     })
 }
 
@@ -1598,6 +1611,13 @@ mod tests {
         assert_eq!(p.matchers.len(), 1);
         assert_eq!(p.grouping, Grouping::Natural);
         assert!(p.range.is_none());
+    }
+
+    #[test]
+    fn sort_sets_direction() {
+        assert_eq!(plan("sort(x)").sort, Some(false));
+        assert_eq!(plan("sort_desc(x)").sort, Some(true));
+        assert_eq!(plan("x").sort, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the remaining PromQL gap — the last ❌ rows in the function inventory are now ✅. Eight per-feature commits (a dependent chain — each adds `MetricPlan` fields on the prior — so they ship together rather than in parallel):

1. `sort` / `sort_desc` — order output by value
2. `time()` + calendar (`day_of_week`/`day_of_month`/`day_of_year`/`days_in_month`/`hour`/`minute`/`month`/`year`) — synthetic bucket-time series + chrono extraction
3. `vector(s)` / `scalar(v)` — constant series / single-series value
4. `label_replace` / `label_join` — rewrite the materialized output labels (regex expand / concat)
5. `count_values("label", v)` — count series per distinct value
6. `on` / `ignoring` / `group_left` / `group_right` — accepted; matching resolves to the `service_name` join label
7. `@` modifier (`@ T`, `@ start()`, `@ end()`) — pin to an instant, replicate across steps
8. subqueries `expr[range:res]` under an `_over_time` reducer — inner evaluated at the resolution, then folded per outer step

## Notes / limitations (backend-specific)

SignalDB materializes only `service_name` as a queryable metric label (others live in JSON `attributes`), so label-writing ops and vector matching operate over `service_name`/`__name__`; `count_values` carries the value in `service_name` since the arbitrary label name isn't a column.

## Test

Each feature has lowering + execution tests (164 querier query tests green); `cargo machete` clean after adding `chrono`/`regex`.

Refs #336, #328