### PR TITLE
feat(metrics, profiles): typed Map attribute columns

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -42,7 +42,7 @@ OTLP Client (gRPC :4317 / HTTP :4318)
 Key details:
 1. Acceptor writes to WAL before acknowledging client
 2. Acceptor converts OTLP protobuf -> Arrow RecordBatches using Flight schemas (v1)
-3. Writer transforms v1 Flight schema -> v2 Iceberg schema (field renames, type conversions, computed partition fields, materialized `label_<key>` columns for configured attributes across all four signals; new logs/traces tables store attributes as typed `Map<String,String>` columns for exact any-attribute matching)
+3. Writer transforms v1 Flight schema -> v2 Iceberg schema (field renames, type conversions, computed partition fields, materialized `label_<key>` columns for configured attributes across all four signals; new tables (all signals) store attributes as typed `Map<String,String>` columns for exact any-attribute matching)
 4. Writer's WalProcessor reads WAL entries every 5s (exponential backoff on failure), writes Parquet via DataFusion
 5. Processed WAL entries are marked and cleaned up
 

--- a/.claude/skills/flight-schemas/SKILL.md
+++ b/.claude/skills/flight-schemas/SKILL.md
@@ -84,7 +84,7 @@ Plus, when `[schema.materialized_labels].<signal>` is configured, a nullable `la
 
 ## Metrics Schemas
 
-Two definitions coexist:
+On new tables the metric/profile attribute columns are `Map<String,String>` (`mapify_attr_fields`, nested IDs after labels); legacy JSON strings. Two definitions coexist:
 - `schemas.toml` defines v1 schemas for `metrics_gauge`, `metrics_sum`, and
   `metrics_histogram` (used by the TOML schema parser / wire side).
 - The **Iceberg** metrics table schemas are built by hardcoded Rust functions in

--- a/.claude/skills/storage-layout/SKILL.md
+++ b/.claude/skills/storage-layout/SKILL.md
@@ -137,7 +137,7 @@ All tables partitioned by `Hour(timestamp)` as `timestamp_hour`.
 
 ### Typed attribute maps
 
-New logs AND traces tables store their attribute columns (`log_attributes`/`span_attributes`/`resource_attributes`/`scope_attributes`) as Iceberg `Map<String,String>` — any attribute matches exactly (incl. regex/ordered) via `get_field` extraction; legacy tables keep JSON strings with the substring approximation. The querier detects the form per table (`attr_context_of`); labels/values/detected_fields read either form (`attr_documents`; `distinct()` skipped for maps — Arrow row format can't sort them). Epic #737 L1 (#730), logs first.
+New tables across all four signals store their attribute columns as Iceberg `Map<String,String>` — any attribute matches exactly (incl. regex/ordered) via `get_field` extraction; legacy tables keep JSON strings with the substring approximation. The querier detects the form per table (`attr_context_of`); labels/values/detected_fields read either form (`attr_documents`; `distinct()` skipped for maps — Arrow row format can't sort them). Epic #737 L1 (#730), logs first.
 
 ### Materialized labels
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -57,8 +57,8 @@ Apache Iceberg provides ACID transactions and structured metadata management:
 - **Materialized labels**: configured attribute keys promoted to dedicated
   columns for exact querying across all four signal types (see
   [storage layout](storage-layout.md#materialized-labels))
-- **Typed attribute maps**: new logs and traces tables store attributes
-  as `Map<String,String>` columns, so any attribute is exactly queryable
+- **Typed attribute maps**: new tables across all four signals store
+  attributes as `Map<String,String>` columns, so any attribute is exactly queryable
   (legacy tables keep JSON strings with per-table fallback)
 
 ### 5. Columnar Storage

--- a/docs/architecture/storage-layout.md
+++ b/docs/architecture/storage-layout.md
@@ -388,7 +388,7 @@ Defined in `src/common/src/iceberg/schemas.rs`.
 | 13 | `scope_schema_url` | String | No | |
 | 14 | `scope_attributes` | String | No | JSON |
 | 15 | `scope_dropped_attr_count` | Int | No | |
-| 16 | `attributes` | String | No | JSON |
+| 16 | `attributes` | Map<String,String> | No | typed map (legacy: JSON string) |
 | 17 | `exemplars` | String | No | JSON |
 | 18 | `date_day` | Date | Yes | Computed |
 | 19 | `hour` | Int | Yes | Computed |

--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -95,7 +95,7 @@ without any declaration: for a window (and optional `query` stream
 selector) it samples the stored attribute documents and returns each key
 with an inferred type (`string`/`int`/`float`/`boolean`) and an
 approximate distinct-value count. Parameters: `start`, `end`, `query`,
-`limit` (default 100). Cardinality is a lower-bound estimate from the
+`limit` (default 100). Works on both JSON-string and map-typed attribute tables. Cardinality is a lower-bound estimate from the
 sample — intended for exploration UIs (faceted field pickers), not exact
 counts.
 

--- a/docs/users/profiles.md
+++ b/docs/users/profiles.md
@@ -84,7 +84,7 @@ The router serves a Pyroscope-compatible surface under `/pyroscope`:
 | `GET /pyroscope/render` | Flamegraph for a query and time range |
 | `GET /pyroscope/render-diff` | Differential flamegraph between two ranges |
 | `GET /pyroscope/profile-types` | Available profile types |
-| `GET /pyroscope/label-names` | Label discovery |
+| `GET /pyroscope/label-names` | Label discovery (reads JSON-string or map-typed attribute tables) |
 | `GET /pyroscope/label-values?label=…` | Values for one label |
 
 Queries use Pyroscope selector syntax; time bounds accept unix seconds,

--- a/docs/users/promql-functions.md
+++ b/docs/users/promql-functions.md
@@ -24,7 +24,7 @@ wrong result.
 | Feature | Status |
 |---------|--------|
 | Instant vector selector `metric{…}` | ✅ |
-| Label matchers `=`, `!=`, `=~`, `!~` | ✅ (all four operators on `service_name` and on **materialized** labels; a non-materialized attribute label supports `=`/`!=` only, matched by JSON substring) |
+| Label matchers `=`, `!=`, `=~`, `!~` | ✅ (all four operators on `service_name` and on **materialized** labels; on map-typed tables any attribute supports all four; legacy JSON tables: `=`/`!=` substring only) |
 | `__name__` matcher | ✅ |
 | Range vector selector `metric[5m]` (as a function argument) | ✅ |
 | `offset` modifier (`metric offset 5m`) | ✅ |

--- a/src/common/src/iceberg/schemas.rs
+++ b/src/common/src/iceberg/schemas.rs
@@ -5,7 +5,7 @@ use iceberg_rust::spec::partition::{
     PartitionField, PartitionSpec, PartitionSpecBuilder, Transform,
 };
 use iceberg_rust::spec::schema::Schema;
-use iceberg_rust::spec::types::{PrimitiveType, StructField, StructType, Type};
+use iceberg_rust::spec::types::{MapType, PrimitiveType, StructField, StructType, Type};
 
 /// Helper to create a required StructField
 fn required_field(id: i32, name: &str, prim: PrimitiveType) -> StructField {
@@ -47,6 +47,27 @@ fn append_materialized_label_fields(fields: &mut Vec<StructField>, labels: &[Str
         }
         fields.push(optional_field(next_id, &name, PrimitiveType::String));
         next_id += 1;
+    }
+}
+
+/// Convert the named top-level string fields of a hand-built schema into
+/// `Map<String, String>` attribute columns, allocating nested key/value
+/// field IDs after every existing top-level ID. Call this **after**
+/// [`append_materialized_label_fields`] so nested IDs cannot collide with
+/// label-column IDs (nested IDs are invisible to top-level `max(id)`).
+fn mapify_attr_fields(fields: &mut [StructField], names: &[&str]) {
+    let mut next_id = fields.iter().map(|f| f.id).max().unwrap_or(0) + 1;
+    for field in fields.iter_mut() {
+        if names.contains(&field.name.as_str()) {
+            field.field_type = Type::Map(MapType {
+                key_id: next_id,
+                key: Box::new(Type::Primitive(PrimitiveType::String)),
+                value_id: next_id + 1,
+                value_required: false,
+                value: Box::new(Type::Primitive(PrimitiveType::String)),
+            });
+            next_id += 2;
+        }
     }
 }
 
@@ -157,6 +178,10 @@ pub fn create_metrics_gauge_schema() -> Result<Schema> {
         required_field(19, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("metrics"));
+    mapify_attr_fields(
+        &mut fields,
+        &["resource_attributes", "scope_attributes", "attributes"],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }
@@ -195,6 +220,10 @@ pub fn create_metrics_sum_schema() -> Result<Schema> {
         required_field(21, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("metrics"));
+    mapify_attr_fields(
+        &mut fields,
+        &["resource_attributes", "scope_attributes", "attributes"],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }
@@ -237,6 +266,10 @@ pub fn create_metrics_histogram_schema() -> Result<Schema> {
         required_field(25, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("metrics"));
+    mapify_attr_fields(
+        &mut fields,
+        &["resource_attributes", "scope_attributes", "attributes"],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }
@@ -284,6 +317,10 @@ pub fn create_metrics_exponential_histogram_schema() -> Result<Schema> {
         required_field(30, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("metrics"));
+    mapify_attr_fields(
+        &mut fields,
+        &["resource_attributes", "scope_attributes", "attributes"],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }
@@ -322,6 +359,10 @@ pub fn create_metrics_summary_schema() -> Result<Schema> {
         required_field(21, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("metrics"));
+    mapify_attr_fields(
+        &mut fields,
+        &["resource_attributes", "scope_attributes", "attributes"],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }
@@ -361,6 +402,14 @@ pub fn create_profiles_schema() -> Result<Schema> {
         required_field(18, "hour", PrimitiveType::Int),      // Sub-partition key
     ];
     append_materialized_label_fields(&mut fields, &materialized_labels_for("profiles"));
+    mapify_attr_fields(
+        &mut fields,
+        &[
+            "resource_attributes",
+            "scope_attributes",
+            "profile_attributes",
+        ],
+    );
 
     Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
 }

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -1373,7 +1373,7 @@ fn distinct_non_empty(batches: &[RecordBatch], column: &str) -> Result<Vec<Strin
 /// handling both storage forms: legacy Utf8 columns holding flat JSON
 /// objects, and typed `Map<Utf8, Utf8>` columns (new tables). Null,
 /// unparseable, or non-object rows yield `None`.
-fn attr_documents(
+pub(super) fn attr_documents(
     batch: &RecordBatch,
     name: &str,
 ) -> Result<Vec<Option<BTreeMap<String, String>>>, QuerierError> {

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -28,7 +28,6 @@ use datafusion::logical_expr::{Expr, SortExpr, cast, col, lit, not};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::scalar::ScalarValue;
 
-use super::logql::MaterializedColumns;
 use super::promql::{
     ArithOp, AtSpec, CalendarFn, CmpOp, Grouping, HistogramFn, LabelMatch, LabelOp, LogicalOp,
     MatchKind, MetricAgg, MetricPlan, QueryPlan, SequenceFn, TopKSpec, ValueOp, plan_promql,
@@ -1400,11 +1399,22 @@ impl MetricsService {
             ["__name__", "job"].iter().map(|s| s.to_string()).collect();
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
         let df = window(df, start, end)?;
-        let batches = df
+        let df = df
             .select_columns(&[LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES])
-            .map_err(QuerierError::QueryFailed)?
-            .distinct()
-            .map_err(QuerierError::QueryFailed)?
+            .map_err(QuerierError::QueryFailed)?;
+        // Arrow's row format cannot sort Map columns; skip the dedup there.
+        let attrs_are_map = df.schema().fields().iter().any(|f| {
+            matches!(
+                f.data_type(),
+                datafusion::arrow::datatypes::DataType::Map(_, _)
+            )
+        });
+        let df = if attrs_are_map {
+            df
+        } else {
+            df.distinct().map_err(QuerierError::QueryFailed)?
+        };
+        let batches = df
             .limit(0, Some(LABEL_SCAN_LIMIT))
             .map_err(QuerierError::QueryFailed)?
             .collect()
@@ -1453,11 +1463,22 @@ impl MetricsService {
         }
 
         // Otherwise pull the value out of the attribute documents.
-        let batches = df
+        let df = df
             .select_columns(&[LOG_ATTRIBUTES, RESOURCE_ATTRIBUTES])
-            .map_err(QuerierError::QueryFailed)?
-            .distinct()
-            .map_err(QuerierError::QueryFailed)?
+            .map_err(QuerierError::QueryFailed)?;
+        // Arrow's row format cannot sort Map columns; skip the dedup there.
+        let attrs_are_map = df.schema().fields().iter().any(|f| {
+            matches!(
+                f.data_type(),
+                datafusion::arrow::datatypes::DataType::Map(_, _)
+            )
+        });
+        let df = if attrs_are_map {
+            df
+        } else {
+            df.distinct().map_err(QuerierError::QueryFailed)?
+        };
+        let batches = df
             .limit(0, Some(LABEL_SCAN_LIMIT))
             .map_err(QuerierError::QueryFailed)?
             .collect()
@@ -1542,50 +1563,36 @@ fn distinct_non_empty(batches: &[RecordBatch], column: &str) -> Result<Vec<Strin
     Ok(values.into_iter().collect())
 }
 
-/// Add every JSON object key from an attribute column to `keys`.
+/// Add every attribute key from an attribute column (JSON-string or
+/// map-typed) to `keys`.
 fn collect_attribute_keys(
     batch: &RecordBatch,
     column: &str,
     keys: &mut BTreeSet<String>,
 ) -> Result<(), QuerierError> {
-    let attrs = string_column(batch, column)?;
-    for i in 0..batch.num_rows() {
-        if attrs.is_null(i) {
-            continue;
-        }
-        if let Ok(serde_json::Value::Object(map)) =
-            serde_json::from_str::<serde_json::Value>(attrs.value(i))
-        {
-            keys.extend(map.keys().cloned());
-        }
+    for doc in super::logs::attr_documents(batch, column)?
+        .into_iter()
+        .flatten()
+    {
+        keys.extend(doc.into_keys());
     }
     Ok(())
 }
 
-/// Add the value of `label` from each attribute document to `values`.
+/// Add the value of `label` from each attribute document (JSON-string or
+/// map-typed) to `values`.
 fn collect_attribute_values(
     batch: &RecordBatch,
     column: &str,
     label: &str,
     values: &mut BTreeSet<String>,
 ) -> Result<(), QuerierError> {
-    let attrs = string_column(batch, column)?;
-    for i in 0..batch.num_rows() {
-        if attrs.is_null(i) {
-            continue;
-        }
-        if let Ok(serde_json::Value::Object(map)) =
-            serde_json::from_str::<serde_json::Value>(attrs.value(i))
-            && let Some(value) = map.get(label)
-        {
-            match value {
-                serde_json::Value::String(s) => {
-                    values.insert(s.clone());
-                }
-                other => {
-                    values.insert(other.to_string());
-                }
-            }
+    for mut doc in super::logs::attr_documents(batch, column)?
+        .into_iter()
+        .flatten()
+    {
+        if let Some(value) = doc.remove(label) {
+            values.insert(value);
         }
     }
     Ok(())
@@ -2000,16 +2007,25 @@ fn apply_filters(
 ) -> Result<DataFrame, QuerierError> {
     // Materialized `label_<key>` columns present in this metrics table, so
     // label matchers on them are exact instead of JSON substring.
-    let materialized: MaterializedColumns = df
-        .schema()
-        .fields()
-        .iter()
-        .map(|f| f.name().to_string())
-        .filter(|n| n.starts_with("label_"))
-        .collect();
+    let attr_ctx = super::logql::AttrContext {
+        materialized: df
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().to_string())
+            .filter(|n| n.starts_with("label_"))
+            .collect(),
+        map_attrs: df.schema().fields().iter().any(|f| {
+            f.name() == LOG_ATTRIBUTES
+                && matches!(
+                    f.data_type(),
+                    datafusion::arrow::datatypes::DataType::Map(_, _)
+                )
+        }),
+    };
     let mut predicate = col("metric_name").eq(lit(plan.metric_name.clone()));
     for m in &plan.matchers {
-        predicate = predicate.and(matcher_expr(m, &materialized)?);
+        predicate = predicate.and(matcher_expr(m, &attr_ctx)?);
     }
     df.filter(
         col("timestamp")
@@ -2022,7 +2038,8 @@ fn apply_filters(
 
 /// Lower one label matcher to a filter expression, mapping well-known
 /// labels to columns and others to the attribute JSON.
-fn matcher_expr(m: &LabelMatch, materialized: &MaterializedColumns) -> Result<Expr, QuerierError> {
+fn matcher_expr(m: &LabelMatch, ctx: &super::logql::AttrContext) -> Result<Expr, QuerierError> {
+    let materialized = &ctx.materialized;
     // A well-known or materialized label matches its dedicated column
     // exactly (and supports regex); other labels fall back to the JSON
     // substring match. A materialized column is nullable, so `!=`/`!~` also
@@ -2049,6 +2066,30 @@ fn matcher_expr(m: &LabelMatch, materialized: &MaterializedColumns) -> Result<Ex
         }),
         None if materialized.contains(&materialized_column_name(&m.name)) => {
             Ok(column_match(materialized_column_name(&m.name)))
+        }
+        // Map-typed attribute tables: per-key extraction, all four
+        // operators, on both attribute columns.
+        None if ctx.map_attrs => {
+            use datafusion::functions::core::expr_fn::get_field;
+            let per = |column: &str| {
+                let e = get_field(col(column), m.name.as_str());
+                match m.op {
+                    MatchKind::Eq => e.eq(lit(m.value.clone())),
+                    MatchKind::Neq => e.clone().is_null().or(e.not_eq(lit(m.value.clone()))),
+                    MatchKind::Re => regexp_like(e, lit(m.value.clone()), None),
+                    MatchKind::Nre => {
+                        e.clone()
+                            .is_null()
+                            .or(not(regexp_like(e, lit(m.value.clone()), None)))
+                    }
+                }
+            };
+            Ok(match m.op {
+                MatchKind::Eq | MatchKind::Re => per(LOG_ATTRIBUTES).or(per(RESOURCE_ATTRIBUTES)),
+                MatchKind::Neq | MatchKind::Nre => {
+                    per(LOG_ATTRIBUTES).and(per(RESOURCE_ATTRIBUTES))
+                }
+            })
         }
         None => {
             let fragment = attribute_fragment(&m.name, &m.value);
@@ -2552,18 +2593,21 @@ mod tests {
 
     #[test]
     fn matcher_routes_materialized_label_to_column() {
-        use std::collections::HashSet;
         let m = LabelMatch {
             name: "namespace".to_string(),
             op: MatchKind::Eq,
             value: "prod".to_string(),
         };
         // No materialized column → attribute-JSON substring match.
-        let json = format!("{:?}", matcher_expr(&m, &HashSet::new()).unwrap());
+        let ctx = super::super::logql::AttrContext::default();
+        let json = format!("{:?}", matcher_expr(&m, &ctx).unwrap());
         assert!(json.contains(r#""namespace":"prod""#), "{json}");
         // With the column → exact equality on `label_namespace`.
-        let cols: HashSet<String> = ["label_namespace".to_string()].into_iter().collect();
-        let rendered = format!("{:?}", matcher_expr(&m, &cols).unwrap());
+        let ctx = super::super::logql::AttrContext {
+            materialized: ["label_namespace".to_string()].into_iter().collect(),
+            map_attrs: false,
+        };
+        let rendered = format!("{:?}", matcher_expr(&m, &ctx).unwrap());
         assert!(rendered.contains("label_namespace"), "{rendered}");
         assert!(!rendered.contains("attributes"), "{rendered}");
     }

--- a/src/querier/src/query/profile.rs
+++ b/src/querier/src/query/profile.rs
@@ -280,11 +280,21 @@ impl ProfileService {
     ) -> Result<Vec<String>, QuerierError> {
         let df = self.profiles_table(tenant_slug, dataset_slug).await?;
         let df = Self::apply_time_window(df, params.start, params.end)?;
-        let batches = df
+        let df = df
             .select_columns(&["profile_attributes"])
-            .map_err(QuerierError::QueryFailed)?
-            .distinct()
-            .map_err(QuerierError::QueryFailed)?
+            .map_err(QuerierError::QueryFailed)?;
+        // Arrow's row format cannot sort Map columns; skip the dedup there.
+        let df = if df.schema().fields().iter().any(|f| {
+            matches!(
+                f.data_type(),
+                datafusion::arrow::datatypes::DataType::Map(_, _)
+            )
+        }) {
+            df
+        } else {
+            df.distinct().map_err(QuerierError::QueryFailed)?
+        };
+        let batches = df
             .limit(0, Some(LABEL_SCAN_LIMIT))
             .map_err(QuerierError::QueryFailed)?
             .collect()
@@ -294,16 +304,11 @@ impl ProfileService {
         let mut names: BTreeSet<String> = BTreeSet::new();
         names.insert("service_name".to_string());
         for batch in &batches {
-            let attrs = string_column(batch, "profile_attributes")?;
-            for i in 0..batch.num_rows() {
-                if attrs.is_null(i) {
-                    continue;
-                }
-                if let Ok(serde_json::Value::Object(map)) =
-                    serde_json::from_str::<serde_json::Value>(attrs.value(i))
-                {
-                    names.extend(map.keys().cloned());
-                }
+            for doc in super::logs::attr_documents(batch, "profile_attributes")?
+                .into_iter()
+                .flatten()
+            {
+                names.extend(doc.into_keys());
             }
         }
         Ok(names.into_iter().collect())
@@ -348,11 +353,21 @@ impl ProfileService {
             return Ok(values.into_iter().collect());
         }
 
-        let batches = df
+        let df = df
             .select_columns(&["profile_attributes"])
-            .map_err(QuerierError::QueryFailed)?
-            .distinct()
-            .map_err(QuerierError::QueryFailed)?
+            .map_err(QuerierError::QueryFailed)?;
+        // Arrow's row format cannot sort Map columns; skip the dedup there.
+        let df = if df.schema().fields().iter().any(|f| {
+            matches!(
+                f.data_type(),
+                datafusion::arrow::datatypes::DataType::Map(_, _)
+            )
+        }) {
+            df
+        } else {
+            df.distinct().map_err(QuerierError::QueryFailed)?
+        };
+        let batches = df
             .limit(0, Some(LABEL_SCAN_LIMIT))
             .map_err(QuerierError::QueryFailed)?
             .collect()
@@ -361,23 +376,12 @@ impl ProfileService {
 
         let mut values = BTreeSet::new();
         for batch in &batches {
-            let attrs = string_column(batch, "profile_attributes")?;
-            for i in 0..batch.num_rows() {
-                if attrs.is_null(i) {
-                    continue;
-                }
-                if let Ok(serde_json::Value::Object(map)) =
-                    serde_json::from_str::<serde_json::Value>(attrs.value(i))
-                    && let Some(value) = map.get(label_name)
-                {
-                    match value {
-                        serde_json::Value::String(s) => {
-                            values.insert(s.clone());
-                        }
-                        other => {
-                            values.insert(other.to_string());
-                        }
-                    }
+            for mut doc in super::logs::attr_documents(batch, "profile_attributes")?
+                .into_iter()
+                .flatten()
+            {
+                if let Some(value) = doc.remove(label_name) {
+                    values.insert(value);
                 }
             }
         }


### PR DESCRIPTION
Completes the Map attribute tier (#730, epic #737 L1) across all four signals: metrics (5 tables) + profiles declare attributes as Iceberg Map<String,String> on new tables (mapify_attr_fields allocates nested key/value IDs after materialized-label IDs to keep IDs unique). Writer unchanged — #741's JSON→Map coercion covers these transforms. Querier: PromQL matchers on map tables use per-key get_field extraction (all four operators on any attribute; != matches absent keys); metrics + profile label/value discovery read either storage form via the shared attr_documents reader, skipping distinct() for maps (Arrow row-format limitation). With #741 (logs) and #742 (traces), Layer 1 is complete signal-wide. querier 220 / common 237 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed attribute maps across new metrics and profile tables.
  * Enabled all label matcher operators for attributes stored in typed maps.
  * Improved label and value discovery for metrics and profiles.

* **Bug Fixes**
  * Improved compatibility with both legacy JSON attributes and typed-map attributes.
  * Prevented inaccurate or unsupported deduplication behavior during label discovery.

* **Documentation**
  * Clarified attribute storage formats, matcher behavior, cardinality estimates, and API endpoint listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->