### PR TITLE
feat(logql): support quantile_over_time

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -124,7 +124,7 @@ sum by (level) (rate({service_name="api"}[5m]))
 
 - **Range functions**: `count_over_time`, `rate`, `bytes_over_time`,
   `bytes_rate`, and the unwrap-based `sum_over_time` / `avg_over_time` /
-  `min_over_time` / `max_over_time`.
+  `min_over_time` / `max_over_time` / `quantile_over_time`.
 - **Vector aggregation**: a single outer `sum` / `avg` / `min` / `max` /
   `count` / `stddev` / `stdvar`, with `by (...)` or `without ()`, wrapping
   one of the above. `sum` folds into the grouped range aggregate; the
@@ -146,7 +146,9 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk`, `sort` / `sort_desc`, and `quantile_over_time`
+- `topk` / `bottomk`, `sort` / `sort_desc`, and the other unwrap-based
+  range functions (`first_over_time`, `last_over_time`,
+  `stddev_over_time`, `stdvar_over_time`)
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -15,7 +15,8 @@
 //! shapes are supported:
 //!
 //! - Range aggregations: `count_over_time`, `rate`, `bytes_over_time`,
-//!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`.
+//!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time` and
+//!   `quantile_over_time`.
 //! - A single outer vector aggregation wrapping one of the above:
 //!   `sum` (sum-of-counts folds into a grouped count/rate), and
 //!   `avg` / `min` / `max` / `count` / `stddev` / `stdvar`, which reduce
@@ -45,6 +46,9 @@ pub enum Aggregate {
     UnwrapMin(String),
     /// `max(<unwrapped label>)`.
     UnwrapMax(String),
+    /// `approx_percentile_cont(<unwrapped label>, <quantile>)` — the
+    /// φ-quantile of the unwrapped sample values in the bucket.
+    UnwrapQuantile { quantile: f64, label: String },
 }
 
 /// A non-`sum` outer vector aggregation that reduces the per-series range
@@ -168,6 +172,20 @@ fn plan_range(
         RangeFunction::AvgOverTime => (Aggregate::UnwrapAvg(unwrap_label()?), None),
         RangeFunction::MinOverTime => (Aggregate::UnwrapMin(unwrap_label()?), None),
         RangeFunction::MaxOverTime => (Aggregate::UnwrapMax(unwrap_label()?), None),
+        RangeFunction::QuantileOverTime => {
+            let quantile = range.param.ok_or_else(|| {
+                QuerierError::Unsupported(
+                    "quantile_over_time requires a quantile parameter".to_string(),
+                )
+            })?;
+            (
+                Aggregate::UnwrapQuantile {
+                    quantile,
+                    label: unwrap_label()?,
+                },
+                None,
+            )
+        }
         other => {
             return Err(QuerierError::Unsupported(format!(
                 "range function {other:?}"
@@ -270,6 +288,22 @@ mod tests {
     }
 
     #[test]
+    fn quantile_over_time_carries_the_quantile_and_label() {
+        assert_eq!(
+            plan(r#"quantile_over_time(0.9, {a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapQuantile {
+                quantile: 0.9,
+                label: "latency".to_string()
+            }
+        );
+        // Missing the `| unwrap` is rejected (no samples to rank).
+        assert!(matches!(
+            err(r#"quantile_over_time(0.9, {a="b"}[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
     fn sum_by_pushes_grouping_down() {
         let p = plan(r#"sum by (level) (count_over_time({a="b"}[5m]))"#);
         assert_eq!(p.aggregate, Aggregate::Count);
@@ -329,10 +363,6 @@ mod tests {
         ));
         assert!(matches!(
             err(r#"sort(rate({a="b"}[5m]))"#),
-            QuerierError::Unsupported(_)
-        ));
-        assert!(matches!(
-            err(r#"quantile_over_time(0.9, {a="b"} | unwrap x [5m])"#),
             QuerierError::Unsupported(_)
         ));
         assert!(matches!(

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -19,7 +19,9 @@ use datafusion::{
     arrow::datatypes::{DataType, IntervalMonthDayNano},
     functions::datetime::expr_fn::date_bin,
     functions::unicode::expr_fn::character_length,
-    functions_aggregate::expr_fn::{avg, count, max, min, stddev_pop, sum, var_pop},
+    functions_aggregate::expr_fn::{
+        approx_percentile_cont, avg, count, max, min, stddev_pop, sum, var_pop,
+    },
     logical_expr::{Expr, cast, col, lit},
     prelude::{DataFrame, SessionContext},
     scalar::ScalarValue,
@@ -472,6 +474,9 @@ fn aggregate_expr(aggregate: &Aggregate) -> Expr {
         Aggregate::UnwrapAvg(label) => avg(unwrap_value(label)),
         Aggregate::UnwrapMin(label) => min(unwrap_value(label)),
         Aggregate::UnwrapMax(label) => max(unwrap_value(label)),
+        Aggregate::UnwrapQuantile { quantile, label } => {
+            approx_percentile_cont(unwrap_value(label).sort(true, false), lit(*quantile), None)
+        }
     }
 }
 
@@ -923,6 +928,61 @@ mod tests {
         catalog.register_schema("d", schema_provider).unwrap();
         ctx.register_catalog("t", catalog);
         LogsService::new(ctx)
+    }
+
+    /// A context with one `api`/`info` series whose `trace_id` column
+    /// carries the numeric strings 10, 20, 30, 40 — a stand-in for an
+    /// unwrappable numeric column, so `unwrap trace_id` yields those
+    /// samples in a single bucket.
+    fn service_with_numeric_unwrap() -> LogsService {
+        let schema = logs_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300, 400])),
+                str_col(&["a", "b", "c", "d"]),
+                str_col(&["api", "api", "api", "api"]),
+                str_col(&["info", "info", "info", "info"]),
+                str_col(&["10", "20", "30", "40"]),
+                str_col(&["s1", "s2", "s3", "s4"]),
+                str_col(&["{}", "{}", "{}", "{}"]),
+                str_col(&["{}", "{}", "{}", "{}"]),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("logs".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+        LogsService::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn quantile_over_time_ranks_unwrapped_samples() {
+        let service = service_with_numeric_unwrap();
+        let q = |phi: &str| {
+            let query = format!(
+                r#"quantile_over_time({phi}, {{service_name="api"}} | unwrap trace_id [1000ns])"#
+            );
+            let service = &service;
+            async move { matrix(service, &query, 1000).await }
+        };
+        // Extremes map to min/max exactly; the median lands between them.
+        let lo = q("0.0").await;
+        assert_eq!(lo.len(), 1);
+        assert!((lo[0].0 - 10.0).abs() < 1e-6, "q0 {}", lo[0].0);
+
+        let hi = q("1.0").await;
+        assert!((hi[0].0 - 40.0).abs() < 1e-6, "q1 {}", hi[0].0);
+
+        let mid = q("0.5").await;
+        assert!(mid[0].0 > 10.0 && mid[0].0 < 40.0, "q0.5 {}", mid[0].0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `quantile_over_time(<phi>, {...} | unwrap <label> [range])` — the φ-quantile of the unwrapped sample values in each bucket. Previously `Unsupported`.

## How

- **Lowering** (`logql_metric.rs`): a new `Aggregate::UnwrapQuantile { quantile, label }`, taking the φ from `RangeAggregation.param` and the sample column from `| unwrap`. Rejects a missing unwrap or missing quantile.
- **Execution** (`logs.rs`): `approx_percentile_cont(unwrap_value(label).sort(..), lit(phi), None)` — DataFusion's t-digest continuous percentile.

```logql
quantile_over_time(0.99, {service_name="api"} | unwrap latency_ms [5m])
```

## Tests

- Lowering: `quantile_over_time_carries_the_quantile_and_label` (φ + label captured; missing unwrap rejected).
- Execution: `quantile_over_time_ranks_unwrapped_samples` — samples [10,20,30,40]; φ=0.0→10, φ=1.0→40, φ=0.5 strictly between.
- `logql-reference.md` updated.

Part of #366. Next: `first`/`last`/`stddev`/`stdvar_over_time`, then `topk`/`bottomk`.