### PR TITLE
feat(logql): support on/ignoring vector matching

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -143,8 +143,11 @@ sum by (level) (rate({service_name="api"}[5m]))
   scaling every value. Operand order is preserved for `-` and `/`.
 - **Vector arithmetic**: two metric queries combined with `+` / `-` / `*`
   / `/` (`sum(rate(...)) / sum(rate(...))` for a ratio). Series are matched
-  one-to-one on `(bucket, labels)`; unmatched series are dropped (there is
-  no `on` / `ignoring` yet).
+  one-to-one on `(bucket, labels)`; unmatched series are dropped.
+- **Vector matching**: an `on (...)` / `ignoring (...)` clause after the
+  operator restricts which labels series match on (`a / on(service) b`,
+  `a / ignoring(level) b`). Matching is one-to-one; a `group_left` /
+  `group_right` modifier is accepted but does not enable many-to-one.
 - **Vector comparison**: two metric queries compared with `==` / `!=` /
   `>` / `>=` / `<` / `<=`. Without `bool` the left series is kept where the
   comparison holds (a filter); with `bool` (`a > bool b`) each matched pair
@@ -176,8 +179,8 @@ exact results.
 
 These parse but return an "unsupported" error at execution:
 
-- `on` / `ignoring` label matching (vector matching uses the full label
-  set) and `... or vector(0)` fallbacks
+- Many-to-one vector matching (`group_left` / `group_right`) and
+  `... or vector(0)` fallbacks
 - `sum without (labels)` with a non-empty label list
 - Grouping by an attribute (non-column) label
 

--- a/src/logql/src/lib.rs
+++ b/src/logql/src/lib.rs
@@ -28,7 +28,7 @@ pub use ast::{
 pub use lexer::{LexError, tokenize};
 pub use metric::{
     AggregationFunction, BinOp, BinaryExpr, LabelReplace, MetricQuery, RangeAggregation,
-    RangeFunction, VectorAggregation,
+    RangeFunction, VectorAggregation, VectorMatch,
 };
 pub use parser::{Expr, ParseError, parse, parse_query, parse_selector};
 pub use token::{SpannedToken, Token};

--- a/src/logql/src/metric.rs
+++ b/src/logql/src/metric.rs
@@ -179,6 +179,23 @@ pub struct BinaryExpr {
     /// `true` when a comparison carries the `bool` modifier
     /// (`> bool 5`), turning the filter into a 0/1 result.
     pub bool_modifier: bool,
+    /// Optional `on (...)` / `ignoring (...)` vector-matching clause that
+    /// restricts which labels series are matched on.
+    pub matching: Option<VectorMatch>,
+}
+
+/// An `on (...)` / `ignoring (...)` vector-matching clause. `group_left` /
+/// `group_right` (many-to-one) are accepted by the parser but recorded as
+/// flags only; matching is evaluated one-to-one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorMatch {
+    /// `true` for `on (...)` (match only these labels), `false` for
+    /// `ignoring (...)` (match on all labels except these).
+    pub on: bool,
+    /// The labels named in the clause.
+    pub labels: Vec<String>,
+    /// `true` when a `group_left` / `group_right` modifier was present.
+    pub grouped: bool,
 }
 
 /// Binary operators, grouped by precedence tier (see the parser).

--- a/src/logql/src/parser.rs
+++ b/src/logql/src/parser.rs
@@ -13,7 +13,7 @@ use crate::ast::{
 use crate::lexer::{LexError, tokenize};
 use crate::metric::{
     AggregationFunction, BinOp, BinaryExpr, MetricQuery, RangeAggregation, RangeFunction,
-    VectorAggregation,
+    VectorAggregation, VectorMatch,
 };
 use crate::token::{SpannedToken, Token};
 
@@ -729,6 +729,9 @@ impl Parser {
                 false
             };
 
+            // Optional `on (...)` / `ignoring (...)` vector-matching clause.
+            let matching = self.parse_optional_vector_match()?;
+
             let next_min = if right_assoc { prec } else { prec + 1 };
             let right = self.parse_binary(next_min)?;
             left = MetricQuery::Binary(Box::new(BinaryExpr {
@@ -736,9 +739,60 @@ impl Parser {
                 left,
                 right,
                 bool_modifier,
+                matching,
             }));
         }
         Ok(left)
+    }
+
+    /// Optional `on (labels)` / `ignoring (labels)` clause, with an optional
+    /// trailing `group_left` / `group_right [ (labels) ]` modifier that is
+    /// accepted but recorded only as a flag (matching is one-to-one).
+    fn parse_optional_vector_match(&mut self) -> Result<Option<VectorMatch>, ParseError> {
+        let on = match self.peek().map(|t| &t.token) {
+            Some(Token::On) => true,
+            Some(Token::Ignoring) => false,
+            _ => return Ok(None),
+        };
+        self.next();
+        let labels = self.parse_label_paren_list("on/ignoring")?;
+
+        // Optional `group_left` / `group_right`, each with an optional
+        // parenthesised label list we consume and ignore.
+        let grouped = match self.peek().map(|t| &t.token) {
+            Some(Token::GroupLeft | Token::GroupRight) => {
+                self.next();
+                if matches!(self.peek().map(|t| &t.token), Some(Token::LParen)) {
+                    self.parse_label_paren_list("group_left/group_right")?;
+                }
+                true
+            }
+            _ => false,
+        };
+
+        Ok(Some(VectorMatch {
+            on,
+            labels,
+            grouped,
+        }))
+    }
+
+    /// Parse a parenthesised, comma-separated label list: `(a, b, c)`.
+    fn parse_label_paren_list(&mut self, what: &str) -> Result<Vec<String>, ParseError> {
+        self.expect(&Token::LParen, "'(' after label-list clause")?;
+        let mut labels = Vec::new();
+        if !matches!(self.peek().map(|t| &t.token), Some(Token::RParen)) {
+            loop {
+                labels.push(self.expect_ident(what)?);
+                if matches!(self.peek().map(|t| &t.token), Some(Token::Comma)) {
+                    self.next();
+                } else {
+                    break;
+                }
+            }
+        }
+        self.expect(&Token::RParen, "')' to close label list")?;
+        Ok(labels)
     }
 
     /// Map the upcoming token to a binary operator and its precedence.
@@ -775,6 +829,7 @@ impl Parser {
                 left: MetricQuery::Literal(0.0),
                 right: inner,
                 bool_modifier: false,
+                matching: None,
             })));
         }
         if matches!(self.peek().map(|t| &t.token), Some(Token::Add)) {
@@ -1525,6 +1580,29 @@ mod tests {
             MetricQuery::Binary(b) => b,
             other => panic!("expected binary expression, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_on_and_ignoring_vector_matching() {
+        let on = metric(r#"sum(rate({a="b"}[1m])) / on(service) sum(rate({a="c"}[1m]))"#);
+        let m = as_binary(&on).matching.as_ref().expect("matching clause");
+        assert!(m.on);
+        assert_eq!(m.labels, vec!["service".to_string()]);
+        assert!(!m.grouped);
+
+        let ign = metric(r#"sum(rate({a="b"}[1m])) / ignoring(level) sum(rate({a="c"}[1m]))"#);
+        let m = as_binary(&ign).matching.as_ref().expect("matching clause");
+        assert!(!m.on);
+        assert_eq!(m.labels, vec!["level".to_string()]);
+
+        // `group_left` is accepted and flagged.
+        let grp =
+            metric(r#"sum(rate({a="b"}[1m])) / on(service) group_left sum(rate({a="c"}[1m]))"#);
+        assert!(as_binary(&grp).matching.as_ref().unwrap().grouped);
+
+        // No clause → None.
+        let plain = metric(r#"sum(rate({a="b"}[1m])) / sum(rate({a="c"}[1m]))"#);
+        assert!(as_binary(&plain).matching.is_none());
     }
 
     #[test]

--- a/src/logql/tests/ast.rs
+++ b/src/logql/tests/ast.rs
@@ -312,8 +312,10 @@ fn cases() -> Vec<(&'static str, Expr)> {
                     ),
                     right: MetricQuery::Literal(2.0),
                     bool_modifier: false,
+                    matching: None,
                 })),
                 bool_modifier: false,
+                matching: None,
             }))),
         ),
         // --- bool modifier on a comparison ---
@@ -329,6 +331,7 @@ fn cases() -> Vec<(&'static str, Expr)> {
                 ),
                 right: MetricQuery::Literal(10.0),
                 bool_modifier: true,
+                matching: None,
             }))),
         ),
         // --- vector(0) fallback ---

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -30,7 +30,10 @@ use datafusion::{
     prelude::{DataFrame, SessionContext},
     scalar::ScalarValue,
 };
-use logql::{BinOp, Expr as LogqlExpr, LogQuery, MetricQuery, parse, parse_query, parse_selector};
+use logql::{
+    BinOp, Expr as LogqlExpr, LogQuery, MetricQuery, VectorMatch, parse, parse_query,
+    parse_selector,
+};
 
 use super::logql::log_query_filter;
 use super::logql_metric::{
@@ -199,12 +202,13 @@ impl LogsService {
             let right_batches = self
                 .execute_plan(&right, params, tenant_slug, dataset_slug)
                 .await?;
+            let matching = bin.matching.as_ref();
             return match kind {
-                BinaryKind::Arith(op) => join_binary(left_batches, op, right_batches),
+                BinaryKind::Arith(op) => join_binary(left_batches, op, right_batches, matching),
                 BinaryKind::Compare(op) => {
-                    join_compare(left_batches, op, bin.bool_modifier, right_batches)
+                    join_compare(left_batches, op, bin.bool_modifier, right_batches, matching)
                 }
-                BinaryKind::Logical(op) => join_logical(left_batches, op, right_batches),
+                BinaryKind::Logical(op) => join_logical(left_batches, op, right_batches, matching),
             };
         }
 
@@ -750,12 +754,42 @@ fn logql_matrix_rows(batch: &RecordBatch) -> Result<Vec<MatrixRow>, QuerierError
     Ok(rows)
 }
 
-/// Index a matrix's rows by `(bucket, labels)` for one side of a join.
-fn index_matrix(batches: &[RecordBatch]) -> Result<JoinMap, QuerierError> {
+/// The labels used to match two series, honoring an `on`/`ignoring` clause.
+/// `on (L)` keeps only labels in `L`; `ignoring (L)` drops labels in `L`;
+/// no clause keeps them all (full-label matching).
+fn match_key(labels: &[(String, String)], matching: Option<&VectorMatch>) -> SeriesLabels {
+    match matching {
+        None => labels.to_vec(),
+        Some(vm) => {
+            // Resolve logical label names (`service`, `level`) to the
+            // physical columns the matrix rows are keyed by.
+            let clause: Vec<String> = vm
+                .labels
+                .iter()
+                .map(|l| {
+                    column_for_label(l)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| l.clone())
+                })
+                .collect();
+            labels
+                .iter()
+                .filter(|(k, _)| clause.iter().any(|c| c == k) == vm.on)
+                .cloned()
+                .collect()
+        }
+    }
+}
+
+/// Index a matrix's rows by `(bucket, match_key)` for one side of a join.
+fn index_matrix(
+    batches: &[RecordBatch],
+    matching: Option<&VectorMatch>,
+) -> Result<JoinMap, QuerierError> {
     let mut index = BTreeMap::new();
     for batch in batches {
         for (bucket, labels, v) in logql_matrix_rows(batch)? {
-            index.insert((bucket, labels), v);
+            index.insert((bucket, match_key(&labels, matching)), v);
         }
     }
     Ok(index)
@@ -809,17 +843,19 @@ fn join_binary(
     left: Vec<RecordBatch>,
     op: ArithOp,
     right: Vec<RecordBatch>,
+    matching: Option<&VectorMatch>,
 ) -> Result<Vec<RecordBatch>, QuerierError> {
     if left.is_empty() {
         return Ok(left);
     }
     let schema = left[0].schema();
-    let rhs = index_matrix(&right)?;
+    let rhs = index_matrix(&right, matching)?;
 
+    // Output keeps the left series' full labels; matching uses `match_key`.
     let mut out: JoinMap = BTreeMap::new();
     for batch in &left {
         for (bucket, labels, lv) in logql_matrix_rows(batch)? {
-            if let Some(&rv) = rhs.get(&(bucket, labels.clone())) {
+            if let Some(&rv) = rhs.get(&(bucket, match_key(&labels, matching))) {
                 out.insert((bucket, labels), arith_apply(op, lv, rv));
             }
         }
@@ -836,17 +872,18 @@ fn join_compare(
     op: CmpOp,
     bool_modifier: bool,
     right: Vec<RecordBatch>,
+    matching: Option<&VectorMatch>,
 ) -> Result<Vec<RecordBatch>, QuerierError> {
     if left.is_empty() {
         return Ok(left);
     }
     let schema = left[0].schema();
-    let rhs = index_matrix(&right)?;
+    let rhs = index_matrix(&right, matching)?;
 
     let mut out: JoinMap = BTreeMap::new();
     for batch in &left {
         for (bucket, labels, lv) in logql_matrix_rows(batch)? {
-            if let Some(&rv) = rhs.get(&(bucket, labels.clone())) {
+            if let Some(&rv) = rhs.get(&(bucket, match_key(&labels, matching))) {
                 let holds = cmp_holds(op, lv, rv);
                 if bool_modifier {
                     out.insert((bucket, labels), if holds { 1.0 } else { 0.0 });
@@ -868,6 +905,7 @@ fn join_logical(
     left: Vec<RecordBatch>,
     op: LogicalOp,
     right: Vec<RecordBatch>,
+    matching: Option<&VectorMatch>,
 ) -> Result<Vec<RecordBatch>, QuerierError> {
     if left.is_empty() {
         // `or` still yields the right side when the left is empty.
@@ -877,12 +915,12 @@ fn join_logical(
         };
     }
     let schema = left[0].schema();
-    let rhs = index_matrix(&right)?;
+    let rhs = index_matrix(&right, matching)?;
 
     let mut out: JoinMap = BTreeMap::new();
     for batch in &left {
         for (bucket, labels, lv) in logql_matrix_rows(batch)? {
-            let matched = rhs.contains_key(&(bucket, labels.clone()));
+            let matched = rhs.contains_key(&(bucket, match_key(&labels, matching)));
             let keep = match op {
                 LogicalOp::And | LogicalOp::Or => matched,
                 LogicalOp::Unless => !matched,
@@ -896,10 +934,10 @@ fn join_logical(
 
     // `or` adds right series that have no left counterpart.
     if matches!(op, LogicalOp::Or) {
-        let lhs = index_matrix(&left)?;
+        let lhs = index_matrix(&left, matching)?;
         for batch in &right {
             for (bucket, labels, rv) in logql_matrix_rows(batch)? {
-                if !lhs.contains_key(&(bucket, labels.clone())) {
+                if !lhs.contains_key(&(bucket, match_key(&labels, matching))) {
                     out.insert((bucket, labels), rv);
                 }
             }
@@ -1798,6 +1836,33 @@ mod tests {
             .await
             .expect("query");
         assert!(batches.iter().all(|b| b.column_by_name("tier").is_none()));
+    }
+
+    #[tokio::test]
+    async fn on_ignoring_restrict_the_match_labels() {
+        let service = service_with_data();
+        // Left: api/error and api/info (both count 1). Right: only api/error.
+        let left = r#"count_over_time({service_name="api"}[1000ns])"#;
+        let right = r#"count_over_time({service_name="api", level="error"}[1000ns])"#;
+
+        // Full-label matching: only api/error matches → one series.
+        let full = matrix(&service, &format!("{left} / {right}"), 1000).await;
+        assert_eq!(full.len(), 1);
+
+        // `on(service_name)`: both api series match the single api/error
+        // series on service_name alone → two series, each 1/1 = 1.
+        let on = matrix(
+            &service,
+            &format!("{left} / on(service_name) {right}"),
+            1000,
+        )
+        .await;
+        assert_eq!(on.len(), 2);
+        assert!(on.iter().all(|(v, _)| *v == 1.0));
+
+        // `ignoring(level)` drops the differing label → same effect.
+        let ign = matrix(&service, &format!("{left} / ignoring(level) {right}"), 1000).await;
+        assert_eq!(ign.len(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `on (...)` / `ignoring (...)` vector-matching clauses to vector-to-vector operations — the final piece of the LogQL metric operator surface.

## How

- **Parser** (`logql` crate): a new `VectorMatch { on, labels, grouped }` on `BinaryExpr`. `parse_binary` parses an optional `on(...)`/`ignoring(...)` after the operator (and an accepted-but-flagged `group_left`/`group_right`), reusing a shared parenthesised label-list parser.
- **Querier** (`logs.rs`): `match_key` resolves the clause's logical labels to physical columns (`service`→`service_name`, `level`→`severity_text`) and restricts the join key — `on` keeps only those labels, `ignoring` drops them. `index_matrix` and the three join functions (`join_binary`/`join_compare`/`join_logical`) key on `match_key` while the output keeps the left series' full labels. Matching stays one-to-one.

```logql
sum(rate({app="api"} |= "error" [5m])) / on(app) sum(rate({app="api"}[5m]))
```

## Tests

- Parser: `parses_on_and_ignoring_vector_matching` — `on`/`ignoring` labels + `group_left` flag + no-clause `None`.
- Execution: `on_ignoring_restrict_the_match_labels` — full-label match yields 1 series; `on(service_name)` / `ignoring(level)` match both api series on the shared label → 2 series.
- `logql-reference.md` updated.

Part of #366. Many-to-one (`group_left`/`group_right`) and `... or vector(0)` remain unsupported.