### PR TITLE
feat(logql): support vector-scalar arithmetic

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -134,6 +134,9 @@ sum by (level) (rate({service_name="api"}[5m]))
   group (`stddev`/`stdvar` are population statistics, as in Prometheus).
 - **Selection**: `topk(k, ...)` / `bottomk(k, ...)` keep the `k` highest /
   lowest series by value in each time bucket, applied after aggregation.
+- **Scalar arithmetic**: a metric query combined with a scalar literal
+  using `+` / `-` / `*` / `/` (`rate(...) / 60`, `100 * rate(...)`),
+  scaling every value. Operand order is preserved for `-` and `/`.
 - **Grouping** is only supported by labels backed by a column
   (`service_name`, `level`, ...).
 
@@ -151,7 +154,8 @@ exact results.
 These parse but return an "unsupported" error at execution:
 
 - `sort` / `sort_desc`
-- Binary operations between metric queries (`a / b`), `vector(N)`,
+- Vector-to-vector binary operations (`a / b`), comparisons
+  (`a > 5`), logical/set operators (`and`/`or`/`unless`), `vector(N)`,
   `label_replace`
 - `sum without (labels)` with a non-empty label list
 - Grouping by an attribute (non-column) label

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -25,11 +25,14 @@
 //!   [`OuterAgg`]).
 //! - `topk` / `bottomk`, which keep the `k` highest/lowest series per
 //!   bucket after aggregation (see [`TopKSpec`]).
+//! - Vector-scalar arithmetic (`expr * 2`, `expr / 60`), folded into the
+//!   plan as a [`ScalarOp`].
 //!
-//! Binary operators, `sort`/`sort_desc`, `vector()`, and `label_replace`
-//! return [`QuerierError::Unsupported`].
+//! Vector-to-vector binary operators, comparisons, logical/set operators,
+//! `sort`/`sort_desc`, `vector()`, and `label_replace` return
+//! [`QuerierError::Unsupported`].
 
-use logql::{AggregationFunction, Grouping, LogQuery, MetricQuery, RangeFunction};
+use logql::{AggregationFunction, BinOp, Grouping, LogQuery, MetricQuery, RangeFunction};
 
 use super::error::QuerierError;
 
@@ -87,6 +90,25 @@ pub enum OuterAgg {
     Stdvar,
 }
 
+/// A binary arithmetic operator (`+`, `-`, `*`, `/`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+/// A scalar arithmetic operation applied to every value of a metric
+/// query, e.g. `rate(...) / 60` or `100 * rate(...)`. `scalar_is_lhs`
+/// records the operand order so non-commutative `-` / `/` stay correct.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScalarOp {
+    pub op: ArithOp,
+    pub scalar: f64,
+    pub scalar_is_lhs: bool,
+}
+
 /// `topk(k, ...)` / `bottomk(k, ...)`: keep the `k` highest (or lowest)
 /// series by value in each time bucket, applied after the range and any
 /// outer aggregation.
@@ -115,6 +137,9 @@ pub struct MetricPlan {
     /// (empty = collapse across all series); when `None`, the range
     /// aggregation is grouped directly by `group_labels`.
     pub outer_agg: Option<OuterAgg>,
+    /// A scalar arithmetic op applied to every value after aggregation and
+    /// before any `topk`/`bottomk` ranking.
+    pub scalar_op: Option<ScalarOp>,
     /// A `topk`/`bottomk` per-bucket ranking to apply after aggregation.
     pub topk: Option<TopKSpec>,
     /// The `[range]` window in nanoseconds (informational; bucketing uses
@@ -190,9 +215,7 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
                 ))),
             }
         }
-        MetricQuery::Binary(_) => Err(QuerierError::Unsupported(
-            "binary operations between metric queries".to_string(),
-        )),
+        MetricQuery::Binary(bin) => plan_binary(bin),
         MetricQuery::Literal(_) | MetricQuery::VectorLiteral(_) => Err(QuerierError::Unsupported(
             "scalar/vector literal metric query".to_string(),
         )),
@@ -266,9 +289,65 @@ fn plan_range(
         aggregate,
         rate_divisor_seconds,
         outer_agg: None,
+        scalar_op: None,
         topk: None,
         range_ns: range.range.as_nanos(),
     })
+}
+
+/// Lower a binary expression. Only **vector-scalar arithmetic** is
+/// supported: one operand is a scalar literal and the other a metric
+/// query, combined with `+`/`-`/`*`/`/`. The scalar folds into the
+/// metric query's plan as a [`ScalarOp`]. Vector-to-vector operations,
+/// comparisons, and logical/set operators are not supported yet.
+fn plan_binary(bin: &logql::BinaryExpr) -> Result<MetricPlan, QuerierError> {
+    let op = match bin.op {
+        BinOp::Add => ArithOp::Add,
+        BinOp::Sub => ArithOp::Sub,
+        BinOp::Mul => ArithOp::Mul,
+        BinOp::Div => ArithOp::Div,
+        other => {
+            return Err(QuerierError::Unsupported(format!(
+                "binary operator {other:?} between metric queries"
+            )));
+        }
+    };
+
+    let (scalar, vector, scalar_is_lhs) = match (&bin.left, &bin.right) {
+        (MetricQuery::Literal(s), rhs) if !is_literal(rhs) => (*s, rhs, true),
+        (lhs, MetricQuery::Literal(s)) if !is_literal(lhs) => (*s, lhs, false),
+        (MetricQuery::Literal(_), MetricQuery::Literal(_)) => {
+            return Err(QuerierError::Unsupported(
+                "arithmetic between two scalars".to_string(),
+            ));
+        }
+        _ => {
+            return Err(QuerierError::Unsupported(
+                "binary operation between two metric queries".to_string(),
+            ));
+        }
+    };
+
+    let mut plan = plan_metric_query(vector)?;
+    if plan.scalar_op.is_some() {
+        return Err(QuerierError::Unsupported(
+            "chained scalar arithmetic".to_string(),
+        ));
+    }
+    plan.scalar_op = Some(ScalarOp {
+        op,
+        scalar,
+        scalar_is_lhs,
+    });
+    Ok(plan)
+}
+
+/// Whether a metric query is a bare scalar literal.
+fn is_literal(query: &MetricQuery) -> bool {
+    matches!(
+        query,
+        MetricQuery::Literal(_) | MetricQuery::VectorLiteral(_)
+    )
 }
 
 /// Extract the `by (...)` labels. `without` is only supported when empty
@@ -475,6 +554,42 @@ mod tests {
             })
         );
         assert_eq!(g.group_labels, vec!["level".to_string()]);
+    }
+
+    #[test]
+    fn vector_scalar_arithmetic_folds_into_the_plan() {
+        // Scalar on the right.
+        let p = plan(r#"rate({a="b"}[5m]) / 60"#);
+        assert_eq!(
+            p.scalar_op,
+            Some(ScalarOp {
+                op: ArithOp::Div,
+                scalar: 60.0,
+                scalar_is_lhs: false
+            })
+        );
+        assert_eq!(p.aggregate, Aggregate::Count);
+
+        // Scalar on the left records the operand order.
+        let l = plan(r#"100 * count_over_time({a="b"}[5m])"#);
+        assert_eq!(
+            l.scalar_op,
+            Some(ScalarOp {
+                op: ArithOp::Mul,
+                scalar: 100.0,
+                scalar_is_lhs: true
+            })
+        );
+
+        // Vector-to-vector arithmetic and comparisons are still rejected.
+        assert!(matches!(
+            err(r#"rate({a="b"}[5m]) / rate({a="c"}[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
+        assert!(matches!(
+            err(r#"rate({a="b"}[5m]) > 5"#),
+            QuerierError::Unsupported(_)
+        ));
     }
 
     #[test]

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -31,7 +31,7 @@ use datafusion::{
 use logql::{Expr as LogqlExpr, LogQuery, parse, parse_query, parse_selector};
 
 use super::logql::log_query_filter;
-use super::logql_metric::{Aggregate, OuterAgg, TopKSpec, plan_metric_query};
+use super::logql_metric::{Aggregate, ArithOp, OuterAgg, ScalarOp, TopKSpec, plan_metric_query};
 use super::{
     LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
 };
@@ -255,6 +255,21 @@ impl LogsService {
             let mut proj = vec![col("bucket")];
             proj.extend(out_group_cols.iter().map(|c| col(*c)));
             proj.push(cast(col("value"), DataType::Float64).alias("value"));
+            df = df.select(proj).map_err(QuerierError::QueryFailed)?;
+        }
+
+        // Vector-scalar arithmetic: scale/shift every value in place. The
+        // surviving group columns are the outer-agg output when present,
+        // else the range aggregation's own grouping.
+        if let Some(scalar_op) = plan.scalar_op {
+            let current_group_cols = if plan.outer_agg.is_some() {
+                &out_group_cols
+            } else {
+                &range_group_cols
+            };
+            let mut proj = vec![col("bucket")];
+            proj.extend(current_group_cols.iter().map(|c| col(*c)));
+            proj.push(scalar_op_expr(col("value"), scalar_op).alias("value"));
             df = df.select(proj).map_err(QuerierError::QueryFailed)?;
         }
 
@@ -512,6 +527,23 @@ fn outer_agg_expr(outer: OuterAgg, value: Expr) -> Expr {
         // statistics across the series in the group.
         OuterAgg::Stddev => stddev_pop(value),
         OuterAgg::Stdvar => var_pop(value),
+    }
+}
+
+/// Apply a scalar arithmetic op to a value expression, honoring the
+/// operand order recorded in the [`ScalarOp`].
+fn scalar_op_expr(value: Expr, scalar_op: ScalarOp) -> Expr {
+    let scalar = lit(scalar_op.scalar);
+    let (lhs, rhs) = if scalar_op.scalar_is_lhs {
+        (scalar, value)
+    } else {
+        (value, scalar)
+    };
+    match scalar_op.op {
+        ArithOp::Add => lhs + rhs,
+        ArithOp::Sub => lhs - rhs,
+        ArithOp::Mul => lhs * rhs,
+        ArithOp::Div => lhs / rhs,
     }
 }
 
@@ -1091,6 +1123,29 @@ mod tests {
             "stddev {}",
             dev[0].0
         );
+    }
+
+    #[tokio::test]
+    async fn scalar_arithmetic_scales_values() {
+        let service = service_with_data();
+        // Each of the three series has count 1; `* 10` scales them to 10.
+        let scaled = matrix(
+            &service,
+            r#"count_over_time({service_name=~".+"}[1000ns]) * 10"#,
+            1000,
+        )
+        .await;
+        assert_eq!(scaled.len(), 3);
+        assert!(scaled.iter().all(|(v, _)| *v == 10.0));
+
+        // Operand order matters for subtraction: 100 - 1 = 99.
+        let shifted = matrix(
+            &service,
+            r#"100 - count_over_time({service_name=~".+"}[1000ns])"#,
+            1000,
+        )
+        .await;
+        assert!(shifted.iter().all(|(v, _)| *v == 99.0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds arithmetic between a metric query and a scalar literal — `rate(...) / 60`, `100 * count_over_time(...)`, etc. — scaling every value. First of the binary-operation increments.

## How

- **Lowering** (`logql_metric.rs`): `plan_binary` detects a scalar/vector pair under `+`/`-`/`*`/`/` and folds a `ScalarOp { op, scalar, scalar_is_lhs }` onto the vector's plan. `scalar_is_lhs` preserves operand order for `-` and `/`. Two-scalar, vector-vector, comparison, and logical ops are rejected.
- **Execution** (`logs.rs`): `scalar_op_expr` applies the op in a value projection after aggregation and before `topk`/`bottomk`.

```logql
rate({service_name="api"}[5m]) / 60
100 * count_over_time({service_name="api"}[5m])
```

## Tests

- Lowering: `vector_scalar_arithmetic_folds_into_the_plan` — both operand orders; vector-vector and comparisons rejected.
- Execution: `scalar_arithmetic_scales_values` — `*10` → 10; `100 - count` → 99 (operand order).
- `logql-reference.md` updated.

Part of #366. Next: vector-to-vector binary ops (the join case), then `sort`/`sort_desc`, `vector()`, `label_replace`.