### PR TITLE
feat(querier): route materialized labels to their columns

### DIFF
--- a/.claude/skills/configuration/SKILL.md
+++ b/.claude/skills/configuration/SKILL.md
@@ -70,6 +70,13 @@ Env: `SIGNALDB__SCHEMA__CATALOG_TYPE`, `SIGNALDB__SCHEMA__CATALOG_URI` (double-u
 
 **Note**: Only SQLite supported for Iceberg catalog (not PostgreSQL).
 
+#### Materialized labels
+```toml
+[schema.materialized_labels]
+logs = ["namespace", "pod"]   # also: traces / metrics / profiles
+```
+Per-signal allowlists of attribute keys promoted from the `*_attributes` JSON into dedicated `label_<key>` columns at ingest, so they match exactly (and support regex / ordered comparisons) instead of the substring-in-JSON approximation. Default empty. Applies to tables created after the change; older tables fall back to JSON matching. See `docs/architecture/storage-layout.md#materialized-labels`.
+
 ### Authentication
 
 Tenant auth is always enforced on the tenant-facing APIs; there is no

--- a/.claude/skills/flight-schemas/SKILL.md
+++ b/.claude/skills/flight-schemas/SKILL.md
@@ -80,6 +80,8 @@ Applied in Writer's Flight `do_put` handler before WAL write -- all WAL data is 
 
 Key fields: `timestamp` (partition), `trace_id`, `span_id`, `severity_text`, `severity_number`, `service_name`, `body`, `resource_attributes`, `log_attributes`, `date_day`, `hour`.
 
+Plus, when `[schema.materialized_labels].logs` is configured, a nullable `label_<key>` column per key. `transform_logs_v1_to_iceberg` appends these (value from resource→scope→record attributes, first non-null) after the base fields. Default empty ⇒ unchanged schema. See `docs/architecture/storage-layout.md#materialized-labels`.
+
 ## Metrics Schemas
 
 Two definitions coexist:

--- a/.claude/skills/storage-layout/SKILL.md
+++ b/.claude/skills/storage-layout/SKILL.md
@@ -135,6 +135,10 @@ Note: `WalConfig::default()` uses `.wal` as the base directory; the TOML-level
 
 All tables partitioned by `Hour(timestamp)` as `timestamp_hour`.
 
+### Materialized labels
+
+`[schema.materialized_labels]` (per signal) promotes attribute keys from the `*_attributes` JSON into nullable `label_<key>` columns at ingest, so they match exactly / by regex / with ordered comparisons instead of the JSON substring approximation. Naming via `common::schema::materialized_column_name` (non-alphanumeric → `_`, `label_` prefix). Writer populates from resource→scope→record attributes (first non-null); `coerce_batch_to_schema` drops columns a table lacks and null-fills nullable ones it has. New tables carry the configured columns from creation (no schema evolution on the pinned iceberg-rust fork); older tables fall back to JSON. Querier routes via the column when the table schema has it. See `docs/architecture/storage-layout.md#materialized-labels`.
+
 ## Key Implementation Files
 
 | File | Purpose |

--- a/docs/architecture/storage-layout.md
+++ b/docs/architecture/storage-layout.md
@@ -320,6 +320,40 @@ Defined in `schemas.toml`.
 
 **Partition**: `Hour(timestamp)` as `timestamp_hour`
 
+### Materialized labels
+
+By default every attribute other than the promoted columns above lives in
+the `*_attributes` JSON and is queried by a substring match — inexact and
+limited to `=` / `!=`. Configuring `[schema.materialized_labels]` promotes
+chosen attribute keys into dedicated columns so they can be matched exactly,
+by regex, and with ordered comparisons.
+
+```toml
+[schema.materialized_labels]
+logs = ["namespace", "pod"]
+# traces = [...]   # metrics / profiles likewise
+```
+
+- **Column naming**: a label key `k` becomes a nullable string column
+  `label_<k>` with non-alphanumeric characters replaced by `_` (so
+  `http.method` → `label_http_method`). This is the one mapping used by
+  schema generation, the writer, and the querier.
+- **Population** (writer): each row's value is taken from its **resource**,
+  then **scope**, then **record** attributes (first non-null wins); the value
+  is also left in the attribute JSON, so label discovery is unaffected.
+- **When it applies**: tables are created lazily and carry the columns from
+  their configured set at creation time (the pinned iceberg-rust fork has no
+  supported schema-evolution to add columns to an existing table). A table
+  that predates a label keeps matching it through the JSON substring path;
+  the writer's schema coercion drops columns a table lacks and null-fills
+  nullable columns it has but the current config no longer produces.
+- **Querying**: the querier routes a label to its `label_<key>` column when
+  the table has one, else to the JSON match (see the
+  [LogQL reference](../users/logql-reference.md#materialized-labels)).
+
+The same mechanism is intended for the trace, metric, and profile signals,
+which share the attribute-JSON pattern.
+
 #### Metrics Gauge Table (v1 -- current)
 
 Defined in `src/common/src/iceberg/schemas.rs`.

--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -57,6 +57,7 @@ labels resolve as follows:
 | `service_name`, `service`, `job` | the `service_name` column |
 | `level`, `severity`, `detected_level` | the `severity_text` column |
 | `trace_id`, `span_id` | the matching columns |
+| a **materialized** label (see below) | its dedicated `label_<key>` column |
 | any other label | a match inside the `log_attributes` / `resource_attributes` JSON |
 
 Labels backed by a column are exact. Any other label is matched by the
@@ -64,6 +65,22 @@ serialized `"key":"value"` fragment inside the attribute JSON — the same
 approximation the trace search API uses. It can occasionally over-match
 when another attribute's text embeds the same fragment; this is a known
 limitation until attributes are indexed.
+
+### Materialized labels
+
+Configured attribute keys are promoted to dedicated columns at ingest via
+`[schema.materialized_labels]` (see `signaldb.dist.toml` and
+[storage layout](../architecture/storage-layout.md#materialized-labels)).
+A materialized label is matched **exactly** — no substring over-match — and,
+unlike JSON attributes, supports regex (`=~` / `!~`) **and ordered
+comparisons** (`| latency_ms > 500`). The value is compared as a string for
+`=` / `!=` / `=~`, and cast to a number for `>` / `>=` / `<` / `<=`.
+
+Materialization applies to data written after the label was configured and
+to tables created after that point; a table that predates the column falls
+back to the JSON substring match for that label. Because the promoted value
+is also kept in the attribute JSON, label discovery (`/labels`,
+`/label/{name}/values`) is unchanged.
 
 Series identity (in `/series` results and un-grouped metric queries) is
 the `service_name` and `level` labels.
@@ -103,9 +120,11 @@ filter rows: they are accepted and pass through. A **label filter** after
 a stage (`| level="error"`, `| status="500"`) does filter, resolving
 labels via the mapping above.
 
-Label filters support `=`, `!=`, `=~`, `!~` against columns and `=`, `!=`
-against attributes, combined with `and`/`or`/comma. Ordered comparisons
-(`>`, `>=`, `<`, `<=`, e.g. `| duration > 1s`) are **not** supported yet.
+Label filters support `=`, `!=`, `=~`, `!~` against columns (including
+materialized labels) and `=`, `!=` against JSON attributes, combined with
+`and`/`or`/comma. Ordered comparisons (`>`, `>=`, `<`, `<=`, e.g.
+`| status >= 500`) work on **materialized** labels — which are cast to a
+number — but not on plain JSON attributes.
 
 ## Metric queries
 

--- a/src/querier/src/query/logql.rs
+++ b/src/querier/src/query/logql.rs
@@ -24,15 +24,25 @@
 //!
 //! Line filters (`|=`, `!=`, `|~`, `!~`) match the `body` column.
 
+use std::collections::HashSet;
+
+use common::schema::materialized_column_name;
+use datafusion::arrow::datatypes::DataType;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions::string::expr_fn::contains;
-use datafusion::logical_expr::{Expr, col, lit, not};
+use datafusion::logical_expr::{Expr, cast, col, lit, not};
 use logql::{
     FilterOp, FilterValue, LabelFilterExpr, LabelMatcher, LineFilter, LineFilterOp, LogQuery,
     MatchOp, PipelineStage,
 };
 
 use super::error::QuerierError;
+
+/// The set of materialized `label_<key>` columns present in the table being
+/// queried. A label in this set routes to its dedicated column (exact,
+/// regex, and ordered comparisons); anything else falls back to the
+/// attribute-JSON substring match.
+pub type MaterializedColumns = HashSet<String>;
 
 /// Attribute columns searched for a label that is not a dedicated column.
 const LOG_ATTRIBUTES: &str = "log_attributes";
@@ -43,13 +53,23 @@ const RESOURCE_ATTRIBUTES: &str = "resource_attributes";
 ///
 /// The caller ANDs in the request's time-range predicate.
 pub fn log_query_filter(query: &LogQuery) -> Result<Option<Expr>, QuerierError> {
+    log_query_filter_with_columns(query, &MaterializedColumns::new())
+}
+
+/// Like [`log_query_filter`], but aware of which materialized `label_<key>`
+/// columns exist in the target table, so attribute labels backed by a
+/// column are matched exactly instead of by JSON substring.
+pub fn log_query_filter_with_columns(
+    query: &LogQuery,
+    columns: &MaterializedColumns,
+) -> Result<Option<Expr>, QuerierError> {
     let mut exprs: Vec<Expr> = Vec::new();
 
     for matcher in &query.selector.matchers {
-        exprs.push(matcher_expr(matcher)?);
+        exprs.push(matcher_expr(matcher, columns)?);
     }
     for stage in &query.pipeline {
-        if let Some(expr) = stage_expr(stage)? {
+        if let Some(expr) = stage_expr(stage, columns)? {
             exprs.push(expr);
         }
     }
@@ -58,7 +78,10 @@ pub fn log_query_filter(query: &LogQuery) -> Result<Option<Expr>, QuerierError> 
 }
 
 /// Lower a stream-selector matcher.
-fn matcher_expr(matcher: &LabelMatcher) -> Result<Expr, QuerierError> {
+fn matcher_expr(
+    matcher: &LabelMatcher,
+    columns: &MaterializedColumns,
+) -> Result<Expr, QuerierError> {
     let op = match matcher.op {
         MatchOp::Eq => FilterOp::Eq,
         MatchOp::Neq => FilterOp::Neq,
@@ -69,15 +92,19 @@ fn matcher_expr(matcher: &LabelMatcher) -> Result<Expr, QuerierError> {
         &matcher.name,
         op,
         &FilterValue::String(matcher.value.clone()),
+        columns,
     )
 }
 
 /// Lower a pipeline stage to an optional filter. Parser stages,
 /// formatters, and drop/keep reshape results without filtering rows.
-fn stage_expr(stage: &PipelineStage) -> Result<Option<Expr>, QuerierError> {
+fn stage_expr(
+    stage: &PipelineStage,
+    columns: &MaterializedColumns,
+) -> Result<Option<Expr>, QuerierError> {
     match stage {
         PipelineStage::LineFilter(f) => Ok(Some(line_filter_expr(f)?)),
-        PipelineStage::LabelFilter(expr) => Ok(Some(label_filter_expr(expr)?)),
+        PipelineStage::LabelFilter(expr) => Ok(Some(label_filter_expr(expr, columns)?)),
         PipelineStage::Json(_)
         | PipelineStage::Logfmt(_)
         | PipelineStage::Regexp(_)
@@ -112,11 +139,18 @@ fn line_filter_expr(f: &LineFilter) -> Result<Expr, QuerierError> {
 }
 
 /// Lower a label-filter expression, preserving its `and`/`or` structure.
-fn label_filter_expr(expr: &LabelFilterExpr) -> Result<Expr, QuerierError> {
+fn label_filter_expr(
+    expr: &LabelFilterExpr,
+    columns: &MaterializedColumns,
+) -> Result<Expr, QuerierError> {
     match expr {
-        LabelFilterExpr::Pred(p) => label_expr(&p.name, p.op, &p.value),
-        LabelFilterExpr::And(a, b) => Ok(label_filter_expr(a)?.and(label_filter_expr(b)?)),
-        LabelFilterExpr::Or(a, b) => Ok(label_filter_expr(a)?.or(label_filter_expr(b)?)),
+        LabelFilterExpr::Pred(p) => label_expr(&p.name, p.op, &p.value, columns),
+        LabelFilterExpr::And(a, b) => {
+            Ok(label_filter_expr(a, columns)?.and(label_filter_expr(b, columns)?))
+        }
+        LabelFilterExpr::Or(a, b) => {
+            Ok(label_filter_expr(a, columns)?.or(label_filter_expr(b, columns)?))
+        }
     }
 }
 
@@ -131,13 +165,79 @@ fn column_for_label(label: &str) -> Option<&'static str> {
     }
 }
 
-/// Lower a `name op value` predicate against a column or the attribute
-/// JSON columns.
-fn label_expr(name: &str, op: FilterOp, value: &FilterValue) -> Result<Expr, QuerierError> {
-    match column_for_label(name) {
-        Some(column) => column_expr(column, op, value),
-        None => attribute_expr(name, op, value),
+/// Lower a `name op value` predicate. Well-known labels resolve to their
+/// dedicated column; other labels resolve to a materialized `label_<key>`
+/// column when the table has one, else to the attribute-JSON substring
+/// match.
+fn label_expr(
+    name: &str,
+    op: FilterOp,
+    value: &FilterValue,
+    columns: &MaterializedColumns,
+) -> Result<Expr, QuerierError> {
+    if let Some(column) = column_for_label(name) {
+        return column_expr(column, op, value);
     }
+    let materialized = materialized_column_name(name);
+    if columns.contains(&materialized) {
+        return materialized_label_expr(&materialized, op, value);
+    }
+    attribute_expr(name, op, value)
+}
+
+/// Predicate against a materialized attribute column (nullable `Utf8`).
+/// Exact/regex comparisons match the string value; ordered comparisons cast
+/// the value to `Float64`. Negations also match rows where the label is
+/// absent (NULL), mirroring the JSON path where an absent key satisfies
+/// `!=`.
+fn materialized_label_expr(
+    column: &str,
+    op: FilterOp,
+    value: &FilterValue,
+) -> Result<Expr, QuerierError> {
+    let c = col(column);
+    Ok(match op {
+        FilterOp::Eq | FilterOp::CmpEq => c.eq(lit(string_value(value)?)),
+        FilterOp::Neq => c.clone().is_null().or(c.not_eq(lit(string_value(value)?))),
+        FilterOp::Re => regexp_like(c, lit(string_value(value)?), None),
+        FilterOp::Nre => {
+            c.clone()
+                .is_null()
+                .or(not(regexp_like(c, lit(string_value(value)?), None)))
+        }
+        FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte => {
+            let n = numeric_value(value)?;
+            let casted = cast(c, DataType::Float64);
+            match op {
+                FilterOp::Gt => casted.gt(lit(n)),
+                FilterOp::Gte => casted.gt_eq(lit(n)),
+                FilterOp::Lt => casted.lt(lit(n)),
+                FilterOp::Lte => casted.lt_eq(lit(n)),
+                _ => unreachable!(),
+            }
+        }
+    })
+}
+
+/// The numeric form of a filter value for ordered comparisons. Durations
+/// use nanoseconds and bytes their raw count, matching how the write path
+/// serializes them.
+fn numeric_value(value: &FilterValue) -> Result<f64, QuerierError> {
+    Ok(match value {
+        FilterValue::Number(n) => *n,
+        FilterValue::Bytes(b) => *b as f64,
+        FilterValue::Duration(d) => d.as_nanos() as f64,
+        FilterValue::String(s) => s.parse::<f64>().map_err(|_| {
+            QuerierError::Unsupported(format!(
+                "ordered comparison needs a numeric value, got '{s}'"
+            ))
+        })?,
+        FilterValue::Ip(_) => {
+            return Err(QuerierError::Unsupported(
+                "ordered comparison on an ip() value".to_string(),
+            ));
+        }
+    })
 }
 
 /// Predicate against a dedicated string column.
@@ -223,6 +323,58 @@ mod tests {
 
     fn lower(query: &str) -> Result<Option<Expr>, QuerierError> {
         log_query_filter(&parse_query(query).expect("parse"))
+    }
+
+    /// Lower with a set of materialized `label_<key>` columns present.
+    fn sql_with(query: &str, columns: &[&str]) -> String {
+        let q = parse_query(query).expect("parse");
+        let cols: MaterializedColumns = columns.iter().map(|c| c.to_string()).collect();
+        let expr = log_query_filter_with_columns(&q, &cols)
+            .expect("lower")
+            .expect("some filter");
+        format!("{expr}")
+    }
+
+    #[test]
+    fn materialized_label_routes_to_its_column() {
+        // Without the column: attribute JSON substring match.
+        assert_eq!(
+            sql(r#"{namespace="prod"}"#),
+            r#"contains(log_attributes, Utf8(""namespace":"prod"")) OR contains(resource_attributes, Utf8(""namespace":"prod""))"#
+        );
+        // With the column: exact equality on the dedicated column.
+        assert_eq!(
+            sql_with(r#"{namespace="prod"}"#, &["label_namespace"]),
+            r#"label_namespace = Utf8("prod")"#
+        );
+        // `!=` also matches rows where the label is absent (NULL).
+        assert_eq!(
+            sql_with(r#"{namespace!="prod"}"#, &["label_namespace"]),
+            r#"label_namespace IS NULL OR label_namespace != Utf8("prod")"#
+        );
+        // Regex against a materialized column.
+        assert_eq!(
+            sql_with(r#"{namespace=~"pr.*"}"#, &["label_namespace"]),
+            r#"regexp_like(label_namespace, Utf8("pr.*"))"#
+        );
+    }
+
+    #[test]
+    fn materialized_label_supports_ordered_comparison() {
+        // `| status > 500` on a materialized column casts to Float64.
+        assert_eq!(
+            sql_with(
+                r#"{service_name="api"} | logfmt | status > 500"#,
+                &["label_status"]
+            ),
+            r#"service_name = Utf8("api") AND CAST(label_status AS Float64) > Float64(500)"#
+        );
+        // Without the column, ordered comparison on an attribute is rejected.
+        let q = parse_query(r#"{service_name="api"} | logfmt | status > 500"#).expect("parse");
+        assert!(matches!(
+            log_query_filter_with_columns(&q, &MaterializedColumns::new()),
+            Err(QuerierError::Unsupported(_))
+        ));
     }
 
     #[test]

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -35,7 +35,7 @@ use logql::{
     parse_selector,
 };
 
-use super::logql::log_query_filter;
+use super::logql::{MaterializedColumns, log_query_filter_with_columns};
 use super::logql_metric::{
     Aggregate, ArithOp, LabelReplaceSpec, OuterAgg, ScalarOp, SortSpec, TopKSpec, plan_metric_query,
 };
@@ -146,10 +146,10 @@ impl LogsService {
     ) -> Result<Vec<RecordBatch>, QuerierError> {
         let parsed =
             parse_query(&params.query).map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
-        let filter = log_query_filter(&parsed)?;
         let direction = Direction::parse(params.direction.as_deref());
 
         let df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let filter = log_query_filter_with_columns(&parsed, &materialized_columns_of(&df))?;
         let df = shape_log_query(
             df,
             filter,
@@ -227,8 +227,6 @@ impl LogsService {
         tenant_slug: &str,
         dataset_slug: &str,
     ) -> Result<Vec<RecordBatch>, QuerierError> {
-        let filter = log_query_filter(&plan.log_query)?;
-
         // Resolve the output grouping columns (the `by` labels); unknown
         // labels can't be grouped with the substring attribute model.
         let out_group_cols: Vec<&'static str> = plan
@@ -253,6 +251,7 @@ impl LogsService {
         };
 
         let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let filter = log_query_filter_with_columns(&plan.log_query, &materialized_columns_of(&df))?;
         df = apply_window(df, params.start, params.end)?;
         if let Some(filter) = filter {
             df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
@@ -476,12 +475,13 @@ impl LogsService {
         // An empty matcher list is invalid in Loki's /series.
         let parsed = parse_selector(selector.trim())
             .map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
-        let filter = log_query_filter(&LogQuery {
+        let query = LogQuery {
             selector: parsed,
             pipeline: Vec::new(),
-        })?;
+        };
 
         let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
+        let filter = log_query_filter_with_columns(&query, &materialized_columns_of(&df))?;
         df = apply_window(df, start, end)?;
         if let Some(filter) = filter {
             df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
@@ -543,6 +543,17 @@ pub fn shape_log_query(
 }
 
 /// Inclusive nanosecond bounds on the `timestamp` column.
+/// The materialized `label_<key>` columns present in a logs table, so the
+/// filter lowering can route those labels to their columns.
+fn materialized_columns_of(df: &DataFrame) -> MaterializedColumns {
+    df.schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().to_string())
+        .filter(|n| n.starts_with("label_"))
+        .collect()
+}
+
 fn apply_window(df: DataFrame, start: i64, end: i64) -> Result<DataFrame, QuerierError> {
     df.filter(col("timestamp").gt_eq(lit(ScalarValue::TimestampNanosecond(Some(start), None))))
         .map_err(QuerierError::QueryFailed)?
@@ -1287,6 +1298,70 @@ mod tests {
 
     fn str_col(values: &[&str]) -> Arc<StringArray> {
         Arc::new(StringArray::from(values.to_vec()))
+    }
+
+    /// A `t.d.logs` table with two materialized label columns
+    /// (`label_namespace`, `label_status`) so the querier routes those
+    /// labels to columns for exact / regex / ordered matching.
+    fn service_with_materialized_labels() -> LogsService {
+        let mut fields: Vec<Field> = logs_schema()
+            .fields()
+            .iter()
+            .map(|f| (**f).clone())
+            .collect();
+        fields.push(Field::new("label_namespace", DataType::Utf8, true));
+        fields.push(Field::new("label_status", DataType::Utf8, true));
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![100, 200, 300])),
+                str_col(&["a", "b", "c"]),
+                str_col(&["api", "api", "web"]),
+                str_col(&["error", "info", "error"]),
+                str_col(&["t1", "t2", "t3"]),
+                str_col(&["s1", "s2", "s3"]),
+                str_col(&["{}", "{}", "{}"]),
+                str_col(&["{}", "{}", "{}"]),
+                str_col(&["prod", "prod", "staging"]),
+                str_col(&["200", "500", "503"]),
+            ],
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let schema_provider = Arc::new(MemorySchemaProvider::new());
+        schema_provider
+            .register_table("logs".to_string(), Arc::new(table))
+            .unwrap();
+        let catalog = Arc::new(MemoryCatalogProvider::new());
+        catalog.register_schema("d", schema_provider).unwrap();
+        ctx.register_catalog("t", catalog);
+        LogsService::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn materialized_label_exact_and_ordered_matching() {
+        let service = service_with_materialized_labels();
+
+        // Exact match on the materialized `namespace` column.
+        let prod = rows(&service, r#"{namespace="prod"}"#, Direction::Forward).await;
+        assert_eq!(prod, vec![(100, "a".to_string()), (200, "b".to_string())]);
+
+        // Ordered comparison — impossible via the JSON substring path — on
+        // the materialized `status` column: keeps 500 and 503, drops 200.
+        let slow = rows(
+            &service,
+            r#"{service_name=~".+"} | logfmt | status >= 500"#,
+            Direction::Forward,
+        )
+        .await;
+        assert_eq!(slow, vec![(200, "b".to_string()), (300, "c".to_string())]);
+
+        // Regex on the materialized column.
+        let ns = rows(&service, r#"{namespace=~"pro.*"}"#, Direction::Forward).await;
+        assert_eq!(ns.len(), 2);
     }
 
     /// A context with a `t.d.logs` table holding three sample rows.


### PR DESCRIPTION
## What

Phase 4 (the user-visible payoff) of write-time label materialization: the querier now **matches materialized labels on their dedicated columns** — exactly, by regex, and with **ordered comparisons** — instead of the attribute-JSON substring approximation.

## How

- `log_query_filter_with_columns(query, columns)` takes the set of materialized `label_<key>` columns present in the target table. `label_expr` routes an attribute label to its column when present:
  - `=` / `!=` → exact string equality (`!=` also matches absent/NULL rows, mirroring the JSON path);
  - `=~` / `!~` → `regexp_like` on the column;
  - `>` / `>=` / `<` / `<=` → `CAST(col AS Float64)` comparison (durations→nanos, bytes→count). **New capability** — ordered comparisons were previously unsupported on attributes.
  - Labels without a column keep the JSON substring match (`=`/`!=` only).
- `query_logs` / `query_metric` / `get_series` derive the column set from the logs table schema (fields named `label_*`), so routing is **per-table**: a table that predates a column falls back to JSON — no error referencing a missing column.

```logql
{namespace="prod"}                              # exact, no substring over-match
{service_name="api"} | logfmt | status >= 500   # ordered comparison on a materialized label
{namespace=~"pro.*"}                            # regex on the column
```

## Tests

- Lowering (`logql.rs`): `materialized_label_routes_to_its_column` (exact / `IS NULL OR !=` / regexp_like), `materialized_label_supports_ordered_comparison` (`CAST(... AS Float64) > 500`; rejected without the column).
- Execution (`logs.rs`): `materialized_label_exact_and_ordered_matching` — a fixture with `label_namespace` / `label_status`: exact `namespace="prod"`, ordered `status >= 500`, regex.

## Docs

LogQL reference (materialized labels + ordered filters), storage-layout (the `label_<key>` mechanism), and the configuration / storage-layout / flight-schemas skills — discharging the deferred debt from #723/#724/#725 now that the feature is functional.

Completes the logs path of write-time materialization. P5 generalizes to trace search / PromQL / profiles (same config + transform + routing pattern).