### PR TITLE
feat(logql): support sort and sort_desc

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -134,6 +134,10 @@ sum by (level) (rate({service_name="api"}[5m]))
   group (`stddev`/`stdvar` are population statistics, as in Prometheus).
 - **Selection**: `topk(k, ...)` / `bottomk(k, ...)` keep the `k` highest /
   lowest series by value in each time bucket, applied after aggregation.
+- **Ordering**: `sort(...)` / `sort_desc(...)` order the result series by
+  value. A range matrix has a value per bucket, so ordering uses each
+  series' value at its latest bucket (`sort` is strictly defined only for
+  instant queries).
 - **Scalar arithmetic**: a metric query combined with a scalar literal
   using `+` / `-` / `*` / `/` (`rate(...) / 60`, `100 * rate(...)`),
   scaling every value. Operand order is preserved for `-` and `/`.
@@ -169,7 +173,6 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `sort` / `sort_desc`
 - `on` / `ignoring` label matching (vector matching uses the full label
   set), `vector(N)`
 - `sum without (labels)` with a non-empty label list

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -25,6 +25,8 @@
 //!   [`OuterAgg`]).
 //! - `topk` / `bottomk`, which keep the `k` highest/lowest series per
 //!   bucket after aggregation (see [`TopKSpec`]).
+//! - `sort` / `sort_desc`, which order the output series by value (see
+//!   [`SortSpec`]).
 //! - Vector-scalar arithmetic (`expr * 2`, `expr / 60`), folded into the
 //!   plan as a [`ScalarOp`].
 //!
@@ -32,7 +34,7 @@
 //!   label on the finished matrix (see [`LabelReplaceSpec`]).
 //!
 //! Vector-to-vector binary operators, comparisons, logical/set operators,
-//! `sort`/`sort_desc`, and `vector()` return [`QuerierError::Unsupported`].
+//! and `vector()` return [`QuerierError::Unsupported`].
 
 use logql::{AggregationFunction, BinOp, Grouping, LogQuery, MetricQuery, RangeFunction};
 
@@ -137,6 +139,13 @@ pub struct TopKSpec {
     pub bottom: bool,
 }
 
+/// `sort(...)` / `sort_desc(...)`: order the output series by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SortSpec {
+    /// `true` for `sort_desc` (descending), `false` for `sort`.
+    pub desc: bool,
+}
+
 /// A lowered metric query.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricPlan {
@@ -159,6 +168,8 @@ pub struct MetricPlan {
     pub scalar_op: Option<ScalarOp>,
     /// A `topk`/`bottomk` per-bucket ranking to apply after aggregation.
     pub topk: Option<TopKSpec>,
+    /// A `sort`/`sort_desc` ordering of the output series by value.
+    pub sort: Option<SortSpec>,
     /// A `label_replace` label rewrite to apply to the finished matrix.
     pub label_replace: Option<LabelReplaceSpec>,
     /// The `[range]` window in nanoseconds (informational; bucketing uses
@@ -196,6 +207,21 @@ pub fn plan_metric_query(query: &MetricQuery) -> Result<MetricPlan, QuerierError
                     k: k as usize,
                     bottom,
                 });
+                return Ok(plan);
+            }
+
+            // `sort`/`sort_desc` order the inner query's output series by
+            // value: lower the inner, then attach a `SortSpec`.
+            if let AggregationFunction::Sort | AggregationFunction::SortDesc = vector.function {
+                let desc = vector.function == AggregationFunction::SortDesc;
+                if vector.grouping.is_some() {
+                    return Err(QuerierError::Unsupported("grouped sort".to_string()));
+                }
+                let mut plan = plan_metric_query(&vector.inner)?;
+                if plan.sort.is_some() {
+                    return Err(QuerierError::Unsupported("chained sort".to_string()));
+                }
+                plan.sort = Some(SortSpec { desc });
                 return Ok(plan);
             }
 
@@ -324,6 +350,7 @@ fn plan_range(
         outer_agg: None,
         scalar_op: None,
         topk: None,
+        sort: None,
         label_replace: None,
         range_ns: range.range.as_nanos(),
     })
@@ -644,11 +671,18 @@ mod tests {
     }
 
     #[test]
+    fn sort_and_sort_desc_fold_onto_the_plan() {
+        let a = plan(r#"sort(rate({a="b"}[5m]))"#);
+        assert_eq!(a.sort, Some(SortSpec { desc: false }));
+        assert_eq!(a.aggregate, Aggregate::Count);
+
+        let d = plan(r#"sort_desc(count_over_time({a="b"}[5m]))"#);
+        assert_eq!(d.sort, Some(SortSpec { desc: true }));
+    }
+
+    #[test]
     fn unsupported_shapes_are_rejected() {
-        assert!(matches!(
-            err(r#"sort(rate({a="b"}[5m]))"#),
-            QuerierError::Unsupported(_)
-        ));
+        assert!(matches!(err(r#"vector(5)"#), QuerierError::Unsupported(_)));
         assert!(matches!(
             err(r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#),
             QuerierError::Unsupported(_)

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -34,7 +34,7 @@ use logql::{BinOp, Expr as LogqlExpr, LogQuery, MetricQuery, parse, parse_query,
 
 use super::logql::log_query_filter;
 use super::logql_metric::{
-    Aggregate, ArithOp, LabelReplaceSpec, OuterAgg, ScalarOp, TopKSpec, plan_metric_query,
+    Aggregate, ArithOp, LabelReplaceSpec, OuterAgg, ScalarOp, SortSpec, TopKSpec, plan_metric_query,
 };
 use super::{
     LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
@@ -328,8 +328,14 @@ impl LogsService {
         };
 
         // `label_replace`: rewrite a label from a regex capture of another.
-        match &plan.label_replace {
-            Some(spec) => apply_label_replace(batches, spec),
+        let batches = match &plan.label_replace {
+            Some(spec) => apply_label_replace(batches, spec)?,
+            None => batches,
+        };
+
+        // `sort`/`sort_desc`: order the output series by value.
+        match plan.sort {
+            Some(spec) => apply_sort(batches, spec),
             None => Ok(batches),
         }
     }
@@ -682,6 +688,12 @@ type SeriesKey = (i64, Vec<(String, String)>);
 /// Joined matrix rows indexed by [`SeriesKey`]; ordered by key.
 type JoinMap = BTreeMap<SeriesKey, f64>;
 
+/// A series' label set (sorted pairs), used to group its points for sort.
+type SeriesLabels = Vec<(String, String)>;
+
+/// A series' `(bucket, value)` points.
+type SeriesPoints = Vec<(i64, f64)>;
+
 /// Read a LogQL matrix batch into `(bucket, sorted label pairs, value)`
 /// rows. Every string column other than `value` is treated as a series
 /// label, so the join key is agnostic to which grouping produced it.
@@ -970,6 +982,85 @@ fn apply_label_replace(
     let schema = Arc::new(Schema::new(fields));
 
     let mut columns: Vec<ArrayRef> = Vec::with_capacity(2 + names.len());
+    columns.push(Arc::new(TimestampNanosecondArray::from(buckets)));
+    for col_values in label_values {
+        columns.push(Arc::new(StringArray::from(col_values)));
+    }
+    columns.push(Arc::new(Float64Array::from(values)));
+
+    let batch = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![batch])
+}
+
+/// Order the output series by value for `sort` / `sort_desc`. Series are
+/// ranked by their value at their latest bucket (a range matrix has one
+/// value per bucket, so `sort` is only strictly defined for instant
+/// queries; the latest value is the natural stand-in). Rows are emitted
+/// series-by-series in that order, which the router preserves as the series
+/// order of the response.
+fn apply_sort(batches: Vec<RecordBatch>, spec: SortSpec) -> Result<Vec<RecordBatch>, QuerierError> {
+    use std::cmp::Ordering;
+
+    if batches.is_empty() {
+        return Ok(batches);
+    }
+    let schema = batches[0].schema();
+
+    // Group each series' (bucket, value) points by its label set.
+    let mut series: BTreeMap<SeriesLabels, SeriesPoints> = BTreeMap::new();
+    for batch in &batches {
+        for (bucket, labels, v) in logql_matrix_rows(batch)? {
+            series.entry(labels).or_default().push((bucket, v));
+        }
+    }
+
+    // Rank series by the value at the latest bucket.
+    let latest = |points: &[(i64, f64)]| -> f64 {
+        points
+            .iter()
+            .max_by_key(|(t, _)| *t)
+            .map(|(_, v)| *v)
+            .unwrap_or(f64::NAN)
+    };
+    let mut ordered: Vec<(SeriesLabels, SeriesPoints)> = series.into_iter().collect();
+    ordered.sort_by(|a, b| {
+        let ord = latest(&a.1)
+            .partial_cmp(&latest(&b.1))
+            .unwrap_or(Ordering::Equal);
+        if spec.desc { ord.reverse() } else { ord }
+    });
+
+    // Emit rows series-by-series (each series' points in bucket order).
+    let label_names: Vec<String> = schema
+        .fields()
+        .iter()
+        .filter(|f| f.name() != "bucket" && f.name() != "value")
+        .map(|f| f.name().to_string())
+        .collect();
+
+    let total: usize = ordered.iter().map(|(_, p)| p.len()).sum();
+    let mut buckets = Vec::with_capacity(total);
+    let mut label_values: Vec<Vec<Option<String>>> =
+        vec![Vec::with_capacity(total); label_names.len()];
+    let mut values = Vec::with_capacity(total);
+    for (labels, mut points) in ordered {
+        points.sort_by_key(|(t, _)| *t);
+        for (bucket, v) in points {
+            buckets.push(bucket);
+            for (j, name) in label_names.iter().enumerate() {
+                label_values[j].push(
+                    labels
+                        .iter()
+                        .find(|(k, _)| k == name)
+                        .map(|(_, v)| v.clone()),
+                );
+            }
+            values.push(v);
+        }
+    }
+
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(2 + label_names.len());
     columns.push(Arc::new(TimestampNanosecondArray::from(buckets)));
     for col_values in label_values {
         columns.push(Arc::new(StringArray::from(col_values)));
@@ -1688,6 +1779,30 @@ mod tests {
         // `or`: union — the two api series plus the right-only web series.
         let or = matrix(&service, &format!("{api} or {all}"), 1000).await;
         assert_eq!(or.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn sort_orders_series_by_value() {
+        let service = service_with_varying_counts();
+        // Two api series: (api,error)=3, (api,info)=1.
+        let asc = matrix(
+            &service,
+            r#"sort(count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(asc.len(), 2);
+        assert_eq!(asc[0].0, 1.0); // lowest first
+        assert_eq!(asc[1].0, 3.0);
+
+        let desc = matrix(
+            &service,
+            r#"sort_desc(count_over_time({service_name="api"}[1000ns]))"#,
+            1000,
+        )
+        .await;
+        assert_eq!(desc[0].0, 3.0); // highest first
+        assert_eq!(desc[1].0, 1.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `sort(...)` / `sort_desc(...)` — order the result series by value.

## How

- **Lowering** (`logql_metric.rs`): a `SortSpec { desc }` folded onto the inner query's plan (like `topk`).
- **Execution** (`logs.rs`): `apply_sort` ranks series by their value at the latest bucket and emits rows series-by-series in that order, which the router preserves as the response's series order.

A range matrix has one value per bucket, so `sort` is strictly defined only for instant queries; the latest-bucket value is the natural stand-in (documented).

```logql
sort_desc(sum by (service_name) (rate({env="prod"}[5m])))
```

## Tests

- Lowering: `sort_and_sort_desc_fold_onto_the_plan`.
- Execution: `sort_orders_series_by_value` — two series (values 1, 3): `sort` → [1, 3], `sort_desc` → [3, 1].
- `logql-reference.md` updated.

Part of #366. Remaining niche tail: `vector()`, `on`/`ignoring`.