### PR TITLE
feat(logql): support first_over_time and last_over_time

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -125,7 +125,8 @@ sum by (level) (rate({service_name="api"}[5m]))
 - **Range functions**: `count_over_time`, `rate`, `bytes_over_time`,
   `bytes_rate`, and the unwrap-based `sum_over_time` / `avg_over_time` /
   `min_over_time` / `max_over_time` / `stddev_over_time` /
-  `stdvar_over_time` / `quantile_over_time`.
+  `stdvar_over_time` / `first_over_time` / `last_over_time` /
+  `quantile_over_time`.
 - **Vector aggregation**: a single outer `sum` / `avg` / `min` / `max` /
   `count` / `stddev` / `stdvar`, with `by (...)` or `without ()`, wrapping
   one of the above. `sum` folds into the grouped range aggregate; the
@@ -147,8 +148,7 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk`, `sort` / `sort_desc`, and the `first_over_time` /
-  `last_over_time` range functions
+- `topk` / `bottomk` and `sort` / `sort_desc`
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -16,7 +16,8 @@
 //!
 //! - Range aggregations: `count_over_time`, `rate`, `bytes_over_time`,
 //!   `bytes_rate`, and the unwrap-based `sum/avg/min/max_over_time`,
-//!   `stddev/stdvar_over_time`, and `quantile_over_time`.
+//!   `stddev/stdvar_over_time`, `first/last_over_time`, and
+//!   `quantile_over_time`.
 //! - A single outer vector aggregation wrapping one of the above:
 //!   `sum` (sum-of-counts folds into a grouped count/rate), and
 //!   `avg` / `min` / `max` / `count` / `stddev` / `stdvar`, which reduce
@@ -55,6 +56,12 @@ pub enum Aggregate {
     /// `var_pop(<unwrapped label>)` — population variance of the unwrapped
     /// sample values in the bucket.
     UnwrapStdvar(String),
+    /// `first_value(<unwrapped label> order by timestamp)` — the unwrapped
+    /// value of the earliest sample in the bucket.
+    UnwrapFirst(String),
+    /// `last_value(<unwrapped label> order by timestamp)` — the unwrapped
+    /// value of the latest sample in the bucket.
+    UnwrapLast(String),
 }
 
 /// A non-`sum` outer vector aggregation that reduces the per-series range
@@ -180,6 +187,8 @@ fn plan_range(
         RangeFunction::MaxOverTime => (Aggregate::UnwrapMax(unwrap_label()?), None),
         RangeFunction::StddevOverTime => (Aggregate::UnwrapStddev(unwrap_label()?), None),
         RangeFunction::StdvarOverTime => (Aggregate::UnwrapStdvar(unwrap_label()?), None),
+        RangeFunction::FirstOverTime => (Aggregate::UnwrapFirst(unwrap_label()?), None),
+        RangeFunction::LastOverTime => (Aggregate::UnwrapLast(unwrap_label()?), None),
         RangeFunction::QuantileOverTime => {
             let quantile = range.param.ok_or_else(|| {
                 QuerierError::Unsupported(
@@ -324,6 +333,22 @@ mod tests {
         // Both require an unwrap expression.
         assert!(matches!(
             err(r#"stddev_over_time({a="b"}[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn first_and_last_over_time_are_unwrap_aggregations() {
+        assert_eq!(
+            plan(r#"first_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapFirst("latency".to_string())
+        );
+        assert_eq!(
+            plan(r#"last_over_time({a="b"} | unwrap latency [5m])"#).aggregate,
+            Aggregate::UnwrapLast("latency".to_string())
+        );
+        assert!(matches!(
+            err(r#"first_over_time({a="b"}[5m])"#),
             QuerierError::Unsupported(_)
         ));
     }

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -20,7 +20,8 @@ use datafusion::{
     functions::datetime::expr_fn::date_bin,
     functions::unicode::expr_fn::character_length,
     functions_aggregate::expr_fn::{
-        approx_percentile_cont, avg, count, max, min, stddev_pop, sum, var_pop,
+        approx_percentile_cont, avg, count, first_value, last_value, max, min, stddev_pop, sum,
+        var_pop,
     },
     logical_expr::{Expr, cast, col, lit},
     prelude::{DataFrame, SessionContext},
@@ -479,6 +480,15 @@ fn aggregate_expr(aggregate: &Aggregate) -> Expr {
         }
         Aggregate::UnwrapStddev(label) => stddev_pop(unwrap_value(label)),
         Aggregate::UnwrapStdvar(label) => var_pop(unwrap_value(label)),
+        // Order by timestamp so first/last pick the earliest/latest sample.
+        Aggregate::UnwrapFirst(label) => first_value(
+            unwrap_value(label),
+            vec![col("timestamp").sort(true, false)],
+        ),
+        Aggregate::UnwrapLast(label) => last_value(
+            unwrap_value(label),
+            vec![col("timestamp").sort(true, false)],
+        ),
     }
 }
 
@@ -1011,6 +1021,28 @@ mod tests {
             "stddev {}",
             dev[0].0
         );
+    }
+
+    #[tokio::test]
+    async fn first_and_last_over_time_pick_by_timestamp() {
+        let service = service_with_numeric_unwrap();
+        // Samples arrive as 10@100, 20@200, 30@300, 40@400 in one bucket.
+        let first = matrix(
+            &service,
+            r#"first_over_time({service_name="api"} | unwrap trace_id [1000ns])"#,
+            1000,
+        )
+        .await;
+        assert_eq!(first.len(), 1);
+        assert!((first[0].0 - 10.0).abs() < 1e-6, "first {}", first[0].0);
+
+        let last = matrix(
+            &service,
+            r#"last_over_time({service_name="api"} | unwrap trace_id [1000ns])"#,
+            1000,
+        )
+        .await;
+        assert!((last[0].0 - 40.0).abs() < 1e-6, "last {}", last[0].0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `first_over_time` and `last_over_time` — the unwrapped value of the earliest / latest sample in each bucket. This completes the unwrap-based `*_over_time` range functions.

## How

- **Lowering**: `Aggregate::UnwrapFirst(label)` / `UnwrapLast(label)`, both requiring `| unwrap`.
- **Execution**: DataFusion `first_value` / `last_value` ordered by `timestamp` (ascending), so first = earliest sample, last = latest.

```logql
first_over_time({service_name="api"} | unwrap latency_ms [5m])
last_over_time({service_name="api"} | unwrap latency_ms [5m])
```

## Tests

- Lowering: `first_and_last_over_time_are_unwrap_aggregations` (mapping + unwrap-required).
- Execution: `first_and_last_over_time_pick_by_timestamp` — samples 10@100…40@400 → first=10, last=40.
- `logql-reference.md` updated.

Part of #366. Remaining metric-side: `topk`/`bottomk`, `sort`/`sort_desc`, and metric binary / `vector` / `label_replace`.