### PR TITLE
feat(schema): add materialized-labels config and column-name helper

### DIFF
--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -146,6 +146,18 @@ logs_enabled = true
 metrics_enabled = true
 profiles_enabled = true
 
+# Attribute keys to promote from the *_attributes JSON into dedicated,
+# queryable columns per signal type. Materialized labels are matched
+# exactly (and support regex / ordered comparisons) instead of the
+# substring-in-JSON approximation. Keep the lists short and low-cardinality
+# — every entry adds a column. Applies to tables created after the change;
+# pre-existing tables fall back to JSON matching for these keys.
+# [schema.materialized_labels]
+# logs = ["namespace", "pod", "container"]
+# traces = ["http.method", "http.status_code"]
+# metrics = []
+# profiles = []
+
 # Custom schema definitions (optional)
 # [schema.default_schemas.custom_schemas]
 # my_custom_table = '''{"fields": [...]}'''

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -421,6 +421,22 @@ fn default_true() -> bool {
     true
 }
 
+/// Per-signal allowlists of attribute keys to materialize into dedicated,
+/// queryable columns (instead of only matching them inside the attribute
+/// JSON). Keeping the set explicit bounds the column cardinality, mirroring
+/// Loki's "labels are declared, not inferred" model.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MaterializedLabels {
+    #[serde(default)]
+    pub logs: Vec<String>,
+    #[serde(default)]
+    pub traces: Vec<String>,
+    #[serde(default)]
+    pub metrics: Vec<String>,
+    #[serde(default)]
+    pub profiles: Vec<String>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SchemaConfig {
     /// Type of catalog backend (sql, memory)
@@ -430,6 +446,9 @@ pub struct SchemaConfig {
     /// Default schemas to create for new tenants
     #[serde(default)]
     pub default_schemas: DefaultSchemas,
+    /// Attribute keys promoted to dedicated columns per signal type.
+    #[serde(default)]
+    pub materialized_labels: MaterializedLabels,
 }
 
 impl Default for SchemaConfig {
@@ -438,6 +457,7 @@ impl Default for SchemaConfig {
             catalog_type: "sql".to_string(),
             catalog_uri: "sqlite::memory:".to_string(),
             default_schemas: DefaultSchemas::default(),
+            materialized_labels: MaterializedLabels::default(),
         }
     }
 }
@@ -755,6 +775,7 @@ impl From<IcebergConfig> for SchemaConfig {
             catalog_type: iceberg_config.catalog_type, // Preserve original catalog_type
             catalog_uri: iceberg_config.catalog_uri,
             default_schemas: DefaultSchemas::default(),
+            materialized_labels: MaterializedLabels::default(),
         }
     }
 }
@@ -1388,6 +1409,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://tenant".to_string(),
                 default_schemas: DefaultSchemas::default(),
+                materialized_labels: Default::default(),
             }),
             custom_schemas: Some({
                 let mut schemas = HashMap::new();

--- a/src/common/src/schema/mod.rs
+++ b/src/common/src/schema/mod.rs
@@ -17,6 +17,22 @@ pub use crate::iceberg::{
 
 use self::schema_parser::SchemaDefinitions;
 
+/// The column name a materialized attribute label is stored under. The
+/// label key is sanitized (non-alphanumeric → `_`) and prefixed with
+/// `label_` so promoted attributes never collide with the built-in schema
+/// columns and are valid SQL/Arrow identifiers (OTLP keys like
+/// `http.method` contain dots that DataFusion would treat as field
+/// access). Writer, schema generation, and querier all resolve a label to
+/// its column through this one function.
+pub fn materialized_column_name(label: &str) -> String {
+    let mut out = String::with_capacity(label.len() + 6);
+    out.push_str("label_");
+    for ch in label.chars() {
+        out.push(if ch.is_ascii_alphanumeric() { ch } else { '_' });
+    }
+    out
+}
+
 /// Embedded schema definitions from schemas.toml
 pub const SCHEMA_DEFINITIONS_TOML: &str = include_str!("../../../../schemas.toml");
 
@@ -212,6 +228,37 @@ mod tests {
     use crate::config::{DefaultSchemas, SchemaConfig, TenantSchemaConfig, TenantsConfig};
     use std::collections::HashMap;
 
+    #[test]
+    fn materialized_column_name_sanitizes_and_prefixes() {
+        assert_eq!(materialized_column_name("namespace"), "label_namespace");
+        // Dots and other non-alphanumerics become underscores.
+        assert_eq!(materialized_column_name("http.method"), "label_http_method");
+        assert_eq!(
+            materialized_column_name("k8s.pod/name"),
+            "label_k8s_pod_name"
+        );
+    }
+
+    #[test]
+    fn materialized_labels_default_is_empty_and_parses_from_toml() {
+        // Default: no materialized labels for any signal.
+        let cfg = SchemaConfig::default();
+        assert!(cfg.materialized_labels.logs.is_empty());
+
+        // A `[schema]` block with a materialized-labels table parses.
+        let toml = r#"
+catalog_type = "sql"
+catalog_uri = "sqlite::memory:"
+[materialized_labels]
+logs = ["namespace", "pod"]
+traces = ["http.method"]
+"#;
+        let parsed: SchemaConfig = toml::from_str(toml).expect("parse schema config");
+        assert_eq!(parsed.materialized_labels.logs, vec!["namespace", "pod"]);
+        assert_eq!(parsed.materialized_labels.traces, vec!["http.method"]);
+        assert!(parsed.materialized_labels.metrics.is_empty());
+    }
+
     #[tokio::test]
     async fn test_tenant_schema_registry_default() {
         let config = Configuration::default();
@@ -244,6 +291,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://".to_string(),
                 default_schemas: DefaultSchemas::default(),
+                materialized_labels: Default::default(),
             }),
             custom_schemas: Some({
                 let mut schemas = HashMap::new();
@@ -302,6 +350,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://".to_string(),
                 default_schemas: DefaultSchemas::default(),
+                materialized_labels: Default::default(),
             }),
             ..Default::default()
         };

--- a/src/common/src/tenant_api.rs
+++ b/src/common/src/tenant_api.rs
@@ -367,6 +367,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://".to_string(),
                 default_schemas: crate::config::DefaultSchemas::default(),
+                materialized_labels: Default::default(),
             }),
             ..Default::default()
         };

--- a/src/common/tests/iceberg_integration.rs
+++ b/src/common/tests/iceberg_integration.rs
@@ -7,6 +7,7 @@ async fn test_iceberg_sql_catalog_basic_operations() {
         catalog_type: "sql".to_string(),
         catalog_uri: "sqlite::memory:".to_string(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     // Create catalog
@@ -40,6 +41,7 @@ async fn ensure_table_reflects_commits_made_through_other_handles() {
         catalog_type: "sql".to_string(),
         catalog_uri: "sqlite::memory:".to_string(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
     let catalog = create_catalog(config).await.unwrap();
     let manager = IcebergTableManager::new(catalog.clone());

--- a/src/common/tests/schema_integration.rs
+++ b/src/common/tests/schema_integration.rs
@@ -18,6 +18,7 @@ async fn test_memory_catalog() {
         catalog_type: "memory".to_string(),
         catalog_uri: "memory://".to_string(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     let catalog = create_catalog(config).await.unwrap();
@@ -33,6 +34,7 @@ async fn test_sql_catalog() {
         catalog_type: "sql".to_string(),
         catalog_uri: "sqlite::memory:".to_string(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     let catalog = create_catalog(config).await.unwrap();
@@ -57,6 +59,7 @@ async fn test_unsupported_catalog_type() {
         catalog_type: "unsupported".to_string(),
         catalog_uri: "unsupported://".to_string(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     let result = create_catalog(config).await;

--- a/src/router/src/endpoints/tenant.rs
+++ b/src/router/src/endpoints/tenant.rs
@@ -178,6 +178,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://test".to_string(),
                 default_schemas: DefaultSchemas::default(),
+                materialized_labels: Default::default(),
             }),
             ..TenantSchemaConfig::default()
         };

--- a/src/writer/benches/connection_pool_benchmarks.rs
+++ b/src/writer/benches/connection_pool_benchmarks.rs
@@ -23,6 +23,7 @@ fn create_benchmark_config() -> Configuration {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),

--- a/src/writer/benches/iceberg_benchmarks.rs
+++ b/src/writer/benches/iceberg_benchmarks.rs
@@ -23,6 +23,7 @@ fn create_benchmark_config() -> Configuration {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),

--- a/src/writer/src/storage/iceberg.rs
+++ b/src/writer/src/storage/iceberg.rs
@@ -432,6 +432,7 @@ mod tests {
                 catalog_type: "memory".to_string(),
                 catalog_uri: "memory://".to_string(),
                 default_schemas: Default::default(),
+                materialized_labels: Default::default(),
             },
             storage: StorageConfig {
                 dsn: "memory://".to_string(),

--- a/src/writer/tests/test_e2e_simple.rs
+++ b/src/writer/tests/test_e2e_simple.rs
@@ -35,6 +35,7 @@ fn create_simple_test_config() -> Configuration {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),

--- a/src/writer/tests/test_retry_logic.rs
+++ b/src/writer/tests/test_retry_logic.rs
@@ -36,6 +36,7 @@ async fn test_retry_config_default() -> Result<()> {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),
@@ -70,6 +71,7 @@ async fn test_retry_config_custom() -> Result<()> {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),
@@ -113,6 +115,7 @@ async fn test_retry_logic_with_valid_batch() -> Result<()> {
                 profiles_enabled: true,
                 custom_schemas: Default::default(),
             },
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -107,6 +107,7 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
         catalog_type: "sql".to_string(),
         catalog_uri: catalog_dsn,
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     // Configure test tenant

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -78,6 +78,7 @@ async fn setup_test_services() -> TestServices {
         catalog_type: "sql".to_string(),
         catalog_uri: catalog_dsn,
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     // Configure storage to use filesystem
@@ -824,6 +825,7 @@ async fn setup_multi_tenant_test_services() -> TestServices {
         catalog_type: "sql".to_string(),
         catalog_uri: catalog_dsn.clone(),
         default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
     };
 
     // Configure storage

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -128,6 +128,7 @@ async fn test_iceberg_namespace_slug_based() -> Result<()> {
             catalog_type: "sql".to_string(),
             catalog_uri: "sqlite::memory:".to_string(),
             default_schemas: Default::default(),
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),
@@ -196,6 +197,7 @@ async fn test_partition_spec_roundtrip() -> Result<()> {
             catalog_type: "sql".to_string(),
             catalog_uri: "sqlite::memory:".to_string(),
             default_schemas: Default::default(),
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: "memory://".to_string(),
@@ -288,6 +290,7 @@ async fn test_write_and_query_with_slugs() -> Result<()> {
             catalog_type: "sql".to_string(),
             catalog_uri: format!("sqlite://{}", catalog_path.display()),
             default_schemas: Default::default(),
+            materialized_labels: Default::default(),
         },
         storage: StorageConfig {
             dsn: format!("file://{}", storage_path.display()),


### PR DESCRIPTION
## What

Phase 0 (foundation) of **write-time label materialization** — promoting configured attribute keys from the `*_attributes` JSON into dedicated, exactly-queryable columns. This PR adds only the config + the shared naming primitive; no behavior change yet.

## How

- **Config**: a per-signal `[schema.materialized_labels]` allowlist (`logs`/`traces`/`metrics`/`profiles`) on `SchemaConfig`, defaulting to empty. Keeping the set explicit bounds column cardinality (Loki's "labels are declared" model).
- **Naming**: `materialized_column_name(label)` → sanitized `label_<key>` (non-alphanumeric → `_`), the single mapping schema-generation, the writer, and the querier will all share so a label always resolves to the same column (and OTLP dotted keys like `http.method` stay valid SQL/Arrow identifiers).

## Notes / plan

Later phases: schema generation injects these columns into new tables → writer extracts the keys (from resource/scope/record attributes, record > scope > resource precedence) → querier routes materialized labels to columns for exact/regex/ordered matching (JSON fallback for pre-existing tables). Existing-table schema evolution is a separate, later phase (the pinned iceberg-rust fork lacks a high-level set-current-schema API).

## Tests

- `materialized_column_name_sanitizes_and_prefixes`, `materialized_labels_default_is_empty_and_parses_from_toml`. Documented in `signaldb.dist.toml`. Updates every `SchemaConfig` literal for the new field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for promoting selected signal attributes into dedicated, queryable columns for logs, traces, metrics, and profiles.
  * Added automatic conversion of attribute keys into safe column names.
  * Added configuration guidance for new tables and fallback behavior for existing tables.

* **Tests**
  * Added coverage for configuration defaults, parsing, and column-name formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->