### PR TITLE
feat(querier, router): detected_fields discovery endpoint

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -64,7 +64,7 @@ Key details:
 4. Results stream back as Arrow RecordBatches via Flight (trace not found -> Flight `not_found` status)
 5. Standalone querier also serves Tempo's `tempopb.Querier` gRPC protocol on the Flight port (see `tempo-api` skill)
 6. Router also nests query APIs for every signal, each lowering a parsed query to a DataFusion `Expr`/aggregate over the signal's Iceberg tables (never a SQL string, matching the trace path):
-   - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series.
+   - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series and `detected_fields` (sampled attribute-field discovery: name, inferred type, approx cardinality — epic #737 L3).
    - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix), plus `histogram_quantile(phi, metric)` interpolated from `metrics_histogram` OTLP buckets; `MetricsService` also backs `/prometheus` labels/values/series. `histogram_quantile` over an inner `rate()`, binary ops, and `topk` remain pending (#335).
    - `/pyroscope` (profiles) via `ProfileService`.
 

--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -160,6 +160,7 @@ Any other `do_get` ticket (including `find_trace:...`, `search_traces:...`, and 
 | `query_logs_labels:{tenant_slug}:{dataset_slug}:{start}:{end}` | Log label names in the nanosecond window |
 | `query_logs_label_values:{tenant_slug}:{dataset_slug}:{label}:{start}:{end}` | Distinct values of one log label in the window |
 | `query_logs_series:{tenant_slug}:{dataset_slug}:{params_json}` | Series (label sets) matching a stream selector (`LogSeriesParams` as JSON) |
+| `query_logs_detected_fields:{tenant_slug}:{dataset_slug}:{params_json}` | Attribute-field discovery: sampled keys with inferred type and approximate cardinality (`DetectedFieldsParams` as JSON) |
 | `query_metric:{tenant_slug}:{dataset_slug}:{params_json}` | LogQL metric query (`MetricQueryParams` as JSON: LogQL string, nanosecond start/end, step). Returns a matrix bucketed by `date_bin(step)` |
 | `query_promql:{tenant_slug}:{dataset_slug}:{params_json}` | PromQL query (`PromQlQueryParams` as JSON: PromQL string, nanosecond start/end, step). Returns a matrix over the metrics tables |
 | anything else | Treated as a raw SQL query executed via DataFusion |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -223,6 +223,7 @@ flowchart LR
 | `GET /loki/api/v1/labels` | Implemented -- known + attribute label names via Querier |
 | `GET /loki/api/v1/label/{name}/values` | Implemented -- distinct label values via Querier |
 | `GET /loki/api/v1/series` | Implemented -- label sets matching a selector via Querier |
+| `GET /loki/api/v1/detected_fields` | Implemented -- sampled attribute-field discovery (name, type, cardinality) |
 | `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
 | LogQL metric queries (`rate`, `count_over_time`, `sum by (...)`) | Implemented via `query_range` -- `date_bin(step)` bucketed matrix (no binary ops / `topk` / `quantile` yet) |
 

--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -40,6 +40,7 @@ APIs (see [Authentication](authentication.md)):
 | `GET /loki/api/v1/labels` | Label names available in the window |
 | `GET /loki/api/v1/label/{name}/values` | Distinct values of one label |
 | `GET /loki/api/v1/series` | Series (label sets) matching a selector |
+| `GET /loki/api/v1/detected_fields` | Discover attribute fields in a window: name, inferred type, approximate cardinality (samples the data; no declaration or indexing needed) |
 | `GET /loki/api/v1/tail` | Not implemented — live tail is tracked separately |
 
 Common query parameters: `query` (the LogQL string), `start`/`end`
@@ -84,6 +85,17 @@ is also kept in the attribute JSON, label discovery (`/labels`,
 
 Series identity (in `/series` results and un-grouped metric queries) is
 the `service_name` and `level` labels.
+
+### Discovering fields
+
+`GET /loki/api/v1/detected_fields` answers "what attributes exist here?"
+without any declaration: for a window (and optional `query` stream
+selector) it samples the stored attribute documents and returns each key
+with an inferred type (`string`/`int`/`float`/`boolean`) and an
+approximate distinct-value count. Parameters: `start`, `end`, `query`,
+`limit` (default 100). Cardinality is a lower-bound estimate from the
+sample — intended for exploration UIs (faceted field pickers), not exact
+counts.
 
 ## Log queries
 

--- a/src/loki-api/src/lib.rs
+++ b/src/loki-api/src/lib.rs
@@ -200,6 +200,32 @@ impl SeriesResponse {
     }
 }
 
+/// One discovered field in a `/loki/api/v1/detected_fields` response.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DetectedField {
+    /// The attribute/field name.
+    pub label: String,
+    /// Inferred type: `string`, `int`, `float`, or `boolean`.
+    #[serde(rename = "type")]
+    pub field_type: String,
+    /// Approximate distinct-value count over the sampled window.
+    pub cardinality: u64,
+    /// Parsers needed to extract the field from the line. SignalDB
+    /// attributes are the structured-metadata analog, so this is empty.
+    #[serde(default)]
+    pub parsers: Vec<String>,
+}
+
+/// Response of `/loki/api/v1/detected_fields`. Loki returns the bare
+/// `fields` + `limit` object (no `status` wrapper).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DetectedFieldsResponse {
+    #[serde(default)]
+    pub fields: Vec<DetectedField>,
+    /// The field limit the response was truncated to.
+    pub limit: u32,
+}
+
 /// Query execution statistics (`data.stats`).
 ///
 /// SignalDB populates the summary block only; Loki's full statistics

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -33,8 +33,8 @@ use crate::query::profile::{
 };
 use crate::query::trace::TraceService;
 use crate::query::{
-    FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams, MetricSeriesParams,
-    PromQlQueryParams, SearchQueryParams,
+    DetectedFieldsParams, FindTraceByIdParams, LogQueryParams, LogSeriesParams, MetricQueryParams,
+    MetricSeriesParams, PromQlQueryParams, SearchQueryParams,
 };
 
 /// Queries the Iceberg catalog directly, bypassing `datafusion_iceberg`'s
@@ -237,6 +237,11 @@ enum TicketRequest {
         tenant_slug: String,
         dataset_slug: String,
         params: LogSeriesParams,
+    },
+    QueryLogsDetectedFields {
+        tenant_slug: String,
+        dataset_slug: String,
+        params: DetectedFieldsParams,
     },
     QueryMetric {
         tenant_slug: String,
@@ -802,6 +807,27 @@ impl QuerierFlightService {
             ));
         }
 
+        // Field discovery:
+        // query_logs_detected_fields:{tenant}:{dataset}:{json DetectedFieldsParams}
+        if let Some(remainder) = ticket_content.strip_prefix("query_logs_detected_fields:") {
+            let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let params: DetectedFieldsParams = serde_json::from_str(parts[2]).map_err(|e| {
+                    Status::invalid_argument(format!(
+                        "Invalid query_logs_detected_fields parameters: {e}"
+                    ))
+                })?;
+                return Ok(TicketRequest::QueryLogsDetectedFields {
+                    tenant_slug: parts[0].to_string(),
+                    dataset_slug: parts[1].to_string(),
+                    params,
+                });
+            }
+            return Err(Status::invalid_argument(
+                "Invalid query_logs_detected_fields ticket format. Expected: query_logs_detected_fields:tenant:dataset:{json}",
+            ));
+        }
+
         // LogQL metric query: query_metric:{tenant}:{dataset}:{json MetricQueryParams}
         if let Some(remainder) = ticket_content.strip_prefix("query_metric:") {
             let parts: Vec<&str> = remainder.splitn(3, ':').collect();
@@ -1191,6 +1217,7 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
+                    | TicketRequest::QueryLogsDetectedFields { tenant_slug, .. }
                     | TicketRequest::QueryMetric { tenant_slug, .. }
                     | TicketRequest::QueryPromql { tenant_slug, .. }
                     | TicketRequest::QueryMetricLabels { tenant_slug, .. }
@@ -1227,6 +1254,7 @@ impl FlightService for QuerierFlightService {
                 TicketRequest::QueryLogsLabels { .. } => "query_logs_labels",
                 TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
                 TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
+                TicketRequest::QueryLogsDetectedFields { .. } => "query_logs_detected_fields",
                 TicketRequest::QueryMetric { .. } => "query_metric",
                 TicketRequest::QueryPromql { .. } => "query_promql",
                 TicketRequest::QueryMetricLabels { .. } => "query_metric_labels",
@@ -1258,6 +1286,7 @@ impl FlightService for QuerierFlightService {
                     | TicketRequest::QueryLogsLabels { tenant_slug, .. }
                     | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
                     | TicketRequest::QueryLogsSeries { tenant_slug, .. }
+                    | TicketRequest::QueryLogsDetectedFields { tenant_slug, .. }
                     | TicketRequest::QueryMetric { tenant_slug, .. }
                     | TicketRequest::QueryPromql { tenant_slug, .. }
                     | TicketRequest::QueryMetricLabels { tenant_slug, .. }
@@ -1574,6 +1603,18 @@ impl FlightService for QuerierFlightService {
                             .await
                             .map_err(querier_error_to_status)?;
                         vec![json_to_batch("series", &series)?]
+                    }
+                    TicketRequest::QueryLogsDetectedFields {
+                        tenant_slug,
+                        dataset_slug,
+                        params,
+                    } => {
+                        let fields = self
+                            .logs_service
+                            .detected_fields(&params, &tenant_slug, &dataset_slug)
+                            .await
+                            .map_err(querier_error_to_status)?;
+                        vec![json_to_batch("fields", &fields)?]
                     }
                     TicketRequest::QueryMetric {
                         tenant_slug,
@@ -2173,6 +2214,17 @@ mod tests {
                 assert_eq!((params.start, params.end), (10, 20));
             }
             other => panic!("expected QueryLogsSeries, got {other:?}"),
+        }
+
+        let detected =
+            r#"query_logs_detected_fields:acme:prod:{"query":null,"start":10,"end":20,"limit":50}"#;
+        match service.parse_ticket(detected).unwrap() {
+            TicketRequest::QueryLogsDetectedFields { params, .. } => {
+                assert_eq!(params.query, None);
+                assert_eq!((params.start, params.end), (10, 20));
+                assert_eq!(params.limit, 50);
+            }
+            other => panic!("expected QueryLogsDetectedFields, got {other:?}"),
         }
     }
 

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -40,7 +40,8 @@ use super::logql_metric::{
     Aggregate, ArithOp, LabelReplaceSpec, OuterAgg, ScalarOp, SortSpec, TopKSpec, plan_metric_query,
 };
 use super::{
-    LogQueryParams, MetricQueryParams, error::QuerierError, table_ref::build_table_reference,
+    DetectedField, DetectedFieldsParams, LogQueryParams, MetricQueryParams, error::QuerierError,
+    table_ref::build_table_reference,
 };
 
 /// Columns projected for a log-line query, in wire order. The Flight
@@ -460,6 +461,119 @@ impl LogsService {
             }
         }
         Ok(values.into_iter().collect())
+    }
+
+    /// Discover the attribute fields present in a window (optionally
+    /// restricted by a stream selector): for each key seen in the sampled
+    /// attribute documents, report an inferred type and an approximate
+    /// distinct-value count. Sampling is capped at [`LABEL_SCAN_LIMIT`]
+    /// rows, so cardinality is a lower-bound estimate by design — this
+    /// backs the Loki-compatible `detected_fields` discovery endpoint.
+    pub async fn detected_fields(
+        &self,
+        params: &DetectedFieldsParams,
+        tenant_slug: &str,
+        dataset_slug: &str,
+    ) -> Result<Vec<DetectedField>, QuerierError> {
+        let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
+        if let Some(q) = params
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            let parsed = parse_query(q).map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+            let filter = log_query_filter_with_columns(&parsed, &materialized_columns_of(&df))?;
+            if let Some(filter) = filter {
+                df = df.filter(filter).map_err(QuerierError::QueryFailed)?;
+            }
+        }
+        let df = apply_window(df, params.start, params.end)?;
+        let batches = df
+            .select_columns(&["log_attributes", "resource_attributes"])
+            .map_err(QuerierError::QueryFailed)?
+            .limit(0, Some(LABEL_SCAN_LIMIT))
+            .map_err(QuerierError::QueryFailed)?
+            .collect()
+            .await
+            .map_err(QuerierError::QueryFailed)?;
+
+        // Per-key aggregate over the sample: distinct values (capped) and
+        // the JSON types observed.
+        #[derive(Default)]
+        struct FieldAgg {
+            values: BTreeSet<String>,
+            saw_string: bool,
+            saw_int: bool,
+            saw_float: bool,
+            saw_bool: bool,
+        }
+        const VALUE_CAP: usize = 1000;
+        let mut agg: BTreeMap<String, FieldAgg> = BTreeMap::new();
+
+        for batch in &batches {
+            for column in ["log_attributes", "resource_attributes"] {
+                let attrs = string_column(batch, column)?;
+                for i in 0..batch.num_rows() {
+                    if attrs.is_null(i) {
+                        continue;
+                    }
+                    let Ok(serde_json::Value::Object(map)) =
+                        serde_json::from_str::<serde_json::Value>(attrs.value(i))
+                    else {
+                        continue;
+                    };
+                    for (key, value) in map {
+                        let entry = agg.entry(key).or_default();
+                        let rendered = match &value {
+                            serde_json::Value::String(s) => {
+                                entry.saw_string = true;
+                                s.clone()
+                            }
+                            serde_json::Value::Number(n) => {
+                                if n.is_i64() || n.is_u64() {
+                                    entry.saw_int = true;
+                                } else {
+                                    entry.saw_float = true;
+                                }
+                                n.to_string()
+                            }
+                            serde_json::Value::Bool(b) => {
+                                entry.saw_bool = true;
+                                b.to_string()
+                            }
+                            other => {
+                                entry.saw_string = true;
+                                other.to_string()
+                            }
+                        };
+                        if entry.values.len() < VALUE_CAP {
+                            entry.values.insert(rendered);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut fields: Vec<DetectedField> = agg
+            .into_iter()
+            .map(|(label, a)| {
+                let field_type = match (a.saw_string, a.saw_int, a.saw_float, a.saw_bool) {
+                    (false, false, false, true) => "boolean",
+                    (false, true, false, false) => "int",
+                    (false, _, true, false) => "float",
+                    _ => "string",
+                };
+                DetectedField {
+                    label,
+                    field_type: field_type.to_string(),
+                    cardinality: a.values.len() as u64,
+                    parsers: Vec::new(),
+                }
+            })
+            .collect();
+        fields.truncate(params.limit.max(1) as usize);
+        Ok(fields)
     }
 
     /// List the distinct series (label sets) matching a stream selector.
@@ -1531,6 +1645,62 @@ mod tests {
         assert!(labels.contains(&"level".to_string()));
         assert!(labels.contains(&"namespace".to_string()));
         assert!(labels.contains(&"pod".to_string()));
+    }
+
+    #[tokio::test]
+    async fn detected_fields_reports_keys_types_and_cardinality() {
+        let service = service_with_data();
+        let fields = service
+            .detected_fields(
+                &DetectedFieldsParams {
+                    query: None,
+                    start: 0,
+                    end: 1000,
+                    limit: 100,
+                },
+                "t",
+                "d",
+            )
+            .await
+            .unwrap();
+        let get = |label: &str| fields.iter().find(|f| f.label == label).unwrap();
+        // namespace: prod, staging → 2 distinct; pod: 3 distinct; strings.
+        assert_eq!(get("namespace").cardinality, 2);
+        assert_eq!(get("namespace").field_type, "string");
+        assert_eq!(get("pod").cardinality, 3);
+
+        // A selector restricts the sample: api rows only see prod.
+        let api_fields = service
+            .detected_fields(
+                &DetectedFieldsParams {
+                    query: Some(r#"{service_name="api"}"#.to_string()),
+                    start: 0,
+                    end: 1000,
+                    limit: 100,
+                },
+                "t",
+                "d",
+            )
+            .await
+            .unwrap();
+        let ns = api_fields.iter().find(|f| f.label == "namespace").unwrap();
+        assert_eq!(ns.cardinality, 1);
+
+        // The limit truncates the field list.
+        let one = service
+            .detected_fields(
+                &DetectedFieldsParams {
+                    query: None,
+                    start: 0,
+                    end: 1000,
+                    limit: 1,
+                },
+                "t",
+                "d",
+            )
+            .await
+            .unwrap();
+        assert_eq!(one.len(), 1);
     }
 
     #[tokio::test]

--- a/src/querier/src/query/mod.rs
+++ b/src/querier/src/query/mod.rs
@@ -76,6 +76,34 @@ pub struct LogSeriesParams {
     pub end: i64,
 }
 
+/// Parameters carried in the `query_logs_detected_fields` Flight ticket.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DetectedFieldsParams {
+    /// Optional stream selector restricting the sample, e.g.
+    /// `{service_name="api"}`. Empty/absent samples everything in range.
+    #[serde(default)]
+    pub query: Option<String>,
+    /// Inclusive range start, unix epoch nanoseconds.
+    pub start: i64,
+    /// Inclusive range end, unix epoch nanoseconds.
+    pub end: i64,
+    /// Maximum number of fields to return.
+    pub limit: u32,
+}
+
+/// One discovered attribute field: its name, inferred type, and an
+/// approximate distinct-value count over the sampled window.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DetectedField {
+    pub label: String,
+    #[serde(rename = "type")]
+    pub field_type: String,
+    pub cardinality: u64,
+    /// Parsers Loki would need to extract the field; our attributes are
+    /// the structured-metadata analog, so this stays empty.
+    pub parsers: Vec<String>,
+}
+
 /// Parameters for single-trace lookup.
 #[derive(Debug)]
 pub struct FindTraceByIdParams {

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -28,7 +28,10 @@ use common::auth::TenantContextExtractor;
 use common::flight::transport::ServiceCapability;
 use datafusion::arrow::array::{Array, RecordBatch, StringArray, TimestampNanosecondArray};
 use futures::StreamExt;
-use loki_api::{LabelsResponse, LogEntry, QueryResponse, QueryResult, SeriesResponse, Stream};
+use loki_api::{
+    DetectedField, DetectedFieldsResponse, LabelsResponse, LogEntry, QueryResponse, QueryResult,
+    SeriesResponse, Stream,
+};
 use serde::Deserialize;
 
 pub fn router<S: RouterState>() -> Router<S> {
@@ -38,6 +41,7 @@ pub fn router<S: RouterState>() -> Router<S> {
         .route("/api/v1/labels", get(labels::<S>))
         .route("/api/v1/label/{name}/values", get(label_values::<S>))
         .route("/api/v1/series", get(series::<S>))
+        .route("/api/v1/detected_fields", get(detected_fields::<S>))
 }
 
 fn default_limit() -> u32 {
@@ -283,6 +287,66 @@ pub async fn series<S: RouterState>(
     Ok(axum::Json(SeriesResponse::success(series_from_batches(
         &batches,
     ))))
+}
+
+/// Query parameters for `/detected_fields`.
+#[derive(Debug, Default, Deserialize)]
+pub struct DetectedFieldsParams {
+    /// Range start (unix epoch ns, s, or RFC3339).
+    pub start: Option<String>,
+    /// Range end (unix epoch ns, s, or RFC3339).
+    pub end: Option<String>,
+    /// Optional stream selector restricting the sample.
+    pub query: Option<String>,
+    /// Maximum fields returned.
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+}
+
+/// GET /loki/api/v1/detected_fields — discover the attribute fields
+/// present in a window, with inferred type and approximate cardinality.
+/// Backs faceted exploration UIs (e.g. Grafana Logs Drilldown); fields
+/// need no prior declaration or indexing.
+#[tracing::instrument(
+    skip(state, tenant_ctx, params),
+    fields(
+        tenant_id = %tenant_ctx.0.tenant_id,
+        dataset_id = %tenant_ctx.0.dataset_id
+    )
+)]
+pub async fn detected_fields<S: RouterState>(
+    State(state): State<S>,
+    tenant_ctx: TenantContextExtractor,
+    Query(params): Query<DetectedFieldsParams>,
+) -> Result<axum::Json<DetectedFieldsResponse>, StatusCode> {
+    let meta = MetadataParams {
+        start: params.start.clone(),
+        end: params.end.clone(),
+        matcher: None,
+        query: None,
+    };
+    let (start, end) = metadata_window(&meta);
+    let payload = serde_json::json!({
+        "query": params.query,
+        "start": start,
+        "end": end,
+        "limit": params.limit,
+    });
+    let ticket = format!(
+        "query_logs_detected_fields:{}:{}:{payload}",
+        tenant_ctx.0.tenant_slug, tenant_ctx.0.dataset_slug
+    );
+    let batches = execute_ticket(&state, ticket).await?;
+    let mut fields: Vec<DetectedField> = Vec::new();
+    for value in string_column(&batches, "fields") {
+        if let Ok(parsed) = serde_json::from_str::<Vec<DetectedField>>(&value) {
+            fields.extend(parsed);
+        }
+    }
+    Ok(axum::Json(DetectedFieldsResponse {
+        fields,
+        limit: params.limit,
+    }))
 }
 
 // ---- execution + conversion ----


### PR DESCRIPTION
## What

`GET /loki/api/v1/detected_fields` — Layer 3 of the attribute-explorability epic (#737): for a time window and optional stream selector, discover which attribute fields exist, with an **inferred type** and an **approximate distinct-value count** — no declaration, no indexing. This is the backend for faceted, Grafana Logs Drilldown-style exploration, and the concrete form of "make unknown unknowns explorable."

Closes #732.

## How

Plumbing mirrors the labels endpoints:
- **Querier**: `LogsService::detected_fields` samples up to `LABEL_SCAN_LIMIT` rows of the attribute documents (selector-filtered via the existing lowering, materialized-column aware), aggregating per key: JSON-type inference (`string`/`int`/`float`/`boolean`, mixed→string) and a capped distinct-value set (cardinality is a lower-bound estimate by contract).
- **Flight**: `query_logs_detected_fields:{tenant}:{dataset}:{json}` ticket → `TicketRequest::QueryLogsDetectedFields`, wired through the tenant-guard/query-type/permit matches; result via `json_to_batch("fields", ...)`.
- **Router + loki-api**: handler + `DetectedFieldsResponse { fields, limit }` matching Loki's shape (`parsers` empty — our attributes are the structured-metadata analog).

## Tests

- `detected_fields_reports_keys_types_and_cardinality`: key discovery, per-key cardinality (namespace=2, pod=3), string typing, selector restriction (api → namespace cardinality 1), limit truncation.
- Ticket-parse test alongside the existing labels/series ones.

## Docs

LogQL reference (endpoint table + "Discovering fields" section), flight-communication ticket table, architecture overview endpoint table, architecture skill.

Note: `querying-sql.md` is flagged by the freshness check only because `flight.rs` is one of its sources — the SQL path is untouched.