### PR TITLE
feat(compactor): advisory attribute-statistics analyzer

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -89,7 +89,7 @@ Key details:
 - **Phase 2**: Active Parquet file compaction for storage efficiency
 - **Phase 3**: Retention enforcement, snapshot expiration, and orphan file cleanup
 
-The compactor runs concurrent background loops for compaction, retention enforcement, and orphan cleanup, all using tokio::select! for non-blocking execution.
+Each rewrite also runs a read-only attribute-stats pass logging per-key presence/cardinality + advisory materialization candidates (epic #737 L4a). The compactor runs concurrent background loops for compaction, retention enforcement, and orphan cleanup, all using tokio::select! for non-blocking execution.
 
 ## Dual Catalog System
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -284,6 +284,7 @@ flowchart LR
 - Distributed leases (`compactor_leases` catalog table) prevent concurrent compaction of the same partition
 - Flight admin interface exposes only `do_action` commands (`compact_now`, `compact_status`, `compact_dry_run`) and `list_actions`; all other Flight RPCs return `unimplemented`
 - Retention enforcement and orphan-file cleanup, configured via `[compactor.retention]` and `[compactor.orphan_cleanup]`
+- Advisory attribute-stats pass on every rewrite: logs per-key presence / approximate cardinality and would-be materialization candidates (epic #737 Layer 4a; read-only)
 - Disabled by default; enable with `[compactor].enabled = true`
 
 ## Multi-Tenancy and Authentication

--- a/docs/operations/compactor/phase3-configuration.md
+++ b/docs/operations/compactor/phase3-configuration.md
@@ -584,3 +584,5 @@ Invalid retention configuration for tenant 'acme': Invalid retention period for 
 - [Phase 3 Operations Guide](phase3-operations.md)
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
+
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line). It requires no configuration and changes no data.

--- a/docs/operations/compactor/phase3-operations.md
+++ b/docs/operations/compactor/phase3-operations.md
@@ -672,3 +672,5 @@ export AWS_S3_USE_ACCELERATE_ENDPOINT=true
 - [Phase 3 Configuration Reference](phase3-configuration.md)
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
+
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line). It requires no configuration and changes no data.

--- a/docs/operations/compactor/phase3-troubleshooting.md
+++ b/docs/operations/compactor/phase3-troubleshooting.md
@@ -797,3 +797,5 @@ If you encounter issues not covered in this guide:
 3. **Gather Metrics:** `curl localhost:9091/metrics | grep compactor > metrics.txt`
 4. **Configuration:** Share `signaldb.toml` (redact sensitive values)
 5. **Open Issue:** https://github.com/cedricziel/signaldb/issues with above information
+
+> The `Attribute-stats analyzer` log line on each rewrite is advisory only (epic #737); it never blocks or alters compaction.

--- a/src/compactor/src/attr_stats.rs
+++ b/src/compactor/src/attr_stats.rs
@@ -1,0 +1,216 @@
+//! # Attribute statistics analyzer (read-only)
+//!
+//! Computes per-key statistics over a table's attribute columns while the
+//! compactor is already scanning the data for a rewrite: presence (how many
+//! rows carry the key) and an approximate distinct-value count. The
+//! analyzer then *logs* which keys would be promoted to materialized
+//! `label_<key>` columns under a schema-width budget — it changes nothing.
+//!
+//! This is the de-risking first half of auto-materialization (epic #737,
+//! Layer 4a): validating the guardrails — especially the cardinality
+//! estimator — against real data before any rewrite-coupled promotion.
+//! Persisting stats to a catalog table and folding in query-demand
+//! counters are follow-ups tracked on the issue.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use datafusion::arrow::array::{Array, MapArray, RecordBatch, StringArray};
+
+/// Attribute columns recognized across the signal tables.
+const ATTR_COLUMNS: &[&str] = &[
+    "log_attributes",
+    "span_attributes",
+    "resource_attributes",
+    "scope_attributes",
+    "attributes",
+    "profile_attributes",
+];
+
+/// Cap on the tracked distinct values per key. Keys that exceed it are
+/// reported as `>= CARDINALITY_CAP` and are never promotion candidates.
+const CARDINALITY_CAP: usize = 10_000;
+
+/// The maximum number of keys the analyzer would promote (schema-width
+/// budget, minus whatever is already materialized — the log is advisory).
+const PROMOTION_BUDGET: usize = 32;
+
+/// Minimum fraction of rows that must carry a key for it to be a
+/// promotion candidate.
+const MIN_PRESENCE: f64 = 0.005;
+
+/// Per-key statistics over the scanned rows.
+#[derive(Debug, Default, Clone)]
+pub struct AttrFieldStats {
+    /// Rows in which the key appeared (across all attribute columns).
+    pub present_rows: u64,
+    /// Distinct values observed, capped at [`CARDINALITY_CAP`].
+    pub distinct: usize,
+    /// Whether the distinct tracking hit the cap (true cardinality is
+    /// at least [`CARDINALITY_CAP`]).
+    pub capped: bool,
+}
+
+/// Analyze the attribute columns of the given batches, returning per-key
+/// statistics plus the total row count scanned.
+pub fn analyze_batches(batches: &[RecordBatch]) -> (BTreeMap<String, AttrFieldStats>, u64) {
+    let mut stats: BTreeMap<String, AttrFieldStats> = BTreeMap::new();
+    let mut values: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut total_rows: u64 = 0;
+
+    for batch in batches {
+        total_rows += batch.num_rows() as u64;
+        for column in ATTR_COLUMNS {
+            let Some(array) = batch.column_by_name(column) else {
+                continue;
+            };
+            for doc in attr_documents(array.as_ref()) {
+                let Some(doc) = doc else { continue };
+                for (key, value) in doc {
+                    let entry = stats.entry(key.clone()).or_default();
+                    entry.present_rows += 1;
+                    let set = values.entry(key).or_default();
+                    if entry.capped {
+                        continue;
+                    }
+                    set.insert(value);
+                    if set.len() >= CARDINALITY_CAP {
+                        entry.capped = true;
+                    }
+                }
+            }
+        }
+    }
+    for (key, set) in values {
+        if let Some(entry) = stats.get_mut(&key) {
+            entry.distinct = set.len();
+        }
+    }
+    (stats, total_rows)
+}
+
+/// Log the promotion candidates for a table: keys that clear the presence
+/// floor and the cardinality cap, ranked by presence, truncated to the
+/// budget. Purely advisory — nothing is changed.
+pub fn log_promotion_candidates(
+    table_name: &str,
+    stats: &BTreeMap<String, AttrFieldStats>,
+    total_rows: u64,
+) {
+    if total_rows == 0 || stats.is_empty() {
+        return;
+    }
+    let mut candidates: Vec<(&String, &AttrFieldStats)> = stats
+        .iter()
+        .filter(|(_, s)| !s.capped && (s.present_rows as f64 / total_rows as f64) >= MIN_PRESENCE)
+        .collect();
+    candidates.sort_by_key(|(_, s)| std::cmp::Reverse(s.present_rows));
+    candidates.truncate(PROMOTION_BUDGET);
+
+    let rejected_cardinality = stats.values().filter(|s| s.capped).count();
+    let summary: Vec<String> = candidates
+        .iter()
+        .map(|(k, s)| {
+            format!(
+                "{k} (presence {:.1}%, distinct {})",
+                100.0 * s.present_rows as f64 / total_rows as f64,
+                s.distinct
+            )
+        })
+        .collect();
+    tracing::info!(
+        table = %table_name,
+        total_rows,
+        keys_seen = stats.len(),
+        rejected_high_cardinality = rejected_cardinality,
+        candidates = %summary.join(", "),
+        "Attribute-stats analyzer: promotion candidates (advisory)"
+    );
+}
+
+/// Iterate an attribute column's per-row documents as key/value pairs,
+/// handling both storage forms: `Map<Utf8, Utf8>` (new tables) and Utf8
+/// columns holding flat JSON objects (legacy tables).
+fn attr_documents(array: &dyn Array) -> Vec<Option<Vec<(String, String)>>> {
+    if let Some(map) = array.as_any().downcast_ref::<MapArray>() {
+        return (0..map.len())
+            .map(|i| {
+                if map.is_null(i) {
+                    return None;
+                }
+                let entries = map.value(i);
+                let keys = entries.column(0).as_any().downcast_ref::<StringArray>()?;
+                let vals = entries.column(1).as_any().downcast_ref::<StringArray>()?;
+                let mut doc = Vec::with_capacity(entries.len());
+                for j in 0..entries.len() {
+                    if !keys.is_null(j) && !vals.is_null(j) {
+                        doc.push((keys.value(j).to_string(), vals.value(j).to_string()));
+                    }
+                }
+                Some(doc)
+            })
+            .collect();
+    }
+    if let Some(strings) = array.as_any().downcast_ref::<StringArray>() {
+        return (0..strings.len())
+            .map(|i| {
+                if strings.is_null(i) {
+                    return None;
+                }
+                match serde_json::from_str::<serde_json::Value>(strings.value(i)) {
+                    Ok(serde_json::Value::Object(map)) => Some(
+                        map.into_iter()
+                            .map(|(k, v)| {
+                                let rendered = match v {
+                                    serde_json::Value::String(s) => s,
+                                    other => other.to_string(),
+                                };
+                                (k, rendered)
+                            })
+                            .collect(),
+                    ),
+                    _ => None,
+                }
+            })
+            .collect();
+    }
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn analyzer_computes_presence_and_cardinality_and_ranks_candidates() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "log_attributes",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![
+                Some(r#"{"namespace":"prod","pod":"a"}"#),
+                Some(r#"{"namespace":"prod","pod":"b"}"#),
+                Some(r#"{"namespace":"staging"}"#),
+                None,
+            ]))],
+        )
+        .unwrap();
+
+        let (stats, total) = analyze_batches(&[batch]);
+        assert_eq!(total, 4);
+        let ns = &stats["namespace"];
+        assert_eq!(ns.present_rows, 3);
+        assert_eq!(ns.distinct, 2);
+        assert!(!ns.capped);
+        assert_eq!(stats["pod"].present_rows, 2);
+        assert_eq!(stats["pod"].distinct, 2);
+
+        // Advisory logging must not panic on real stats or empty input.
+        log_promotion_candidates("logs", &stats, total);
+        log_promotion_candidates("logs", &BTreeMap::new(), 0);
+    }
+}

--- a/src/compactor/src/lib.rs
+++ b/src/compactor/src/lib.rs
@@ -12,6 +12,7 @@
 //!   operation
 //! - `flight`/`http`: on-demand admin actions and observability endpoints
 
+pub mod attr_stats;
 pub mod commit;
 pub mod executor;
 pub mod flight;

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -88,6 +88,13 @@ impl ParquetRewriter {
 
         let rows_read: u64 = merged_batches.iter().map(|b| b.num_rows() as u64).sum();
 
+        // Advisory attribute-stats pass (epic #737 L4a): the data is
+        // already in memory for the rewrite, so per-key presence and
+        // approximate cardinality come nearly free. Logs promotion
+        // candidates; changes nothing.
+        let (attr_stats, scanned) = crate::attr_stats::analyze_batches(&merged_batches);
+        crate::attr_stats::log_promotion_candidates(&table_name, &attr_stats, scanned);
+
         // Chunk batches toward the target file size so the writer produces
         // reasonably sized files.
         let split_batches = self.split_batches_by_size(merged_batches, target_file_size_bytes)?;


### PR DESCRIPTION
Layer 4a of epic #737 (first half of #733): every compaction rewrite runs a **read-only** stats pass over the batches it already loaded — per-key presence + capped distinct count across all signal attribute columns (Map-typed and legacy JSON both) — and logs the advisory materialization candidates (budget 32, cardinality cap 10k, presence floor 0.5%). Zero behavior change to compaction; validates the promotion guardrails against real data before #734 wires rewrite-coupled promotion. Stats persistence to a catalog table + query-demand counters stay tracked on #733. Tests: analyzer unit test; full compactor suite green (94).