### PR TITLE
feat(logql): support vector(N)

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -152,6 +152,9 @@ sum by (level) (rate({service_name="api"}[5m]))
 - **Logical / set**: `and` (left series with a right match), `or` (union of
   both sides), `unless` (left series with no right match). Matching is on
   `(bucket, labels)`; values are carried through, never combined.
+- **`vector(N)`**: a scalar promoted to a constant, no-label series valued
+  `N` at every step bucket (as in `... or vector(0)` in Prometheus, though
+  the `or` form itself is not supported yet).
 - **`label_replace(v, dst, replacement, src, regex)`**: rewrites the `dst`
   label from a regex capture of `src` (`$1` / `${name}` in `replacement`).
   The regex is anchored to the whole source value; a non-match leaves the
@@ -174,7 +177,7 @@ exact results.
 These parse but return an "unsupported" error at execution:
 
 - `on` / `ignoring` label matching (vector matching uses the full label
-  set), `vector(N)`
+  set) and `... or vector(0)` fallbacks
 - `sum without (labels)` with a non-empty label list
 - Grouping by an attribute (non-column) label
 

--- a/src/querier/src/query/logql_metric.rs
+++ b/src/querier/src/query/logql_metric.rs
@@ -682,7 +682,10 @@ mod tests {
 
     #[test]
     fn unsupported_shapes_are_rejected() {
-        assert!(matches!(err(r#"vector(5)"#), QuerierError::Unsupported(_)));
+        assert!(matches!(
+            err(r#"absent_over_time({a="b"}[5m])"#),
+            QuerierError::Unsupported(_)
+        ));
         assert!(matches!(
             err(r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#),
             QuerierError::Unsupported(_)

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -180,6 +180,11 @@ impl LogsService {
                 "not a metric query (use query_logs for log queries)".to_string(),
             ));
         };
+        // `vector(N)`: a scalar promoted to a constant, no-label series at
+        // every step bucket — no table scan.
+        if let MetricQuery::VectorLiteral(n) = metric {
+            return synthesize_vector(n, params.start, params.end, params.step);
+        }
         // Vector-to-vector operations (`a / b`, `a > b`): evaluate each
         // operand and join on (bucket, series labels). Scalar operations and
         // everything else lower to a single plan below.
@@ -993,6 +998,43 @@ fn apply_label_replace(
     Ok(vec![batch])
 }
 
+/// Synthesize the matrix for `vector(N)`: a single no-label series holding
+/// the constant `n` at every step-aligned bucket in `[start, end]`. Buckets
+/// align to the unix epoch, matching `date_bin(step, timestamp)` used by
+/// the scanning path.
+fn synthesize_vector(
+    n: f64,
+    start: i64,
+    end: i64,
+    step: i64,
+) -> Result<Vec<RecordBatch>, QuerierError> {
+    let mut buckets = Vec::new();
+    if step > 0 {
+        let mut b = start.div_euclid(step) * step;
+        while b <= end {
+            buckets.push(b);
+            b += step;
+        }
+    }
+    let values = vec![n; buckets.len()];
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "bucket",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new("value", DataType::Float64, false),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(TimestampNanosecondArray::from(buckets)),
+        Arc::new(Float64Array::from(values)),
+    ];
+    let batch = RecordBatch::try_new(schema, columns)
+        .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+    Ok(vec![batch])
+}
+
 /// Order the output series by value for `sort` / `sort_desc`. Series are
 /// ranked by their value at their latest bucket (a range matrix has one
 /// value per bucket, so `sort` is only strictly defined for instant
@@ -1779,6 +1821,15 @@ mod tests {
         // `or`: union — the two api series plus the right-only web series.
         let or = matrix(&service, &format!("{api} or {all}"), 1000).await;
         assert_eq!(or.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn vector_literal_is_a_constant_no_label_series() {
+        let service = service_with_data();
+        // step 1000 over [0, 1000] → buckets 0 and 1000, both valued 5.
+        let out = matrix(&service, r#"vector(5)"#, 1000).await;
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|(v, s)| *v == 5.0 && s.is_none()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds standalone `vector(N)` — a scalar promoted to a constant, no-label series valued `N` at every step bucket.

## How

`query_metric` intercepts `MetricQuery::VectorLiteral(n)` before the scanning path and calls `synthesize_vector`, which emits one no-label row per step-aligned bucket in `[start, end]` (aligned to the unix epoch, matching `date_bin`). No table scan.

```logql
vector(0)
```

The `... or vector(0)` fallback is still unsupported (its `or` combines a labeled series with the no-label constant, which needs vector-matching semantics that interact with our sum-keeps-labels model).

## Tests

- Execution: `vector_literal_is_a_constant_no_label_series` — `vector(5)` over `[0,1000]` step 1000 → two buckets, both `5`, no labels.
- `logql-reference.md` updated.

Part of #366. Remaining: `on`/`ignoring` label matching.