### PR TITLE
feat(traces): typed Map attribute columns for trace search

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -42,7 +42,7 @@ OTLP Client (gRPC :4317 / HTTP :4318)
 Key details:
 1. Acceptor writes to WAL before acknowledging client
 2. Acceptor converts OTLP protobuf -> Arrow RecordBatches using Flight schemas (v1)
-3. Writer transforms v1 Flight schema -> v2 Iceberg schema (field renames, type conversions, computed partition fields, materialized `label_<key>` columns for configured attributes across all four signals; new logs tables store attributes as typed `Map<String,String>` columns for exact any-attribute matching)
+3. Writer transforms v1 Flight schema -> v2 Iceberg schema (field renames, type conversions, computed partition fields, materialized `label_<key>` columns for configured attributes across all four signals; new logs/traces tables store attributes as typed `Map<String,String>` columns for exact any-attribute matching)
 4. Writer's WalProcessor reads WAL entries every 5s (exponential backoff on failure), writes Parquet via DataFusion
 5. Processed WAL entries are marked and cleaned up
 

--- a/.claude/skills/flight-schemas/SKILL.md
+++ b/.claude/skills/flight-schemas/SKILL.md
@@ -34,7 +34,7 @@ The wire format and storage format differ intentionally. Writer applies `transfo
 |--------|-------------------|---------------------|
 | Span name | `name` | `span_name` |
 | Duration | `duration_nano` (UInt64) | `duration_nanos` (Int64) |
-| Attributes | `attributes_json` | `span_attributes` |
+| Attributes | `attributes_json` | `span_attributes` (Map on new tables; JSON string legacy) |
 | Resource | `resource_json` | `resource_attributes` |
 | Time fields | UInt64 (nanos) | Long/Int64 (nanos) |
 | Events/Links | `List<Struct>` (nested Arrow) | `String` (JSON) |

--- a/.claude/skills/storage-layout/SKILL.md
+++ b/.claude/skills/storage-layout/SKILL.md
@@ -137,7 +137,7 @@ All tables partitioned by `Hour(timestamp)` as `timestamp_hour`.
 
 ### Typed attribute maps
 
-New logs tables store `log_attributes`/`resource_attributes`/`scope_attributes` as Iceberg `Map<String,String>` — any attribute matches exactly (incl. regex/ordered) via `get_field` extraction; legacy tables keep JSON strings with the substring approximation. The querier detects the form per table (`attr_context_of`); labels/values/detected_fields read either form (`attr_documents`; `distinct()` skipped for maps — Arrow row format can't sort them). Epic #737 L1 (#730), logs first.
+New logs AND traces tables store their attribute columns (`log_attributes`/`span_attributes`/`resource_attributes`/`scope_attributes`) as Iceberg `Map<String,String>` — any attribute matches exactly (incl. regex/ordered) via `get_field` extraction; legacy tables keep JSON strings with the substring approximation. The querier detects the form per table (`attr_context_of`); labels/values/detected_fields read either form (`attr_documents`; `distinct()` skipped for maps — Arrow row format can't sort them). Epic #737 L1 (#730), logs first.
 
 ### Materialized labels
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -57,8 +57,8 @@ Apache Iceberg provides ACID transactions and structured metadata management:
 - **Materialized labels**: configured attribute keys promoted to dedicated
   columns for exact querying across all four signal types (see
   [storage layout](storage-layout.md#materialized-labels))
-- **Typed attribute maps**: new logs tables store attributes as
-  `Map<String,String>` columns, so any attribute is exactly queryable
+- **Typed attribute maps**: new logs and traces tables store attributes
+  as `Map<String,String>` columns, so any attribute is exactly queryable
   (legacy tables keep JSON strings with per-table fallback)
 
 ### 5. Columnar Storage

--- a/schemas.toml
+++ b/schemas.toml
@@ -26,8 +26,8 @@ fields = [
     { name = "status_code", type = "string", required = true },
     { name = "status_message", type = "string", required = false },
     { name = "is_root", type = "boolean", required = true },
-    { name = "attributes_json", type = "string", required = false },
-    { name = "resource_json", type = "string", required = false },
+    { name = "attributes_json", type = "map<string,string>", required = false },
+    { name = "resource_json", type = "map<string,string>", required = false },
     { name = "events", type = "list<struct>", required = false },
     { name = "links", type = "list<struct>", required = false },
     { name = "trace_state", type = "string", required = false },
@@ -35,7 +35,7 @@ fields = [
     { name = "scope_name", type = "string", required = false },
     { name = "scope_version", type = "string", required = false },
     { name = "scope_schema_url", type = "string", required = false },
-    { name = "scope_attributes", type = "string", required = false },
+    { name = "scope_attributes", type = "map<string,string>", required = false },
 ]
 
 [traces.v2]

--- a/src/querier/src/query/search_filter.rs
+++ b/src/querier/src/query/search_filter.rs
@@ -100,10 +100,12 @@ impl Condition {
             Selector::ResourceAttribute(key) if ctx.map_attrs => {
                 Ok(map_attribute_expr("resource_attributes", key, &self.value))
             }
-            Selector::AnyAttribute(key) if ctx.map_attrs => {
-                Ok(map_attribute_expr("span_attributes", key, &self.value)
-                    .or(map_attribute_expr("resource_attributes", key, &self.value)))
-            }
+            Selector::AnyAttribute(key) if ctx.map_attrs => Ok(map_attribute_expr(
+                "span_attributes",
+                key,
+                &self.value,
+            )
+            .or(map_attribute_expr("resource_attributes", key, &self.value))),
             Selector::SpanAttribute(key) => Ok(attribute_expr("span_attributes", key, &self.value)),
             Selector::ResourceAttribute(key) => {
                 Ok(attribute_expr("resource_attributes", key, &self.value))
@@ -479,10 +481,7 @@ mod tests {
             selector: Selector::SpanAttribute("http.method".to_string()),
             value: FilterValue::String("GET".to_string()),
         };
-        let rendered = format!(
-            "{:?}",
-            condition.to_expr(&AttrContext::default()).unwrap()
-        );
+        let rendered = format!("{:?}", condition.to_expr(&AttrContext::default()).unwrap());
         assert!(rendered.contains(r#""http.method":"GET""#), "{rendered}");
 
         // Numbers match both bare (real OTLP int) and quoted forms.
@@ -490,10 +489,7 @@ mod tests {
             selector: Selector::SpanAttribute("http.status_code".to_string()),
             value: FilterValue::Number("200".to_string()),
         };
-        let rendered = format!(
-            "{:?}",
-            numeric.to_expr(&AttrContext::default()).unwrap()
-        );
+        let rendered = format!("{:?}", numeric.to_expr(&AttrContext::default()).unwrap());
         assert!(rendered.contains(r#""http.status_code":200"#), "{rendered}");
         assert!(
             rendered.contains(r#""http.status_code":"200""#),
@@ -531,10 +527,7 @@ mod tests {
             value: FilterValue::String("prod".to_string()),
         };
         // Without the column: JSON substring across both attribute columns.
-        let json = format!(
-            "{:?}",
-            condition.to_expr(&AttrContext::default()).unwrap()
-        );
+        let json = format!("{:?}", condition.to_expr(&AttrContext::default()).unwrap());
         assert!(json.contains(r#""namespace":"prod""#), "{json}");
 
         // With the column: exact equality on `label_namespace`.

--- a/src/querier/src/query/search_filter.rs
+++ b/src/querier/src/query/search_filter.rs
@@ -26,7 +26,7 @@ use datafusion::functions::string::expr_fn::contains;
 use datafusion::logical_expr::{Expr, col, lit};
 
 use super::error::QuerierError;
-use super::logql::MaterializedColumns;
+use super::logql::{AttrContext, MaterializedColumns};
 
 /// Where a filter condition applies.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,8 +63,11 @@ pub enum FilterValue {
 impl Condition {
     /// Lower the condition to a DataFusion filter expression, routing an
     /// attribute key to its materialized `label_<key>` column (exact match)
-    /// when the table has one, else to the attribute-JSON substring match.
-    pub fn to_expr(&self, columns: &MaterializedColumns) -> Result<Expr, QuerierError> {
+    /// when the table has one; otherwise to per-key `get_field` extraction
+    /// on map-typed attribute tables, else the attribute-JSON substring
+    /// match (legacy tables).
+    pub fn to_expr(&self, ctx: &AttrContext) -> Result<Expr, QuerierError> {
+        let columns: &MaterializedColumns = &ctx.materialized;
         match &self.selector {
             Selector::ServiceName => Ok(col("service_name").eq(lit(self.string_value()?))),
             Selector::SpanName => Ok(col("span_name").eq(lit(self.string_value()?))),
@@ -90,6 +93,16 @@ impl Condition {
                     &materialized_column_name(key),
                     &self.value,
                 ))
+            }
+            Selector::SpanAttribute(key) if ctx.map_attrs => {
+                Ok(map_attribute_expr("span_attributes", key, &self.value))
+            }
+            Selector::ResourceAttribute(key) if ctx.map_attrs => {
+                Ok(map_attribute_expr("resource_attributes", key, &self.value))
+            }
+            Selector::AnyAttribute(key) if ctx.map_attrs => {
+                Ok(map_attribute_expr("span_attributes", key, &self.value)
+                    .or(map_attribute_expr("resource_attributes", key, &self.value)))
             }
             Selector::SpanAttribute(key) => Ok(attribute_expr("span_attributes", key, &self.value)),
             Selector::ResourceAttribute(key) => {
@@ -120,6 +133,19 @@ fn materialized_expr(column: &str, value: &FilterValue) -> Expr {
         FilterValue::Bool(b) => b.to_string(),
     };
     col(column).eq(lit(v))
+}
+
+/// Exact per-key equality on a map-typed attribute column. Values are
+/// stored as strings (numbers/bools rendered bare at ingest), so every
+/// filter value compares by its string form.
+fn map_attribute_expr(column: &str, key: &str, value: &FilterValue) -> Expr {
+    use datafusion::functions::core::expr_fn::get_field;
+    let v = match value {
+        FilterValue::String(s) => s.clone(),
+        FilterValue::Number(n) => n.clone(),
+        FilterValue::Bool(b) => b.to_string(),
+    };
+    get_field(col(column), key).eq(lit(v))
 }
 
 /// Match the serialized `"key":value` fragment inside a flat-JSON
@@ -434,7 +460,7 @@ mod tests {
             selector: Selector::Status,
             value: FilterValue::String("error".to_string()),
         };
-        let expr = condition.to_expr(&MaterializedColumns::new()).unwrap();
+        let expr = condition.to_expr(&AttrContext::default()).unwrap();
         assert!(format!("{expr:?}").contains("Error"));
 
         let bad = Condition {
@@ -442,7 +468,7 @@ mod tests {
             value: FilterValue::String("bogus".to_string()),
         };
         assert!(matches!(
-            bad.to_expr(&MaterializedColumns::new()),
+            bad.to_expr(&AttrContext::default()),
             Err(QuerierError::InvalidInput(_))
         ));
     }
@@ -455,7 +481,7 @@ mod tests {
         };
         let rendered = format!(
             "{:?}",
-            condition.to_expr(&MaterializedColumns::new()).unwrap()
+            condition.to_expr(&AttrContext::default()).unwrap()
         );
         assert!(rendered.contains(r#""http.method":"GET""#), "{rendered}");
 
@@ -466,13 +492,36 @@ mod tests {
         };
         let rendered = format!(
             "{:?}",
-            numeric.to_expr(&MaterializedColumns::new()).unwrap()
+            numeric.to_expr(&AttrContext::default()).unwrap()
         );
         assert!(rendered.contains(r#""http.status_code":200"#), "{rendered}");
         assert!(
             rendered.contains(r#""http.status_code":"200""#),
             "{rendered}"
         );
+    }
+
+    #[test]
+    fn map_attribute_tables_use_get_field_extraction() {
+        let ctx = AttrContext {
+            materialized: MaterializedColumns::new(),
+            map_attrs: true,
+        };
+        let condition = Condition {
+            selector: Selector::AnyAttribute("namespace".to_string()),
+            value: FilterValue::String("prod".to_string()),
+        };
+        let rendered = format!("{:?}", condition.to_expr(&ctx).unwrap());
+        assert!(rendered.contains("GetFieldFunc"), "{rendered}");
+        assert!(!rendered.contains("ContainsFunc"), "{rendered}");
+
+        // Numbers compare by their bare string form (ingest rendering).
+        let numeric = Condition {
+            selector: Selector::SpanAttribute("http.status_code".to_string()),
+            value: FilterValue::Number("200".to_string()),
+        };
+        let rendered = format!("{:?}", numeric.to_expr(&ctx).unwrap());
+        assert!(rendered.contains(r#"Utf8("200")"#), "{rendered}");
     }
 
     #[test]
@@ -484,13 +533,16 @@ mod tests {
         // Without the column: JSON substring across both attribute columns.
         let json = format!(
             "{:?}",
-            condition.to_expr(&MaterializedColumns::new()).unwrap()
+            condition.to_expr(&AttrContext::default()).unwrap()
         );
         assert!(json.contains(r#""namespace":"prod""#), "{json}");
 
         // With the column: exact equality on `label_namespace`.
-        let cols: MaterializedColumns = ["label_namespace".to_string()].into_iter().collect();
-        let rendered = format!("{:?}", condition.to_expr(&cols).unwrap());
+        let ctx = AttrContext {
+            materialized: ["label_namespace".to_string()].into_iter().collect(),
+            map_attrs: false,
+        };
+        let rendered = format!("{:?}", condition.to_expr(&ctx).unwrap());
         assert!(rendered.contains("label_namespace"), "{rendered}");
         assert!(!rendered.contains("span_attributes"), "{rendered}");
     }

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -439,15 +439,24 @@ impl TraceService {
         if let Some(tags) = query.tags.as_deref().filter(|s| !s.trim().is_empty()) {
             conditions.extend(search_filter::parse_tags(tags)?);
         }
-        let materialized: super::logql::MaterializedColumns = df
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| f.name().to_string())
-            .filter(|n| n.starts_with("label_"))
-            .collect();
+        let attr_ctx = super::logql::AttrContext {
+            materialized: df
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().to_string())
+                .filter(|n| n.starts_with("label_"))
+                .collect(),
+            map_attrs: df.schema().fields().iter().any(|f| {
+                f.name() == "span_attributes"
+                    && matches!(
+                        f.data_type(),
+                        datafusion::arrow::datatypes::DataType::Map(_, _)
+                    )
+            }),
+        };
         for condition in &conditions {
-            df = df.filter(condition.to_expr(&materialized)?).map_err(|e| {
+            df = df.filter(condition.to_expr(&attr_ctx)?).map_err(|e| {
                 log::error!("Failed to apply search filter {condition:?}: {e}");
                 QuerierError::QueryFailed(e)
             })?;


### PR DESCRIPTION
## What

Extends the Map attribute tier (#741, epic #737 L1 / #730) to **traces**: new traces tables store `span_attributes` / `resource_attributes` / `scope_attributes` as Iceberg `Map<String,String>`, and Tempo search (`tags` / TraceQL attribute selectors) matches **any attribute exactly** on those tables — no substring over-match, no declaration.

## How

- **Schema**: traces v1 attr fields → `map<string,string>` in `schemas.toml` (v2 inherits; the parser's nested-ID allocation from #741 applies as-is).
- **Writer**: no change needed — the trace transform keeps emitting JSON strings and #741's `json_strings_to_map_array` coercion converts for map-schema tables.
- **Querier**: `Condition::to_expr` takes the shared `AttrContext`; on map tables attribute selectors lower to per-key `get_field` equality (numbers/bools compare by their ingest string form), with the JSON fragment path kept for legacy tables. `trace.rs` detects the storage form from the table schema.

## Tests

`map_attribute_tables_use_get_field_extraction` (get_field lowering, bare-number comparison); existing search/materialized tests unchanged; querier 221 / common 237 green. The write path is covered by #741's coercion test + the #739 fork spike.

Metrics/profiles are the remaining Map verticals.