### PR TITLE
feat(logql): support avg/min/max/count outer aggregations

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -125,8 +125,10 @@ sum by (level) (rate({service_name="api"}[5m]))
 - **Range functions**: `count_over_time`, `rate`, `bytes_over_time`,
   `bytes_rate`, and the unwrap-based `sum_over_time` / `avg_over_time` /
   `min_over_time` / `max_over_time`.
-- **Vector aggregation**: a single outer `sum by (...)` /
-  `sum without ()` wrapping one of the above.
+- **Vector aggregation**: a single outer `sum` / `avg` / `min` / `max` /
+  `count`, with `by (...)` or `without ()`, wrapping one of the above.
+  `sum` folds into the grouped range aggregate; the others reduce the
+  per-series range aggregation across the series in each group.
 - **Grouping** is only supported by labels backed by a column
   (`service_name`, `level`, ...).
 
@@ -143,8 +145,8 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk`, `quantile_over_time`, and non-`sum` outer
-  aggregations (`avg`/`min`/`max`/`count` over a range aggregation)
+- `topk` / `bottomk`, `stddev` / `stdvar`, `sort` / `sort_desc`, and
+  `quantile_over_time`
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -16,12 +16,13 @@
 //!
 //! - Range aggregations: `count_over_time`, `rate`, `bytes_over_time`,
 //!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`.
-//! - A single outer `sum by (...)` / `sum without ()` vector aggregation
-//!   wrapping one of the above (sum-of-counts folds into a grouped
-//!   count/rate).
+//! - A single outer vector aggregation wrapping one of the above:
+//!   `sum` (sum-of-counts folds into a grouped count/rate), and
+//!   `avg` / `min` / `max` / `count`, which reduce the range
+//!   aggregation across series within each group (see [`OuterAgg`]).
 //!
-//! Binary operators, `topk`/`bottomk`, `quantile*`, `vector()`,
-//! `label_replace`, and non-`sum` outer aggregations return
+//! Binary operators, `topk`/`bottomk` (parameterized aggregations),
+//! `quantile*`, `vector()`, and `label_replace` return
 //! [`QuerierError::Unsupported`].
 
 use logql::{AggregationFunction, Grouping, LogQuery, MetricQuery, RangeFunction};
@@ -45,6 +46,24 @@ pub enum Aggregate {
     UnwrapMax(String),
 }
 
+/// A non-`sum` outer vector aggregation that reduces the per-series range
+/// aggregation across the series in each group.
+///
+/// `sum` is absent because it folds directly into the grouped range
+/// aggregate (sum-of-counts == count-of-group) and needs no second pass;
+/// the others genuinely reduce across per-series values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OuterAgg {
+    /// `avg(...)` — mean of the per-series values.
+    Avg,
+    /// `min(...)` — smallest per-series value.
+    Min,
+    /// `max(...)` — largest per-series value.
+    Max,
+    /// `count(...)` — number of series with data in the bucket.
+    Count,
+}
+
 /// A lowered metric query.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricPlan {
@@ -57,6 +76,11 @@ pub struct MetricPlan {
     pub aggregate: Aggregate,
     /// When set, divide the aggregate by this many seconds (`rate`).
     pub rate_divisor_seconds: Option<f64>,
+    /// A non-`sum` outer aggregation to apply across series after the range
+    /// aggregation. When set, `group_labels` names the surviving group
+    /// (empty = collapse across all series); when `None`, the range
+    /// aggregation is grouped directly by `group_labels`.
+    pub outer_agg: Option<OuterAgg>,
     /// The `[range]` window in nanoseconds (informational; bucketing uses
     /// the caller's step).
     pub range_ns: u128,
@@ -67,15 +91,22 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
     match query {
         MetricQuery::Range(range) => plan_range(range, Vec::new()),
         MetricQuery::Vector(vector) => {
-            // Only a `sum` outer aggregation folds cleanly into grouped
-            // counts/rates; others need per-series values we don't
-            // materialize.
-            if vector.function != AggregationFunction::Sum {
-                return Err(QuerierError::Unsupported(format!(
-                    "outer aggregation '{:?}' over a range aggregation",
-                    vector.function
-                )));
-            }
+            // `sum` folds into the grouped range aggregate (`outer_agg`
+            // stays `None`); `avg`/`min`/`max`/`count` reduce across series
+            // in a second pass. `topk`/`bottomk` and other parameterized or
+            // exotic aggregations still need per-series machinery we lack.
+            let outer_agg = match vector.function {
+                AggregationFunction::Sum => None,
+                AggregationFunction::Avg => Some(OuterAgg::Avg),
+                AggregationFunction::Min => Some(OuterAgg::Min),
+                AggregationFunction::Max => Some(OuterAgg::Max),
+                AggregationFunction::Count => Some(OuterAgg::Count),
+                other => {
+                    return Err(QuerierError::Unsupported(format!(
+                        "outer aggregation '{other:?}' over a range aggregation"
+                    )));
+                }
+            };
             if vector.param.is_some() {
                 return Err(QuerierError::Unsupported(
                     "parameterized outer aggregation".to_string(),
@@ -83,7 +114,11 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
             }
             let group_labels = grouping_labels(vector.grouping.as_ref())?;
             match &vector.inner {
-                MetricQuery::Range(range) => plan_range(range, group_labels),
+                MetricQuery::Range(range) => {
+                    let mut plan = plan_range(range, group_labels)?;
+                    plan.outer_agg = outer_agg;
+                    Ok(plan)
+                }
                 other => Err(QuerierError::Unsupported(format!(
                     "nested metric expression: {other:?}"
                 ))),
@@ -146,6 +181,7 @@ fn plan_range(
         group_labels,
         aggregate,
         rate_divisor_seconds,
+        outer_agg: None,
         range_ns: range.range.as_nanos(),
     })
 }
@@ -247,13 +283,43 @@ mod tests {
     }
 
     #[test]
+    fn non_sum_outer_aggregations_reduce_across_series() {
+        // `sum` folds into the grouped range aggregate (no second pass).
+        let s = plan(r#"sum by (level) (rate({a="b"}[5m]))"#);
+        assert_eq!(s.outer_agg, None);
+        assert_eq!(s.group_labels, vec!["level".to_string()]);
+
+        // The others carry an `OuterAgg` for the cross-series reduction.
+        for (query, expected) in [
+            (r#"avg(rate({a="b"}[5m]))"#, OuterAgg::Avg),
+            (r#"min(rate({a="b"}[5m]))"#, OuterAgg::Min),
+            (r#"max by (level) (rate({a="b"}[5m]))"#, OuterAgg::Max),
+            (
+                r#"count by (level) (count_over_time({a="b"}[5m]))"#,
+                OuterAgg::Count,
+            ),
+        ] {
+            let p = plan(query);
+            assert_eq!(p.outer_agg, Some(expected), "{query}");
+        }
+
+        // `by` labels survive onto the plan for the second pass.
+        assert_eq!(
+            plan(r#"max by (level) (rate({a="b"}[5m]))"#).group_labels,
+            vec!["level".to_string()]
+        );
+        // No `by`: collapse across all series (empty group).
+        assert!(plan(r#"avg(rate({a="b"}[5m]))"#).group_labels.is_empty());
+    }
+
+    #[test]
     fn unsupported_shapes_are_rejected() {
         assert!(matches!(
             err(r#"topk(5, rate({a="b"}[5m]))"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(
-            err(r#"avg(rate({a="b"}[5m]))"#),
+            err(r#"stddev(rate({a="b"}[5m]))"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -27,7 +27,7 @@ use datafusion::{
 use logql::{Expr as LogqlExpr, LogQuery, parse, parse_query, parse_selector};
 
 use super::logql::log_query_filter;
-use super::logql_metric::{Aggregate, plan_metric_query};
+use super::logql_metric::{Aggregate, OuterAgg, plan_metric_query};
 use super::{
     LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
 };
@@ -175,19 +175,27 @@ impl LogsService {
         let plan = plan_metric_query(&metric)?;
         let filter = log_query_filter(&plan.log_query)?;
 
-        // Resolve the grouping columns; unknown labels can't be grouped
-        // with the substring attribute model.
-        let group_cols: Vec<&'static str> = if plan.group_labels.is_empty() {
-            SERIES_COLUMNS.to_vec()
-        } else {
-            plan.group_labels
-                .iter()
-                .map(|label| {
-                    column_for_label(label).ok_or_else(|| {
-                        QuerierError::Unsupported(format!("grouping by attribute label '{label}'"))
-                    })
+        // Resolve the output grouping columns (the `by` labels); unknown
+        // labels can't be grouped with the substring attribute model.
+        let out_group_cols: Vec<&'static str> = plan
+            .group_labels
+            .iter()
+            .map(|label| {
+                column_for_label(label).ok_or_else(|| {
+                    QuerierError::Unsupported(format!("grouping by attribute label '{label}'"))
                 })
-                .collect::<Result<_, _>>()?
+            })
+            .collect::<Result<_, _>>()?;
+
+        // The range aggregation groups by the output columns directly for a
+        // plain or `sum`-folded query (defaulting to the natural series
+        // identity). A non-`sum` outer aggregation instead groups by the
+        // full series identity so the second pass has per-series values to
+        // reduce across.
+        let range_group_cols: Vec<&'static str> = match plan.outer_agg {
+            None if out_group_cols.is_empty() => SERIES_COLUMNS.to_vec(),
+            None => out_group_cols.clone(),
+            Some(_) => SERIES_COLUMNS.to_vec(),
         };
 
         let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
@@ -210,7 +218,7 @@ impl LogsService {
         let bucket = date_bin(stride, timestamp_ns, origin).alias("bucket");
 
         let mut group_exprs = vec![bucket];
-        group_exprs.extend(group_cols.iter().map(|c| col(*c)));
+        group_exprs.extend(range_group_cols.iter().map(|c| col(*c)));
 
         let value = aggregate_expr(&plan.aggregate).alias("value");
         df = df
@@ -220,7 +228,7 @@ impl LogsService {
         // Normalize `value` to Float64 (count/bytes aggregate to Int64)
         // and apply the `rate` divisor in the same projection.
         let mut proj = vec![col("bucket")];
-        proj.extend(group_cols.iter().map(|c| col(*c)));
+        proj.extend(range_group_cols.iter().map(|c| col(*c)));
         let value = cast(col("value"), DataType::Float64);
         let value = match plan.rate_divisor_seconds {
             Some(seconds) => value / lit(seconds),
@@ -228,6 +236,23 @@ impl LogsService {
         };
         proj.push(value.alias("value"));
         df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+
+        // Second pass: reduce the per-series range aggregation across series
+        // within each output group (`avg`/`min`/`max`/`count`).
+        if let Some(outer) = plan.outer_agg {
+            let mut group_exprs = vec![col("bucket")];
+            group_exprs.extend(out_group_cols.iter().map(|c| col(*c)));
+            let reduced = outer_agg_expr(outer, col("value")).alias("value");
+            df = df
+                .aggregate(group_exprs, vec![reduced])
+                .map_err(QuerierError::QueryFailed)?;
+
+            // `count` reduces to Int64; keep the matrix value Float64.
+            let mut proj = vec![col("bucket")];
+            proj.extend(out_group_cols.iter().map(|c| col(*c)));
+            proj.push(cast(col("value"), DataType::Float64).alias("value"));
+            df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+        }
 
         df.sort(vec![col("bucket").sort(true, true)])
             .map_err(QuerierError::QueryFailed)?
@@ -447,6 +472,17 @@ fn aggregate_expr(aggregate: &Aggregate) -> Expr {
         Aggregate::UnwrapAvg(label) => avg(unwrap_value(label)),
         Aggregate::UnwrapMin(label) => min(unwrap_value(label)),
         Aggregate::UnwrapMax(label) => max(unwrap_value(label)),
+    }
+}
+
+/// Build the second-pass expression that reduces the per-series range
+/// aggregation across series within a group (non-`sum` outer aggregation).
+fn outer_agg_expr(outer: OuterAgg, value: Expr) -> Expr {
+    match outer {
+        OuterAgg::Avg => avg(value),
+        OuterAgg::Min => min(value),
+        OuterAgg::Max => max(value),
+        OuterAgg::Count => count(value),
     }
 }
 
@@ -800,6 +836,57 @@ mod tests {
             .find(|(_, s)| s.as_deref() == Some("api"))
             .unwrap();
         assert_eq!(api.0, 2.0);
+    }
+
+    #[tokio::test]
+    async fn count_outer_aggregation_counts_series() {
+        let service = service_with_data();
+        // Three natural series (api/error, api/info, web/error) collapse to
+        // a single value: the series count.
+        let out = matrix(
+            &service,
+            r#"count(count_over_time({service_name=~".+"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, 3.0);
+    }
+
+    #[tokio::test]
+    async fn count_by_service_counts_series_per_group() {
+        let service = service_with_data();
+        // api has two series (error, info), web one.
+        let out = matrix(
+            &service,
+            r#"count by (service_name) (count_over_time({service_name=~".+"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        let get = |name: &str| {
+            out.iter()
+                .find(|(_, s)| s.as_deref() == Some(name))
+                .unwrap()
+                .0
+        };
+        assert_eq!(out.len(), 2);
+        assert_eq!(get("api"), 2.0);
+        assert_eq!(get("web"), 1.0);
+    }
+
+    #[tokio::test]
+    async fn avg_by_service_reduces_across_series() {
+        let service = service_with_data();
+        // Each series has count 1, so the per-service average is 1 — but
+        // the three natural series collapse to two grouped rows.
+        let out = matrix(
+            &service,
+            r#"avg by (service_name) (count_over_time({service_name=~".+"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|(v, _)| *v == 1.0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds the non-`sum` outer vector aggregations — `avg`, `min`, `max`, `count` — over a LogQL range aggregation. These previously returned `Unsupported`.

## How

- **Lowering** (`logql_metric.rs`): a new `OuterAgg` on `MetricPlan`. `sum` still folds into the grouped range aggregate (`outer_agg: None`); the others carry an `OuterAgg` for a second pass.
- **Execution** (`logs.rs`): when `outer_agg` is set, the range aggregation groups by the full series identity (`service_name`, `severity_text`) to produce per-series values, then a second DataFusion aggregate reduces them across series within each output group. `count` is cast back to `Float64` so the matrix value column stays `Float64`.

```logql
avg(rate({service_name="api"}[5m]))
count by (level) (count_over_time({service_name="api"}[5m]))
max by (service_name) (bytes_rate({service_name="api"}[5m]))
```

Grouping stays column-backed (`service_name`/`level`); `topk`/`bottomk`, `stddev`/`stdvar`, `sort`, and `quantile_over_time` remain unsupported (next steps toward #366).

## Tests

- Lowering: `non_sum_outer_aggregations_reduce_across_series` (sum stays folded; avg/min/max/count carry the right `OuterAgg`; `by` labels survive).
- Execution: `count_outer_aggregation_counts_series` (3 series → 3), `count_by_service_counts_series_per_group` (api=2, web=1), `avg_by_service_reduces_across_series` (3 series collapse to 2 groups).
- `logql-reference.md` ✅/❌ surface updated.

Part of #366.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `avg`, `min`, `max`, and `count` outer aggregations in metric queries.
  - Added support for grouping these aggregations with `by (...)` and `without (...)`.
  - Metric results now correctly reduce across series and preserve requested grouping.

- **Documentation**
  - Updated the LogQL metric query reference with supported aggregation rules.
  - Clarified currently unsupported functions, including `stddev`, `stdvar`, `sort`, and `sort_desc`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->