### PR TITLE
feat(logql): support stddev_over_time and stdvar_over_time

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -124,7 +124,8 @@ sum by (level) (rate({service_name="api"}[5m]))
 
 - **Range functions**: `count_over_time`, `rate`, `bytes_over_time`,
   `bytes_rate`, and the unwrap-based `sum_over_time` / `avg_over_time` /
-  `min_over_time` / `max_over_time` / `quantile_over_time`.
+  `min_over_time` / `max_over_time` / `stddev_over_time` /
+  `stdvar_over_time` / `quantile_over_time`.
 - **Vector aggregation**: a single outer `sum` / `avg` / `min` / `max` /
   `count` / `stddev` / `stdvar`, with `by (...)` or `without ()`, wrapping
   one of the above. `sum` folds into the grouped range aggregate; the
@@ -146,9 +147,8 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk`, `sort` / `sort_desc`, and the other unwrap-based
-  range functions (`first_over_time`, `last_over_time`,
-  `stddev_over_time`, `stdvar_over_time`)
+- `topk` / `bottomk`, `sort` / `sort_desc`, and the `first_over_time` /
+  `last_over_time` range functions
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -15,8 +15,8 @@
 //! shapes are supported:
 //!
 //! - Range aggregations: `count_over_time`, `rate`, `bytes_over_time`,
-//!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time` and
-//!   `quantile_over_time`.
+//!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`,
+//!   `stddev/stdvar_over_time`, and `quantile_over_time`.
 //! - A single outer vector aggregation wrapping one of the above:
 //!   `sum` (sum-of-counts folds into a grouped count/rate), and
 //!   `avg` / `min` / `max` / `count` / `stddev` / `stdvar`, which reduce
@@ -49,6 +49,12 @@ pub enum Aggregate {
     /// `approx_percentile_cont(<unwrapped label>, <quantile>)` — the
     /// φ-quantile of the unwrapped sample values in the bucket.
     UnwrapQuantile { quantile: f64, label: String },
+    /// `stddev_pop(<unwrapped label>)` — population standard deviation of
+    /// the unwrapped sample values in the bucket.
+    UnwrapStddev(String),
+    /// `var_pop(<unwrapped label>)` — population variance of the unwrapped
+    /// sample values in the bucket.
+    UnwrapStdvar(String),
 }
 
 /// A non-`sum` outer vector aggregation that reduces the per-series range
@@ -172,6 +178,8 @@ fn plan_range(
         RangeFunction::AvgOverTime => (Aggregate::UnwrapAvg(unwrap_label()?), None),
         RangeFunction::MinOverTime => (Aggregate::UnwrapMin(unwrap_label()?), None),
         RangeFunction::MaxOverTime => (Aggregate::UnwrapMax(unwrap_label()?), None),
+        RangeFunction::StddevOverTime => (Aggregate::UnwrapStddev(unwrap_label()?), None),
+        RangeFunction::StdvarOverTime => (Aggregate::UnwrapStdvar(unwrap_label()?), None),
         RangeFunction::QuantileOverTime => {
             let quantile = range.param.ok_or_else(|| {
                 QuerierError::Unsupported(
@@ -299,6 +307,23 @@ mod tests {
         // Missing the `| unwrap` is rejected (no samples to rank).
         assert!(matches!(
             err(r#"quantile_over_time(0.9, {a="b"}[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn stddev_and_stdvar_over_time_are_unwrap_aggregations() {
+        assert_eq!(
+            plan(r#"stddev_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapStddev("latency".to_string())
+        );
+        assert_eq!(
+            plan(r#"stdvar_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapStdvar("latency".to_string())
+        );
+        // Both require an unwrap expression.
+        assert!(matches!(
+            err(r#"stddev_over_time({a="b"}[5m])"#),
             QuerierError::Unsupported(_)
         ));
     }

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -477,6 +477,8 @@ fn aggregate_expr(aggregate: &Aggregate) -> Expr {
         Aggregate::UnwrapQuantile { quantile, label } => {
             approx_percentile_cont(unwrap_value(label).sort(true, false), lit(*quantile), None)
         }
+        Aggregate::UnwrapStddev(label) => stddev_pop(unwrap_value(label)),
+        Aggregate::UnwrapStdvar(label) => var_pop(unwrap_value(label)),
     }
 }
 
@@ -983,6 +985,32 @@ mod tests {
 
         let mid = q("0.5").await;
         assert!(mid[0].0 > 10.0 && mid[0].0 < 40.0, "q0.5 {}", mid[0].0);
+    }
+
+    #[tokio::test]
+    async fn stddev_stdvar_over_time_reduce_unwrapped_samples() {
+        let service = service_with_numeric_unwrap();
+        // Samples [10, 20, 30, 40]: population variance 125, stddev ~11.18.
+        let var = matrix(
+            &service,
+            r#"stdvar_over_time({service_name="api"} | unwrap trace_id [1000ns])"#,
+            1000,
+        )
+        .await;
+        assert_eq!(var.len(), 1);
+        assert!((var[0].0 - 125.0).abs() < 1e-6, "stdvar {}", var[0].0);
+
+        let dev = matrix(
+            &service,
+            r#"stddev_over_time({service_name="api"} | unwrap trace_id [1000ns])"#,
+            1000,
+        )
+        .await;
+        assert!(
+            (dev[0].0 - 125.0_f64.sqrt()).abs() < 1e-6,
+            "stddev {}",
+            dev[0].0
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds the unwrap-based population-statistic range functions `stddev_over_time` and `stdvar_over_time`, completing the `*_over_time` statistics alongside `sum`/`avg`/`min`/`max`/`quantile`.

## How

- **Lowering**: `Aggregate::UnwrapStddev(label)` / `UnwrapStdvar(label)`, both requiring `| unwrap`.
- **Execution**: `stddev_pop` / `var_pop` over the unwrapped sample column (population, as in Prometheus/Loki).

```logql
stddev_over_time({service_name="api"} | unwrap latency_ms [5m])
stdvar_over_time({service_name="api"} | unwrap latency_ms [5m])
```

## Tests

- Lowering: `stddev_and_stdvar_over_time_are_unwrap_aggregations` (mapping + unwrap-required).
- Execution: `stddev_stdvar_over_time_reduce_unwrapped_samples` — samples [10,20,30,40] → variance 125, stddev √125.
- `logql-reference.md` updated.

Part of #366. Next: `first_over_time`/`last_over_time`, then `topk`/`bottomk`.