### PR TITLE
feat(logql): support stddev/stdvar outer aggregations

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -126,9 +126,10 @@ sum by (level) (rate({service_name="api"}[5m]))
   `bytes_rate`, and the unwrap-based `sum_over_time` / `avg_over_time` /
   `min_over_time` / `max_over_time`.
 - **Vector aggregation**: a single outer `sum` / `avg` / `min` / `max` /
-  `count`, with `by (...)` or `without ()`, wrapping one of the above.
-  `sum` folds into the grouped range aggregate; the others reduce the
-  per-series range aggregation across the series in each group.
+  `count` / `stddev` / `stdvar`, with `by (...)` or `without ()`, wrapping
+  one of the above. `sum` folds into the grouped range aggregate; the
+  others reduce the per-series range aggregation across the series in each
+  group (`stddev`/`stdvar` are population statistics, as in Prometheus).
 - **Grouping** is only supported by labels backed by a column
   (`service_name`, `level`, ...).
 
@@ -145,8 +146,7 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk`, `stddev` / `stdvar`, `sort` / `sort_desc`, and
-  `quantile_over_time`
+- `topk` / `bottomk`, `sort` / `sort_desc`, and `quantile_over_time`
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -18,8 +18,9 @@
 //!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`.
 //! - A single outer vector aggregation wrapping one of the above:
 //!   `sum` (sum-of-counts folds into a grouped count/rate), and
-//!   `avg` / `min` / `max` / `count`, which reduce the range
-//!   aggregation across series within each group (see [`OuterAgg`]).
+//!   `avg` / `min` / `max` / `count` / `stddev` / `stdvar`, which reduce
+//!   the range aggregation across series within each group (see
+//!   [`OuterAgg`]).
 //!
 //! Binary operators, `topk`/`bottomk` (parameterized aggregations),
 //! `quantile*`, `vector()`, and `label_replace` return
@@ -62,6 +63,10 @@ pub enum OuterAgg {
     Max,
     /// `count(...)` — number of series with data in the bucket.
     Count,
+    /// `stddev(...)` — population standard deviation across series.
+    Stddev,
+    /// `stdvar(...)` — population variance across series.
+    Stdvar,
 }
 
 /// A lowered metric query.
@@ -101,6 +106,8 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
                 AggregationFunction::Min => Some(OuterAgg::Min),
                 AggregationFunction::Max => Some(OuterAgg::Max),
                 AggregationFunction::Count => Some(OuterAgg::Count),
+                AggregationFunction::Stddev => Some(OuterAgg::Stddev),
+                AggregationFunction::Stdvar => Some(OuterAgg::Stdvar),
                 other => {
                     return Err(QuerierError::Unsupported(format!(
                         "outer aggregation '{other:?}' over a range aggregation"
@@ -298,6 +305,8 @@ mod tests {
                 r#"count by (level) (count_over_time({a="b"}[5m]))"#,
                 OuterAgg::Count,
             ),
+            (r#"stddev(rate({a="b"}[5m]))"#, OuterAgg::Stddev),
+            (r#"stdvar by (level) (rate({a="b"}[5m]))"#, OuterAgg::Stdvar),
         ] {
             let p = plan(query);
             assert_eq!(p.outer_agg, Some(expected), "{query}");
@@ -319,7 +328,7 @@ mod tests {
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(
-            err(r#"stddev(rate({a="b"}[5m]))"#),
+            err(r#"sort(rate({a="b"}[5m]))"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -19,7 +19,7 @@ use datafusion::{
     arrow::datatypes::{DataType, IntervalMonthDayNano},
     functions::datetime::expr_fn::date_bin,
     functions::unicode::expr_fn::character_length,
-    functions_aggregate::expr_fn::{avg, count, max, min, sum},
+    functions_aggregate::expr_fn::{avg, count, max, min, stddev_pop, sum, var_pop},
     logical_expr::{Expr, cast, col, lit},
     prelude::{DataFrame, SessionContext},
     scalar::ScalarValue,
@@ -483,6 +483,10 @@ fn outer_agg_expr(outer: OuterAgg, value: Expr) -> Expr {
         OuterAgg::Min => min(value),
         OuterAgg::Max => max(value),
         OuterAgg::Count => count(value),
+        // Loki follows Prometheus: `stddev`/`stdvar` are population
+        // statistics across the series in the group.
+        OuterAgg::Stddev => stddev_pop(value),
+        OuterAgg::Stdvar => var_pop(value),
     }
 }
 
@@ -887,6 +891,62 @@ mod tests {
         .await;
         assert_eq!(out.len(), 2);
         assert!(out.iter().all(|(v, _)| *v == 1.0));
+    }
+
+    /// A context whose `api` service has two series with differing row
+    /// counts in one bucket: `error`×3 and `info`×1 — so a cross-series
+    /// `stddev`/`stdvar` over them is non-zero.
+    fn service_with_varying_counts() -> LogsService {
+        let schema = logs_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300, 400])),
+                str_col(&["a", "b", "c", "d"]),
+                str_col(&["api", "api", "api", "api"]),
+                str_col(&["error", "error", "error", "info"]),
+                str_col(&["t1", "t2", "t3", "t4"]),
+                str_col(&["s1", "s2", "s3", "s4"]),
+                str_col(&["{}", "{}", "{}", "{}"]),
+                str_col(&["{}", "{}", "{}", "{}"]),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("logs".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+        LogsService::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn stddev_and_stdvar_reduce_across_series() {
+        let service = service_with_varying_counts();
+        // Series counts within `api` are [3, 1]: population variance is 1,
+        // population stddev is 1.
+        let stdvar = matrix(
+            &service,
+            r#"stdvar by (service_name) (count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(stdvar.len(), 1);
+        assert!((stdvar[0].0 - 1.0).abs() < 1e-9, "stdvar {}", stdvar[0].0);
+
+        let stddev = matrix(
+            &service,
+            r#"stddev by (service_name) (count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(stddev.len(), 1);
+        assert!((stddev[0].0 - 1.0).abs() < 1e-9, "stddev {}", stddev[0].0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds the `stddev` and `stdvar` outer vector aggregations over a LogQL range aggregation, completing the non-`sum` aggregation set alongside `avg`/`min`/`max`/`count` (#709).

## How

Two more `OuterAgg` variants, mapped in the second-pass reducer to DataFusion's population `stddev_pop` / `var_pop`. Loki follows Prometheus, where `stddev`/`stdvar` are **population** statistics across the series in a group.

```logql
stddev(rate({service_name="api"}[5m]))
stdvar by (level) (count_over_time({service_name="api"}[5m]))
```

## Tests

- Lowering: extends `non_sum_outer_aggregations_reduce_across_series` (stddev→`Stddev`, stdvar→`Stdvar`).
- Execution: `stddev_and_stdvar_reduce_across_series` — a fixture with `api` series counts `[3, 1]` in one bucket, asserting population variance 1.0 and stddev 1.0.
- `logql-reference.md` ✅/❌ surface updated.

Part of #366. Next: `sort`/`sort_desc`, `topk`/`bottomk`, `quantile_over_time`.