### PR TITLE
feat(logql): support topk and bottomk

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -132,6 +132,8 @@ sum by (level) (rate({service_name="api"}[5m]))
   one of the above. `sum` folds into the grouped range aggregate; the
   others reduce the per-series range aggregation across the series in each
   group (`stddev`/`stdvar` are population statistics, as in Prometheus).
+- **Selection**: `topk(k, ...)` / `bottomk(k, ...)` keep the `k` highest /
+  lowest series by value in each time bucket, applied after aggregation.
 - **Grouping** is only supported by labels backed by a column
   (`service_name`, `level`, ...).
 
@@ -148,7 +150,7 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `topk` / `bottomk` and `sort` / `sort_desc`
+- `sort` / `sort_desc`
 - Binary operations between metric queries (`a / b`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -23,10 +23,11 @@
 //!   `avg` / `min` / `max` / `count` / `stddev` / `stdvar`, which reduce
 //!   the range aggregation across series within each group (see
 //!   [`OuterAgg`]).
+//! - `topk` / `bottomk`, which keep the `k` highest/lowest series per
+//!   bucket after aggregation (see [`TopKSpec`]).
 //!
-//! Binary operators, `topk`/`bottomk` (parameterized aggregations),
-//! `quantile*`, `vector()`, and `label_replace` return
-//! [`QuerierError::Unsupported`].
+//! Binary operators, `sort`/`sort_desc`, `vector()`, and `label_replace`
+//! return [`QuerierError::Unsupported`].
 
 use logql::{AggregationFunction, Grouping, LogQuery, MetricQuery, RangeFunction};
 
@@ -86,6 +87,17 @@ pub enum OuterAgg {
     Stdvar,
 }
 
+/// `topk(k, ...)` / `bottomk(k, ...)`: keep the `k` highest (or lowest)
+/// series by value in each time bucket, applied after the range and any
+/// outer aggregation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TopKSpec {
+    /// How many series to keep per bucket.
+    pub k: usize,
+    /// `true` for `bottomk` (keep the lowest), `false` for `topk`.
+    pub bottom: bool,
+}
+
 /// A lowered metric query.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricPlan {
@@ -103,6 +115,8 @@ pub struct MetricPlan {
     /// (empty = collapse across all series); when `None`, the range
     /// aggregation is grouped directly by `group_labels`.
     pub outer_agg: Option<OuterAgg>,
+    /// A `topk`/`bottomk` per-bucket ranking to apply after aggregation.
+    pub topk: Option<TopKSpec>,
     /// The `[range]` window in nanoseconds (informational; bucketing uses
     /// the caller's step).
     pub range_ns: u128,
@@ -113,10 +127,38 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
     match query {
         MetricQuery::Range(range) => plan_range(range, Vec::new()),
         MetricQuery::Vector(vector) => {
+            // `topk`/`bottomk` rank the inner query's series per bucket:
+            // lower the inner, then attach a `TopKSpec` post-pass.
+            if let AggregationFunction::Topk | AggregationFunction::Bottomk = vector.function {
+                let bottom = vector.function == AggregationFunction::Bottomk;
+                let k = vector
+                    .param
+                    .filter(|k| k.is_finite() && *k >= 0.0)
+                    .ok_or_else(|| {
+                        QuerierError::Unsupported(
+                            "topk/bottomk requires a non-negative k parameter".to_string(),
+                        )
+                    })?;
+                if vector.grouping.is_some() {
+                    return Err(QuerierError::Unsupported(
+                        "grouped topk/bottomk".to_string(),
+                    ));
+                }
+                let mut plan = plan_metric_query(&vector.inner)?;
+                if plan.topk.is_some() {
+                    return Err(QuerierError::Unsupported("nested topk/bottomk".to_string()));
+                }
+                plan.topk = Some(TopKSpec {
+                    k: k as usize,
+                    bottom,
+                });
+                return Ok(plan);
+            }
+
             // `sum` folds into the grouped range aggregate (`outer_agg`
             // stays `None`); `avg`/`min`/`max`/`count` reduce across series
-            // in a second pass. `topk`/`bottomk` and other parameterized or
-            // exotic aggregations still need per-series machinery we lack.
+            // in a second pass. Other parameterized or exotic aggregations
+            // still need per-series machinery we lack.
             let outer_agg = match vector.function {
                 AggregationFunction::Sum => None,
                 AggregationFunction::Avg => Some(OuterAgg::Avg),
@@ -224,6 +266,7 @@ fn plan_range(
         aggregate,
         rate_divisor_seconds,
         outer_agg: None,
+        topk: None,
         range_ns: range.range.as_nanos(),
     })
 }
@@ -406,11 +449,36 @@ mod tests {
     }
 
     #[test]
+    fn topk_and_bottomk_rank_the_inner_series() {
+        let t = plan(r#"topk(5, rate({a="b"}[5m]))"#);
+        assert_eq!(
+            t.topk,
+            Some(TopKSpec {
+                k: 5,
+                bottom: false
+            })
+        );
+        // The inner range aggregation is preserved underneath.
+        assert_eq!(t.aggregate, Aggregate::Count);
+        assert_eq!(t.rate_divisor_seconds, Some(300.0));
+
+        let b = plan(r#"bottomk(3, count_over_time({a="b"}[5m]))"#);
+        assert_eq!(b.topk, Some(TopKSpec { k: 3, bottom: true }));
+
+        // topk over a grouped inner keeps the grouping.
+        let g = plan(r#"topk(2, sum by (level) (rate({a="b"}[5m])))"#);
+        assert_eq!(
+            g.topk,
+            Some(TopKSpec {
+                k: 2,
+                bottom: false
+            })
+        );
+        assert_eq!(g.group_labels, vec!["level".to_string()]);
+    }
+
+    #[test]
     fn unsupported_shapes_are_rejected() {
-        assert!(matches!(
-            err(r#"topk(5, rate({a="b"}[5m]))"#),
-            QuerierError::Unsupported(_)
-        ));
         assert!(matches!(
             err(r#"sort(rate({a="b"}[5m]))"#),
             QuerierError::Unsupported(_)

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -15,7 +15,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use datafusion::{
-    arrow::array::{Array, RecordBatch, StringArray},
+    arrow::array::{Array, Float64Array, RecordBatch, StringArray, TimestampNanosecondArray},
+    arrow::compute::{concat_batches, take},
     arrow::datatypes::{DataType, IntervalMonthDayNano},
     functions::datetime::expr_fn::date_bin,
     functions::unicode::expr_fn::character_length,
@@ -30,7 +31,7 @@ use datafusion::{
 use logql::{Expr as LogqlExpr, LogQuery, parse, parse_query, parse_selector};
 
 use super::logql::log_query_filter;
-use super::logql_metric::{Aggregate, OuterAgg, plan_metric_query};
+use super::logql_metric::{Aggregate, OuterAgg, TopKSpec, plan_metric_query};
 use super::{
     LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
 };
@@ -257,11 +258,18 @@ impl LogsService {
             df = df.select(proj).map_err(QuerierError::QueryFailed)?;
         }
 
-        df.sort(vec![col("bucket").sort(true, true)])
+        let batches = df
+            .sort(vec![col("bucket").sort(true, true)])
             .map_err(QuerierError::QueryFailed)?
             .collect()
             .await
-            .map_err(QuerierError::QueryFailed)
+            .map_err(QuerierError::QueryFailed)?;
+
+        // `topk`/`bottomk`: keep the k highest/lowest series per bucket.
+        match plan.topk {
+            Some(spec) => apply_topk(batches, spec),
+            None => Ok(batches),
+        }
     }
 
     /// List the label names available for logs. Returns the labels backed
@@ -505,6 +513,68 @@ fn outer_agg_expr(outer: OuterAgg, value: Expr) -> Expr {
         OuterAgg::Stddev => stddev_pop(value),
         OuterAgg::Stdvar => var_pop(value),
     }
+}
+
+/// Keep the `k` highest (or lowest, for `bottomk`) series by value in each
+/// time bucket. Operates on the finished matrix, so it is agnostic to which
+/// label columns are present — it ranks rows within a `bucket` and selects
+/// them with Arrow's `take`, preserving every column.
+fn apply_topk(batches: Vec<RecordBatch>, spec: TopKSpec) -> Result<Vec<RecordBatch>, QuerierError> {
+    use std::cmp::Ordering;
+
+    if batches.is_empty() {
+        return Ok(batches);
+    }
+    let schema = batches[0].schema();
+    let batch =
+        concat_batches(&schema, &batches).map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+
+    let bucket = batch
+        .column_by_name("bucket")
+        .and_then(|c| c.as_any().downcast_ref::<TimestampNanosecondArray>())
+        .ok_or_else(|| QuerierError::InvalidInput("bucket column missing".to_string()))?;
+    let value = batch
+        .column_by_name("value")
+        .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+        .ok_or_else(|| QuerierError::InvalidInput("value column missing".to_string()))?;
+
+    // Group row indices by bucket (BTreeMap keeps buckets ascending), rank
+    // within each, and keep the first `k`.
+    let mut by_bucket: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for i in 0..batch.num_rows() {
+        let b = if bucket.is_null(i) {
+            i64::MIN
+        } else {
+            bucket.value(i)
+        };
+        by_bucket.entry(b).or_default().push(i);
+    }
+    let val = |i: usize| {
+        if value.is_null(i) {
+            f64::NAN
+        } else {
+            value.value(i)
+        }
+    };
+    let mut keep: Vec<u32> = Vec::new();
+    for (_bucket, mut idxs) in by_bucket {
+        idxs.sort_by(|&a, &b| {
+            let ord = val(a).partial_cmp(&val(b)).unwrap_or(Ordering::Equal);
+            if spec.bottom { ord } else { ord.reverse() }
+        });
+        idxs.truncate(spec.k);
+        keep.extend(idxs.iter().map(|&i| i as u32));
+    }
+
+    let indices = datafusion::arrow::array::UInt32Array::from(keep);
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|c| take(c, &indices, None).map_err(|e| QuerierError::InvalidInput(e.to_string())))
+        .collect::<Result<Vec<_>, _>>()?;
+    let out = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![out])
 }
 
 /// The unwrapped label's numeric value: the dedicated column when the
@@ -1021,6 +1091,38 @@ mod tests {
             "stddev {}",
             dev[0].0
         );
+    }
+
+    #[tokio::test]
+    async fn topk_and_bottomk_keep_k_series_per_bucket() {
+        let service = service_with_varying_counts();
+        // Two `api` series with counts [3, 1] in one bucket.
+        let top1 = matrix(
+            &service,
+            r#"topk(1, count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(top1.len(), 1);
+        assert_eq!(top1[0].0, 3.0);
+
+        let bottom1 = matrix(
+            &service,
+            r#"bottomk(1, count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(bottom1.len(), 1);
+        assert_eq!(bottom1[0].0, 1.0);
+
+        // k beyond the series count keeps all of them.
+        let top5 = matrix(
+            &service,
+            r#"topk(5, count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(top5.len(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `topk(k, ...)` and `bottomk(k, ...)` — keep the `k` highest / lowest series by value in each time bucket, applied after aggregation.

## How

- **Lowering** (`logql_metric.rs`): a `TopKSpec { k, bottom }` on `MetricPlan`. The `topk`/`bottomk` vector aggregation recurses into its inner metric query (range agg, `sum by`, etc.) and attaches the spec. Grouped/nested topk rejected.
- **Execution** (`logs.rs`): `apply_topk` runs on the finished matrix — groups rows by `bucket`, ranks by `value`, keeps `k`, and selects with Arrow's `take`, so it is agnostic to which label columns the grouping produced (unlike the metrics-side version that hardcodes them).

```logql
topk(5, sum by (service_name) (rate({env="prod"}[5m])))
bottomk(3, count_over_time({service_name="api"}[5m]))
```

## Tests

- Lowering: `topk_and_bottomk_rank_the_inner_series` — spec captured; inner range agg + grouping preserved.
- Execution: `topk_and_bottomk_keep_k_series_per_bucket` — two `api` series counts [3,1]; topk(1)→3, bottomk(1)→1, topk(5)→both.
- `logql-reference.md` updated.

Part of #366. Remaining: `sort`/`sort_desc`, metric binary / `vector` / `label_replace`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `topk` and `bottomk` in LogQL metric queries.
  - Ranking is applied independently for each time bucket after aggregation.
  - Results preserve inner query groupings and retain all series when `k` exceeds the available series.

- **Documentation**
  - Updated the LogQL reference to document `topk` and `bottomk` as supported.
  - Clarified that `sort` and `sort_desc` remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->