### PR TITLE
feat(compactor, querier): persist attribute stats and query demand

### DIFF
--- a/.claude/skills/service-discovery/SKILL.md
+++ b/.claude/skills/service-discovery/SKILL.md
@@ -57,6 +57,11 @@ CREATE TABLE ingesters (
 );
 ```
 
+The same catalog also holds multi-tenancy tables (`tenants`, `api_keys`,
+`datasets`), `compactor_leases`, and the advisory `attribute_stats` table
+(epic #737: per-attribute-key presence/cardinality from the compactor's
+analyzer plus query-demand counters flushed by the querier).
+
 ## Discovery Mechanism
 
 - **InMemoryFlightTransport**: Connection pooling (max 50 connections, 30s timeout, 5min expiry) + capability-based client lookup

--- a/docs/architecture/service-discovery.md
+++ b/docs/architecture/service-discovery.md
@@ -61,6 +61,12 @@ CREATE TABLE shard_owners (
 );
 ```
 
+The same catalog database also holds the multi-tenancy tables (`tenants`,
+`api_keys`, `datasets`), the `compactor_leases` table, and the advisory
+`attribute_stats` table (per-attribute-key presence and cardinality written
+by the compactor's analyzer, plus query-demand hit counters flushed
+periodically by the querier — see the attribute-explorability ADR).
+
 ## Service Roles and Discovery
 
 | Service Role | Discovery Method | Registration | Status |

--- a/docs/operations/compactor/phase3-configuration.md
+++ b/docs/operations/compactor/phase3-configuration.md
@@ -585,4 +585,4 @@ Invalid retention configuration for tenant 'acme': Invalid retention period for 
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
 
-> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line). It requires no configuration and changes no data.
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). It requires no configuration and changes no table data.

--- a/docs/operations/compactor/phase3-operations.md
+++ b/docs/operations/compactor/phase3-operations.md
@@ -673,4 +673,4 @@ export AWS_S3_USE_ACCELERATE_ENDPOINT=true
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
 
-> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line). It requires no configuration and changes no data.
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). It requires no configuration and changes no table data.

--- a/docs/operations/compactor/phase3-troubleshooting.md
+++ b/docs/operations/compactor/phase3-troubleshooting.md
@@ -798,4 +798,4 @@ If you encounter issues not covered in this guide:
 4. **Configuration:** Share `signaldb.toml` (redact sensitive values)
 5. **Open Issue:** https://github.com/cedricziel/signaldb/issues with above information
 
-> The `Attribute-stats analyzer` log line on each rewrite is advisory only (epic #737); it never blocks or alters compaction.
+> The `Attribute-stats analyzer` log line on each rewrite is advisory only (epic #737); it never blocks or alters compaction. Its statistics are persisted to the catalog's `attribute_stats` table; a `Failed to persist attribute scan stats` warning means the catalog write failed and is safe to ignore for compaction correctness.

--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -242,6 +242,13 @@ curl -G 'http://localhost:3000/loki/api/v1/query_range' \
   --data-urlencode 'step=5m'
 ```
 
+## Query-demand statistics
+
+Attribute labels used in filters (any label that is not a dedicated
+column) are counted as *query demand* and flushed to the catalog's
+advisory `attribute_stats` table, where they inform which attributes are
+worth materializing (see the storage layout docs on materialized labels).
+
 ## Related
 
 - [Grafana datasource](grafana-datasource.md) — connecting Grafana

--- a/src/common/src/attr_demand.rs
+++ b/src/common/src/attr_demand.rs
@@ -1,0 +1,95 @@
+//! # Attribute Query-Demand Registry
+//!
+//! In-process counters for "this attribute key was used in a query filter"
+//! (epic #737, #733). The querier records a hit at its query entrypoints —
+//! LogQL/PromQL/trace-search — for every label that is *not* backed by a
+//! dedicated column, i.e. the ones that would benefit from materialization.
+//! A background task periodically drains the registry into the service
+//! catalog's `attribute_stats` table, where the compactor's advisory
+//! analyzer joins demand with scan-side presence/cardinality.
+//!
+//! The registry is a process-global so the deeply nested query lowering
+//! does not need a counter handle threaded through it; the entrypoints
+//! (which know the tenant/dataset/signal) do the recording.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// One demand counter key: (tenant, dataset, signal, attribute key).
+pub type DemandKey = (String, String, String, String);
+
+fn registry() -> &'static Mutex<HashMap<DemandKey, u64>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<DemandKey, u64>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one query-filter hit for an attribute key.
+pub fn record(tenant_id: &str, dataset_id: &str, signal: &str, attr_key: &str) {
+    let key = (
+        tenant_id.to_string(),
+        dataset_id.to_string(),
+        signal.to_string(),
+        attr_key.to_string(),
+    );
+    if let Ok(mut map) = registry().lock() {
+        *map.entry(key).or_insert(0) += 1;
+    }
+}
+
+/// Take all accumulated counters, leaving the registry empty. Callers flush
+/// the result into the catalog's `attribute_stats` table.
+pub fn drain() -> Vec<(DemandKey, u64)> {
+    match registry().lock() {
+        Ok(mut map) => map.drain().collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Spawn a background task that periodically drains the registry into the
+/// catalog's `attribute_stats` table. Flush failures are logged and the
+/// counters are dropped (advisory data — losing a window is acceptable).
+pub fn spawn_flusher(
+    catalog: std::sync::Arc<crate::catalog::Catalog>,
+    interval: std::time::Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            for ((tenant, dataset, signal, key), hits) in drain() {
+                if let Err(e) = catalog
+                    .add_attribute_query_hits(&tenant, &dataset, &signal, &key, hits as i64)
+                    .await
+                {
+                    tracing::warn!(error = %e, attr_key = %key, "Failed to flush attribute query-demand counter");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    /// A single test covers record+drain because the registry is
+    /// process-global — parallel tests would observe each other's counts.
+    #[test]
+    fn record_accumulates_and_drain_empties() {
+        super::record("t", "d", "logs", "namespace");
+        super::record("t", "d", "logs", "namespace");
+        super::record("t", "d", "traces", "http.method");
+        let mut drained = super::drain();
+        drained.sort();
+        let ns = drained
+            .iter()
+            .find(|((_, _, s, k), _)| s == "logs" && k == "namespace")
+            .expect("namespace counter");
+        assert_eq!(ns.1, 2);
+        assert!(
+            drained
+                .iter()
+                .any(|((_, _, s, k), _)| s == "traces" && k == "http.method")
+        );
+        assert!(super::drain().is_empty());
+    }
+}

--- a/src/common/src/catalog.rs
+++ b/src/common/src/catalog.rs
@@ -184,6 +184,25 @@ impl Catalog {
                 )
                 .execute(pool)
                 .await?;
+
+                // Advisory attribute statistics (epic #737, #733): per-key
+                // presence/cardinality written by the compactor's analyzer
+                // and query-demand hit counters written by the querier.
+                let create_attribute_stats = r#"
+                CREATE TABLE IF NOT EXISTS attribute_stats (
+                    tenant_id TEXT NOT NULL,
+                    dataset_id TEXT NOT NULL,
+                    signal TEXT NOT NULL,
+                    attr_key TEXT NOT NULL,
+                    present_rows BIGINT NOT NULL DEFAULT 0,
+                    total_rows BIGINT NOT NULL DEFAULT 0,
+                    distinct_estimate BIGINT NOT NULL DEFAULT 0,
+                    capped INTEGER NOT NULL DEFAULT 0,
+                    query_hits BIGINT NOT NULL DEFAULT 0,
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (tenant_id, dataset_id, signal, attr_key)
+                )"#;
+                query(create_attribute_stats).execute(pool).await?;
             }
             Catalog::Postgres(pool) => {
                 // PostgreSQL schema
@@ -285,6 +304,25 @@ impl Catalog {
                 )
                 .execute(pool)
                 .await?;
+
+                // Advisory attribute statistics (epic #737, #733): per-key
+                // presence/cardinality written by the compactor's analyzer
+                // and query-demand hit counters written by the querier.
+                let create_attribute_stats = r#"
+                CREATE TABLE IF NOT EXISTS attribute_stats (
+                    tenant_id TEXT NOT NULL,
+                    dataset_id TEXT NOT NULL,
+                    signal TEXT NOT NULL,
+                    attr_key TEXT NOT NULL,
+                    present_rows BIGINT NOT NULL DEFAULT 0,
+                    total_rows BIGINT NOT NULL DEFAULT 0,
+                    distinct_estimate BIGINT NOT NULL DEFAULT 0,
+                    capped BOOLEAN NOT NULL DEFAULT FALSE,
+                    query_hits BIGINT NOT NULL DEFAULT 0,
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (tenant_id, dataset_id, signal, attr_key)
+                )"#;
+                query(create_attribute_stats).execute(pool).await?;
             }
         }
 
@@ -856,6 +894,214 @@ pub struct DatasetRecord {
     pub tenant_id: String,
     pub name: String,
     pub created_at: DateTime<Utc>,
+}
+
+/// A per-attribute-key statistics row (epic #737, #733): scan-side
+/// presence/cardinality from the compactor's analyzer plus query-demand
+/// hit counters from the querier.
+#[derive(Debug, Clone)]
+pub struct AttributeStatsRecord {
+    pub tenant_id: String,
+    pub dataset_id: String,
+    pub signal: String,
+    pub attr_key: String,
+    pub present_rows: i64,
+    pub total_rows: i64,
+    pub distinct_estimate: i64,
+    pub capped: bool,
+    pub query_hits: i64,
+}
+
+/// Advisory attribute-statistics methods (epic #737, #733).
+impl Catalog {
+    /// Upsert the scan-side statistics for one attribute key, replacing the
+    /// previous presence/cardinality observation (the analyzer sees the
+    /// whole rewritten table, so newer observations supersede older ones).
+    /// `query_hits` is left untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_attribute_scan_stats(
+        &self,
+        tenant_id: &str,
+        dataset_id: &str,
+        signal: &str,
+        attr_key: &str,
+        present_rows: i64,
+        total_rows: i64,
+        distinct_estimate: i64,
+        capped: bool,
+    ) -> Result<(), sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                query(
+                    r#"
+                INSERT INTO attribute_stats
+                    (tenant_id, dataset_id, signal, attr_key, present_rows,
+                     total_rows, distinct_estimate, capped, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                ON CONFLICT (tenant_id, dataset_id, signal, attr_key) DO UPDATE SET
+                    present_rows = excluded.present_rows,
+                    total_rows = excluded.total_rows,
+                    distinct_estimate = excluded.distinct_estimate,
+                    capped = excluded.capped,
+                    updated_at = datetime('now')
+                "#,
+                )
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .bind(attr_key)
+                .bind(present_rows)
+                .bind(total_rows)
+                .bind(distinct_estimate)
+                .bind(capped)
+                .execute(pool)
+                .await?;
+            }
+            Catalog::Postgres(pool) => {
+                query(
+                    r#"
+                INSERT INTO attribute_stats
+                    (tenant_id, dataset_id, signal, attr_key, present_rows,
+                     total_rows, distinct_estimate, capped, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+                ON CONFLICT (tenant_id, dataset_id, signal, attr_key) DO UPDATE SET
+                    present_rows = EXCLUDED.present_rows,
+                    total_rows = EXCLUDED.total_rows,
+                    distinct_estimate = EXCLUDED.distinct_estimate,
+                    capped = EXCLUDED.capped,
+                    updated_at = NOW()
+                "#,
+                )
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .bind(attr_key)
+                .bind(present_rows)
+                .bind(total_rows)
+                .bind(distinct_estimate)
+                .bind(capped)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Add query-demand hits for one attribute key (accumulating counter).
+    /// Scan-side columns are left untouched.
+    pub async fn add_attribute_query_hits(
+        &self,
+        tenant_id: &str,
+        dataset_id: &str,
+        signal: &str,
+        attr_key: &str,
+        hits: i64,
+    ) -> Result<(), sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                query(
+                    r#"
+                INSERT INTO attribute_stats
+                    (tenant_id, dataset_id, signal, attr_key, query_hits, updated_at)
+                VALUES (?, ?, ?, ?, ?, datetime('now'))
+                ON CONFLICT (tenant_id, dataset_id, signal, attr_key) DO UPDATE SET
+                    query_hits = attribute_stats.query_hits + excluded.query_hits,
+                    updated_at = datetime('now')
+                "#,
+                )
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .bind(attr_key)
+                .bind(hits)
+                .execute(pool)
+                .await?;
+            }
+            Catalog::Postgres(pool) => {
+                query(
+                    r#"
+                INSERT INTO attribute_stats
+                    (tenant_id, dataset_id, signal, attr_key, query_hits, updated_at)
+                VALUES ($1, $2, $3, $4, $5, NOW())
+                ON CONFLICT (tenant_id, dataset_id, signal, attr_key) DO UPDATE SET
+                    query_hits = attribute_stats.query_hits + EXCLUDED.query_hits,
+                    updated_at = NOW()
+                "#,
+                )
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .bind(attr_key)
+                .bind(hits)
+                .execute(pool)
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// The stored statistics for one (tenant, dataset, signal), sorted by
+    /// attribute key.
+    pub async fn get_attribute_stats(
+        &self,
+        tenant_id: &str,
+        dataset_id: &str,
+        signal: &str,
+    ) -> Result<Vec<AttributeStatsRecord>, sqlx::Error> {
+        let sql_sqlite = r#"
+            SELECT tenant_id, dataset_id, signal, attr_key, present_rows,
+                   total_rows, distinct_estimate, capped, query_hits
+            FROM attribute_stats
+            WHERE tenant_id = ? AND dataset_id = ? AND signal = ?
+            ORDER BY attr_key
+        "#;
+        let sql_pg = r#"
+            SELECT tenant_id, dataset_id, signal, attr_key, present_rows,
+                   total_rows, distinct_estimate, capped, query_hits
+            FROM attribute_stats
+            WHERE tenant_id = $1 AND dataset_id = $2 AND signal = $3
+            ORDER BY attr_key
+        "#;
+        fn record<R: Row>(row: &R) -> AttributeStatsRecord
+        where
+            for<'a> &'a str: sqlx::ColumnIndex<R>,
+            for<'a> String: sqlx::Decode<'a, R::Database> + sqlx::Type<R::Database>,
+            for<'a> i64: sqlx::Decode<'a, R::Database> + sqlx::Type<R::Database>,
+            for<'a> bool: sqlx::Decode<'a, R::Database> + sqlx::Type<R::Database>,
+        {
+            AttributeStatsRecord {
+                tenant_id: row.get("tenant_id"),
+                dataset_id: row.get("dataset_id"),
+                signal: row.get("signal"),
+                attr_key: row.get("attr_key"),
+                present_rows: row.get("present_rows"),
+                total_rows: row.get("total_rows"),
+                distinct_estimate: row.get("distinct_estimate"),
+                capped: row.get("capped"),
+                query_hits: row.get("query_hits"),
+            }
+        }
+        match self {
+            Catalog::Sqlite(pool) => Ok(query(sql_sqlite)
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .fetch_all(pool)
+                .await?
+                .iter()
+                .map(record)
+                .collect()),
+            Catalog::Postgres(pool) => Ok(query(sql_pg)
+                .bind(tenant_id)
+                .bind(dataset_id)
+                .bind(signal)
+                .fetch_all(pool)
+                .await?
+                .iter()
+                .map(record)
+                .collect()),
+        }
+    }
 }
 
 /// Multi-tenancy catalog methods
@@ -1969,6 +2215,56 @@ mod multi_tenancy_tests {
         let fake_hash = "nonexistent_hash";
         let result = catalog.validate_api_key(fake_hash).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn attribute_stats_scan_upsert_and_demand_accumulate() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        catalog
+            .upsert_attribute_scan_stats("t", "d", "logs", "namespace", 80, 100, 5, false)
+            .await
+            .unwrap();
+        // Demand accumulates across flushes; scan stats replace.
+        catalog
+            .add_attribute_query_hits("t", "d", "logs", "namespace", 3)
+            .await
+            .unwrap();
+        catalog
+            .add_attribute_query_hits("t", "d", "logs", "namespace", 2)
+            .await
+            .unwrap();
+        catalog
+            .upsert_attribute_scan_stats("t", "d", "logs", "namespace", 90, 120, 7, true)
+            .await
+            .unwrap();
+        // A demand-only key exists with zeroed scan stats.
+        catalog
+            .add_attribute_query_hits("t", "d", "logs", "pod", 1)
+            .await
+            .unwrap();
+
+        let stats = catalog.get_attribute_stats("t", "d", "logs").await.unwrap();
+        assert_eq!(stats.len(), 2);
+        let ns = &stats[0];
+        assert_eq!(ns.attr_key, "namespace");
+        assert_eq!(ns.present_rows, 90);
+        assert_eq!(ns.total_rows, 120);
+        assert_eq!(ns.distinct_estimate, 7);
+        assert!(ns.capped);
+        assert_eq!(ns.query_hits, 5);
+        let pod = &stats[1];
+        assert_eq!(pod.attr_key, "pod");
+        assert_eq!(pod.query_hits, 1);
+        assert_eq!(pod.present_rows, 0);
+
+        assert!(
+            catalog
+                .get_attribute_stats("t", "d", "traces")
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod attr_demand;
 pub mod auth;
 pub mod catalog;
 pub mod catalog_manager;

--- a/src/compactor/src/attr_stats.rs
+++ b/src/compactor/src/attr_stats.rs
@@ -26,6 +26,17 @@ const ATTR_COLUMNS: &[&str] = &[
     "profile_attributes",
 ];
 
+/// The signal a table's statistics are recorded under.
+pub fn signal_of_table(table_name: &str) -> &'static str {
+    match table_name {
+        "traces" => "traces",
+        "logs" => "logs",
+        "profiles" => "profiles",
+        t if t.starts_with("metrics_") => "metrics",
+        _ => "unknown",
+    }
+}
+
 /// Cap on the tracked distinct values per key. Keys that exceed it are
 /// reported as `>= CARDINALITY_CAP` and are never promotion candidates.
 const CARDINALITY_CAP: usize = 10_000;
@@ -176,6 +187,38 @@ fn attr_documents(array: &dyn Array) -> Vec<Option<Vec<(String, String)>>> {
     Vec::new()
 }
 
+/// Persist the analyzer's per-key statistics into the service catalog's
+/// `attribute_stats` table (epic #737, #733), keyed by
+/// (tenant, dataset, signal, key). Failures are logged and swallowed —
+/// the stats are advisory and must never fail a compaction.
+pub async fn persist_stats(
+    catalog: &common::catalog::Catalog,
+    tenant_id: &str,
+    dataset_id: &str,
+    table_name: &str,
+    stats: &BTreeMap<String, AttrFieldStats>,
+    total_rows: u64,
+) {
+    let signal = signal_of_table(table_name);
+    for (key, s) in stats {
+        if let Err(e) = catalog
+            .upsert_attribute_scan_stats(
+                tenant_id,
+                dataset_id,
+                signal,
+                key,
+                s.present_rows as i64,
+                total_rows as i64,
+                s.distinct as i64,
+                s.capped,
+            )
+            .await
+        {
+            tracing::warn!(error = %e, attr_key = %key, "Failed to persist attribute scan stats");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,5 +255,41 @@ mod tests {
         // Advisory logging must not panic on real stats or empty input.
         log_promotion_candidates("logs", &stats, total);
         log_promotion_candidates("logs", &BTreeMap::new(), 0);
+    }
+
+    #[tokio::test]
+    async fn persist_stats_writes_scan_rows_under_the_signal() {
+        let catalog = common::catalog::Catalog::new("sqlite::memory:")
+            .await
+            .unwrap();
+        let mut stats = BTreeMap::new();
+        stats.insert(
+            "namespace".to_string(),
+            AttrFieldStats {
+                present_rows: 80,
+                distinct: 5,
+                capped: false,
+            },
+        );
+        super::persist_stats(&catalog, "t", "d", "metrics_gauge", &stats, 100).await;
+
+        let rows = catalog
+            .get_attribute_stats("t", "d", "metrics")
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].attr_key, "namespace");
+        assert_eq!(rows[0].present_rows, 80);
+        assert_eq!(rows[0].total_rows, 100);
+        assert_eq!(rows[0].distinct_estimate, 5);
+        assert!(!rows[0].capped);
+    }
+
+    #[test]
+    fn signal_of_table_maps_all_tables() {
+        assert_eq!(super::signal_of_table("traces"), "traces");
+        assert_eq!(super::signal_of_table("logs"), "logs");
+        assert_eq!(super::signal_of_table("metrics_histogram"), "metrics");
+        assert_eq!(super::signal_of_table("profiles"), "profiles");
     }
 }

--- a/src/compactor/src/executor.rs
+++ b/src/compactor/src/executor.rs
@@ -113,6 +113,13 @@ impl CompactionExecutor {
         }
     }
 
+    /// Persist the rewriter's advisory attribute statistics to the service
+    /// catalog (epic #737, #733).
+    pub fn with_service_catalog(mut self, catalog: Arc<common::catalog::Catalog>) -> Self {
+        self.rewriter.set_service_catalog(catalog);
+        self
+    }
+
     /// Execute compaction for a candidate
     pub async fn execute_candidate(
         &self,

--- a/src/compactor/src/main.rs
+++ b/src/compactor/src/main.rs
@@ -167,11 +167,15 @@ async fn main() -> Result<()> {
     // Create compaction executor
     let executor_config = ExecutorConfig::from(&planner_config);
     let compaction_metrics = CompactionMetrics::new();
-    let executor = Arc::new(CompactionExecutor::new(
-        catalog_manager.clone(),
-        executor_config,
-        compaction_metrics.clone(),
-    ));
+    let executor = Arc::new(
+        CompactionExecutor::new(
+            catalog_manager.clone(),
+            executor_config,
+            compaction_metrics.clone(),
+        )
+        // Persist advisory attribute statistics (epic #737, #733).
+        .with_service_catalog(Arc::new(bootstrap.catalog().clone())),
+    );
 
     tracing::info!(
         "Compaction planner and executor initialized with tick interval: {:?}",

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -27,12 +27,24 @@ pub struct RewriteOutcome {
 /// Handles Parquet file merging and rewriting
 pub struct ParquetRewriter {
     catalog_manager: Arc<CatalogManager>,
+    /// Service catalog for persisting advisory attribute statistics
+    /// (epic #737, #733). `None` (e.g. in tests) keeps the analyzer
+    /// log-only.
+    service_catalog: Option<Arc<common::catalog::Catalog>>,
 }
 
 impl ParquetRewriter {
     /// Create a new Parquet rewriter
     pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
-        Self { catalog_manager }
+        Self {
+            catalog_manager,
+            service_catalog: None,
+        }
+    }
+
+    /// Persist the advisory attribute statistics to this service catalog.
+    pub fn set_service_catalog(&mut self, catalog: Arc<common::catalog::Catalog>) {
+        self.service_catalog = Some(catalog);
     }
 
     /// Load a table with fresh metadata, without creating it if missing.
@@ -94,6 +106,21 @@ impl ParquetRewriter {
         // candidates; changes nothing.
         let (attr_stats, scanned) = crate::attr_stats::analyze_batches(&merged_batches);
         crate::attr_stats::log_promotion_candidates(&table_name, &attr_stats, scanned);
+        if let Some(catalog) = &self.service_catalog {
+            // The identifier namespace is [tenant_slug, dataset_slug].
+            let ns = table.identifier().namespace();
+            if let [tenant, dataset] = ns.as_ref() {
+                crate::attr_stats::persist_stats(
+                    catalog,
+                    tenant,
+                    dataset,
+                    &table_name,
+                    &attr_stats,
+                    scanned,
+                )
+                .await;
+            }
+        }
 
         // Chunk batches toward the target file size so the writer produces
         // reasonably sized files.

--- a/src/querier/src/main.rs
+++ b/src/querier/src/main.rs
@@ -109,6 +109,11 @@ async fn main() -> anyhow::Result<()> {
     // bootstrap moves into the transport
     let sql_catalog = Arc::new(service_bootstrap.catalog().clone());
 
+    // Periodically flush attribute query-demand counters (epic #737, #733)
+    // into the catalog's advisory `attribute_stats` table.
+    let _demand_flusher =
+        common::attr_demand::spawn_flusher(sql_catalog.clone(), std::time::Duration::from_secs(60));
+
     // Create Flight transport and register this querier's Flight service
     let flight_transport = Arc::new(InMemoryFlightTransport::new(service_bootstrap));
 

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -147,6 +147,7 @@ impl LogsService {
     ) -> Result<Vec<RecordBatch>, QuerierError> {
         let parsed =
             parse_query(&params.query).map_err(|e| QuerierError::InvalidInput(e.to_string()))?;
+        record_attr_demand(&parsed, tenant_slug, dataset_slug);
         let direction = Direction::parse(params.direction.as_deref());
 
         let df = self.logs_table(tenant_slug, dataset_slug).await?;
@@ -228,6 +229,7 @@ impl LogsService {
         tenant_slug: &str,
         dataset_slug: &str,
     ) -> Result<Vec<RecordBatch>, QuerierError> {
+        record_attr_demand(&plan.log_query, tenant_slug, dataset_slug);
         let mut df = self.logs_table(tenant_slug, dataset_slug).await?;
         let materialized = materialized_columns_of(&df);
 
@@ -1346,6 +1348,17 @@ fn unwrap_value(label: &str) -> Expr {
 }
 
 /// The dedicated column a known label maps to.
+/// Record query demand (epic #737, #733) for every selector label that is
+/// not backed by a dedicated column — the keys that would benefit from
+/// materialization (or, if already materialized, from staying so).
+fn record_attr_demand(query: &LogQuery, tenant_slug: &str, dataset_slug: &str) {
+    for matcher in &query.selector.matchers {
+        if column_for_label(&matcher.name).is_none() {
+            common::attr_demand::record(tenant_slug, dataset_slug, "logs", &matcher.name);
+        }
+    }
+}
+
 fn column_for_label(label: &str) -> Option<&'static str> {
     match label {
         "service_name" | "service" | "job" => Some("service_name"),

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -248,6 +248,14 @@ impl MetricsService {
             return eval_time(plan, start, end, step);
         }
 
+        // Query demand (epic #737, #733): every matcher label without a
+        // dedicated column is a materialization candidate.
+        for m in &plan.matchers {
+            if column_for_label(&m.name).is_none() {
+                common::attr_demand::record(tenant_slug, dataset_slug, "metrics", &m.name);
+            }
+        }
+
         let df = self.scan_union(tenant_slug, dataset_slug).await?;
         // The materialized `label_<key>` columns of the scanned tables widen
         // the natural series identity and are groupable like `service_name`.

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -455,6 +455,16 @@ impl TraceService {
                     )
             }),
         };
+        // Query demand (epic #737, #733): attribute conditions are
+        // materialization candidates.
+        for condition in &conditions {
+            if let search_filter::Selector::SpanAttribute(key)
+            | search_filter::Selector::ResourceAttribute(key)
+            | search_filter::Selector::AnyAttribute(key) = &condition.selector
+            {
+                common::attr_demand::record(tenant_slug, dataset_slug, "traces", key);
+            }
+        }
         for condition in &conditions {
             df = df.filter(condition.to_expr(&attr_ctx)?).map_err(|e| {
                 log::error!("Failed to apply search filter {condition:?}: {e}");

--- a/src/signaldb-bin/src/main.rs
+++ b/src/signaldb-bin/src/main.rs
@@ -188,6 +188,13 @@ async fn main() -> Result<()> {
     .await
     .context("Failed to initialize querier service bootstrap")?;
 
+    // Periodically flush attribute query-demand counters (epic #737, #733)
+    // into the catalog's advisory `attribute_stats` table.
+    let _demand_flusher = common::attr_demand::spawn_flusher(
+        Arc::new(querier_bootstrap.catalog().clone()),
+        std::time::Duration::from_secs(60),
+    );
+
     // Create Flight transport and register querier with QueryExecution capability
     let querier_flight_transport = Arc::new(InMemoryFlightTransport::new(querier_bootstrap));
     let querier_service_id = querier_flight_transport


### PR DESCRIPTION
Completes #733 (epic #737). The advisory analyzer from #744 now persists its per-key statistics, and the querier counts query demand:

- **New `attribute_stats` catalog table** (SQLite + Postgres DDL), keyed by `(tenant, dataset, signal, attr_key)`: scan-side presence/total rows, capped distinct estimate, an accumulating `query_hits` counter, and a `promote_streak` hysteresis column (used by the upcoming #734 decision pass), with upsert/get methods on `Catalog`.
- **Compactor**: the rewrite pass persists analyzer output through an optional service-catalog handle on `ParquetRewriter` (wired in the standalone compactor via `bootstrap.catalog()`). Advisory writes are logged-and-swallowed — they never fail a compaction.
- **Query demand** (`common::attr_demand`): a process-global registry. The querier records a hit at its entrypoints for every filter label not backed by a dedicated column — LogQL selectors (stream + metric paths), PromQL matchers, and trace-search attribute conditions — and a background task flushes counters into `attribute_stats` every 60s (standalone querier and monolithic mode).

Scan stats *replace* on each rewrite (the analyzer sees the whole table); demand *accumulates* across flushes. Together they feed the #734 promotion scoring (demand × presence).

## Tests

- `attribute_stats_scan_upsert_and_demand_accumulate` (catalog round-trip: replace vs accumulate semantics, demand-only rows)
- `record_accumulates_and_drain_empties` (demand registry)
- `persist_stats_writes_scan_rows_under_the_signal` + `signal_of_table_maps_all_tables` (compactor persistence)

`cargo test -p common/-p compactor/-p querier` pass (one unrelated testcontainers test requires Docker); clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory attribute statistics to the service catalog, combining scan metrics with query-demand data.
  * Query filters now track demand for non-column attributes and periodically store usage statistics.
  * Compaction records per-attribute presence, cardinality, and materialization recommendations without affecting compaction success or table data.

* **Documentation**
  * Expanded architecture, operations, troubleshooting, and query reference documentation for attribute statistics and query-demand tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->