### PR TITLE
fix(acceptor): implement OTLP/HTTP trace ingestion with tenant auth

### DIFF
--- a/docs/users/sending-otlp.md
+++ b/docs/users/sending-otlp.md
@@ -14,9 +14,11 @@ Goal: point an OpenTelemetry SDK or Collector at SignalDB so traces, logs,
 and metrics are ingested.
 
 SignalDB accepts OTLP over **gRPC on port 4317** for all three signals.
-Use gRPC. The OTLP/HTTP port (4318) does not ingest OTLP today — see
-[the HTTP limitation](#otlphttp-is-not-implemented) below. Port 4318 does
-serve [Prometheus remote_write](prometheus-remote-write.md).
+The OTLP/HTTP port (4318) additionally ingests **traces** at
+`POST /v1/traces` (protobuf and JSON bodies, authenticated); logs and
+metrics remain gRPC-only — see
+[OTLP/HTTP support](#otlphttp-support-is-partial) below. Port 4318 also
+serves [Prometheus remote_write](prometheus-remote-write.md).
 
 ## Prerequisites
 
@@ -29,18 +31,24 @@ serve [Prometheus remote_write](prometheus-remote-write.md).
 
 ### 1. Choose the endpoint
 
-Every OTLP export goes to the gRPC endpoint:
+Use the gRPC endpoint — it supports all signals:
 
 ```text
 http://<acceptor-host>:4317
 ```
 
+For traces only, the OTLP/HTTP endpoint is also available:
+
+```text
+http://<acceptor-host>:4318/v1/traces
+```
+
 ### 2. Attach the auth metadata
 
-Each gRPC request must carry these metadata keys (see
-[Authentication](authentication.md) for details):
+Each request — gRPC metadata or HTTP headers alike — must carry these keys
+(see [Authentication](authentication.md) for details):
 
-| Metadata key | Required | Value |
+| Metadata key / header | Required | Value |
 |---|---|---|
 | `authorization` | yes | `Bearer <api-key>` |
 | `x-tenant-id` | yes | your tenant ID |
@@ -94,23 +102,55 @@ successful export response means the data is durable.
 
 ## Per-signal support
 
-| Signal | OTLP/gRPC :4317 | Stored as |
-|---|---|---|
-| Traces | yes | `traces` table |
-| Logs | yes | `logs` table |
-| Metrics | yes | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
-| Profiles | yes | `profiles` table (see [profiles](profiles.md)) |
+| Signal | OTLP/gRPC :4317 | OTLP/HTTP :4318 | Stored as |
+|---|---|---|---|
+| Traces | yes | yes (`POST /v1/traces`) | `traces` table |
+| Logs | yes | no | `logs` table |
+| Metrics | yes | no | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
+| Profiles | yes | yes (`POST /v1development/profiles`) | `profiles` table (see [profiles](profiles.md)) |
 
 ## OTLP/HTTP support is partial
 
-The HTTP server on port 4318 exposes `POST /v1development/profiles` for
-the profiles signal (protobuf and JSON bodies, authenticated) — see
-[profiles](profiles.md). For the other signals it exposes only
-`POST /v1/traces`, and that handler is a stub: it logs the payload size
-and returns `200 OK` without writing anything. There are no `/v1/logs` or
-`/v1/metrics` routes. Do not point an `http/protobuf` or `http/json` OTLP
-exporter at SignalDB for traces, logs, or metrics — the export will
-appear to succeed but no data is stored.
+The HTTP server on port 4318 ingests **traces** at `POST /v1/traces` and
+**profiles** at `POST /v1development/profiles` (see
+[profiles](profiles.md)). Both accept `application/x-protobuf` and
+`application/json` (protojson encoding: trace and span IDs are hex
+strings) request bodies, require the same auth headers as gRPC, and
+enforce per-tenant rate limits and storage quotas. Compressed
+(`Content-Encoding: gzip`) request bodies are not supported — export
+uncompressed.
+
+A successful trace export returns `200 OK` with an
+`ExportTraceServiceResponse` body in the same encoding as the request.
+Error responses:
+
+| Status | Meaning |
+|---|---|
+| `400 Bad Request` | Malformed payload, or missing/malformed `Authorization` / `X-Tenant-ID` headers |
+| `401 Unauthorized` | API key is wrong or revoked |
+| `403 Forbidden` | Key does not belong to the tenant/dataset you named |
+| `429 Too Many Requests` | Per-tenant ingest rate limit or storage quota hit |
+
+There are no `/v1/logs` or `/v1/metrics` HTTP routes — an `http/protobuf`
+or `http/json` exporter pointed at SignalDB for logs or metrics gets
+`404 Not Found`. Use gRPC on :4317 for those signals.
+
+To use OTLP/HTTP for traces from the OpenTelemetry Collector:
+
+```yaml
+exporters:
+  otlphttp/signaldb:
+    endpoint: http://signaldb:4318
+    headers:
+      authorization: "Bearer sk-acme-prod-key-123"
+      x-tenant-id: "acme"
+    compression: none   # gzip request bodies are not supported
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/signaldb]
+```
 
 ## Troubleshooting
 
@@ -122,5 +162,6 @@ appear to succeed but no data is stored.
 | `PERMISSION_DENIED` | Key does not belong to the tenant/dataset you named | Use a key issued for that tenant |
 | `RESOURCE_EXHAUSTED` | Per-tenant ingest rate limit hit | Back off and retry; ask your operator about tenant limits |
 | `RESOURCE_EXHAUSTED` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
-| `429 Too Many Requests` on `POST /v1development/profiles` | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | See [profiles](profiles.md) |
-| Exports return 200 but no data is queryable | Exporter uses OTLP/HTTP on :4318 | Switch the exporter to gRPC on :4317 |
+| `429 Too Many Requests` on `POST /v1/traces` or `POST /v1development/profiles` | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | Back off and retry (rate limit), or talk to your operator (quota) |
+| `400 Bad Request` on `POST /v1/traces` with a JSON body | Payload is not valid protojson (e.g. base64 trace IDs instead of hex) | Use a protojson-compliant encoder; trace/span IDs must be hex strings |
+| `404 Not Found` on `:4318/v1/logs` or `:4318/v1/metrics` | Logs and metrics have no OTLP/HTTP routes | Switch those pipelines to gRPC on :4317 |

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -317,7 +317,6 @@ pub async fn serve_otlp_grpc(
 
 pub fn acceptor_router() -> Router {
     Router::new()
-        .route("/v1/traces", post(handle_traces))
         .route("/health", get(health))
         .layer(axum::middleware::from_fn(
             common::self_monitoring::http_metrics_middleware,
@@ -401,6 +400,158 @@ pub fn profiles_http_router(
         ))
 }
 
+/// Shared state for the OTLP/HTTP traces endpoint
+#[derive(Clone)]
+pub struct TracesHandlerState {
+    pub handler: Arc<TraceHandler>,
+    pub rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    pub storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
+}
+
+/// Create a router for the OTLP/HTTP traces ingestion endpoint with authentication
+///
+/// Handles `POST /v1/traces` with protobuf (`application/x-protobuf`) or JSON
+/// (`application/json`, protojson encoding with hex trace/span ids) request
+/// bodies, matching the OTLP/HTTP specification. Per-tenant ingest rate
+/// limits and storage quotas are enforced with HTTP 429; both are unlimited
+/// unless configured.
+pub fn traces_http_router(
+    authenticator: Arc<Authenticator>,
+    trace_handler: Arc<TraceHandler>,
+    rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
+) -> Router {
+    use axum::middleware;
+
+    let state = TracesHandlerState {
+        handler: trace_handler,
+        rate_limiter,
+        storage_quota,
+    };
+
+    Router::new()
+        .route("/v1/traces", post(handle_http_traces))
+        .layer(Extension(state))
+        .layer(middleware::from_fn(move |req, next| {
+            let auth = authenticator.clone();
+            async move { auth_middleware(auth, req, next).await }
+        }))
+        .layer(middleware::from_fn(
+            common::self_monitoring::http_metrics_middleware,
+        ))
+}
+
+/// OTLP/HTTP traces export: decode by content type, hand off to the
+/// trace handler (WAL durability + Flight forward), and answer with an
+/// `ExportTraceServiceResponse` in the request's encoding.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        tenant_id = %tenant_context.tenant_id,
+        dataset_id = %tenant_context.dataset_id
+    )
+)]
+async fn handle_http_traces(
+    Extension(state): Extension<TracesHandlerState>,
+    headers: axum::http::HeaderMap,
+    crate::middleware::TenantContextExtractor(tenant_context): crate::middleware::TenantContextExtractor,
+    body: axum::body::Bytes,
+) -> axum::response::Response<axum::body::Body> {
+    use opentelemetry_proto::tonic::collector::trace::v1::{
+        ExportTraceServiceRequest, ExportTraceServiceResponse,
+    };
+    use prost::Message;
+
+    // Per-tenant ingest rate limiting (HTTP 429 with the reason)
+    if let Err(e) = state
+        .rate_limiter
+        .check_ingest(&tenant_context.tenant_id, body.len())
+    {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
+
+    // Per-tenant storage quota: a tenant at or over max_storage_bytes
+    // must free space (or get a raised quota) before ingesting more.
+    if let Err(e) = state.storage_quota.check_ingest(&tenant_context.tenant_id) {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
+
+    let is_json = otlp_http_content_type_is_json(&headers);
+
+    let request = if is_json {
+        match serde_json::from_slice::<ExportTraceServiceRequest>(&body) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/JSON traces payload: {e}"),
+                );
+            }
+        }
+    } else {
+        match ExportTraceServiceRequest::decode(body.as_ref()) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/protobuf traces payload: {e}"),
+                );
+            }
+        }
+    };
+
+    match state
+        .handler
+        .handle_grpc_otlp_traces(&tenant_context, request)
+        .await
+    {
+        Ok(()) => {
+            // Per OTLP/HTTP spec the response body is a full
+            // ExportTraceServiceResponse in the same encoding as the request.
+            let builder = axum::response::Response::builder().status(axum::http::StatusCode::OK);
+            let response = if is_json {
+                builder
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from("{}"))
+            } else {
+                builder
+                    .header(axum::http::header::CONTENT_TYPE, "application/x-protobuf")
+                    .body(axum::body::Body::from(
+                        ExportTraceServiceResponse::default().encode_to_vec(),
+                    ))
+            };
+            match response {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to build OTLP/HTTP traces response");
+                    otlp_http_error(
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to build export response".to_string(),
+                    )
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to durably accept traces export via HTTP");
+            otlp_http_error(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                format!("failed to durably accept traces export: {e:#}"),
+            )
+        }
+    }
+}
+
+/// Whether an OTLP/HTTP request body is JSON-encoded.
+///
+/// OTLP/HTTP defaults to protobuf when no content type is present.
+fn otlp_http_content_type_is_json(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/x-protobuf")
+        .starts_with("application/json")
+}
+
 /// OTLP/HTTP profiles export: decode by content type, hand off to the
 /// profile handler, and answer with an empty export response.
 #[tracing::instrument(
@@ -433,12 +584,7 @@ async fn handle_http_profiles(
         return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
     }
 
-    let content_type = headers
-        .get(axum::http::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/x-protobuf");
-
-    let request = if content_type.starts_with("application/json") {
+    let request = if otlp_http_content_type_is_json(&headers) {
         match serde_json::from_slice::<ExportProfilesServiceRequest>(&body) {
             Ok(request) => request,
             Err(e) => {
@@ -519,20 +665,6 @@ async fn health() -> &'static str {
     "ok"
 }
 
-#[tracing::instrument(skip_all)]
-async fn handle_traces(
-    axum::extract::Json(payload): axum::extract::Json<serde_json::Value>,
-) -> axum::response::Response<axum::body::Body> {
-    tracing::info!(
-        payload_size = payload.to_string().len(),
-        "Got traces via HTTP"
-    );
-    axum::response::Response::builder()
-        .status(200)
-        .body(axum::body::Body::empty())
-        .unwrap()
-}
-
 /// Configuration for the HTTP acceptor server
 pub struct HttpAcceptorConfig {
     pub addr: SocketAddr,
@@ -564,8 +696,20 @@ pub async fn serve_otlp_http(
         config.wal_manager.clone(),
     ));
 
+    // Create trace handler with shared resources (same WAL + Flight path as gRPC)
+    let trace_handler = Arc::new(TraceHandler::new(
+        config.flight_transport.clone(),
+        config.wal_manager.clone(),
+    ));
+
     // Build combined router with health, traces, Prometheus, and profiles endpoints
     let app = acceptor_router()
+        .merge(traces_http_router(
+            config.authenticator.clone(),
+            trace_handler,
+            config.rate_limiter.clone(),
+            config.storage_usage.clone(),
+        ))
         .merge(prometheus_router(
             config.authenticator.clone(),
             prometheus_handler,
@@ -577,6 +721,7 @@ pub async fn serve_otlp_http(
             config.storage_usage.clone(),
         ));
 
+    tracing::info!("OTLP traces endpoint enabled at POST /v1/traces");
     tracing::info!("Prometheus remote_write endpoint enabled at POST /api/v1/write");
     tracing::info!("OTLP profiles endpoint enabled at POST /v1development/profiles");
 

--- a/src/acceptor/tests/otlp_http_traces.rs
+++ b/src/acceptor/tests/otlp_http_traces.rs
@@ -1,0 +1,329 @@
+//! Integration tests for the OTLP/HTTP traces ingestion endpoint
+//!
+//! Covers the full flow: HTTP request -> auth middleware -> decode
+//! (protobuf and JSON) -> trace handler -> WAL durability.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acceptor::handler::WalManager;
+use acceptor::handler::otlp_grpc::TraceHandler;
+use acceptor::traces_http_router;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use common::auth::Authenticator;
+use common::config::Configuration;
+use common::flight::transport::InMemoryFlightTransport;
+use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+use common::wal::{WalConfig, WalOperation};
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, span};
+use prost::Message;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const TEST_TENANT: &str = "test-tenant";
+const TEST_DATASET: &str = "default";
+const TEST_API_KEY: &str = "test-api-key";
+
+/// Build a minimal but valid OTLP trace export request with one span.
+fn sample_trace_request() -> ExportTraceServiceRequest {
+    ExportTraceServiceRequest {
+        resource_spans: vec![ResourceSpans {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("test-service".to_string())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            scope_spans: vec![ScopeSpans {
+                scope: None,
+                spans: vec![Span {
+                    trace_id: vec![
+                        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+                        0x0d, 0x0e, 0x0f, 0x10,
+                    ],
+                    span_id: vec![0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18],
+                    name: "test-span".to_string(),
+                    kind: span::SpanKind::Server as i32,
+                    start_time_unix_nano: 1_700_000_000_000_000_000,
+                    end_time_unix_nano: 1_700_000_001_000_000_000,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// Set up the OTLP/HTTP traces router with an authenticated test tenant.
+///
+/// Returns the router, the WAL manager (to verify durability), and the
+/// temp dir keeping catalog/WAL files alive.
+async fn setup_traces_test() -> (axum::Router, Arc<WalManager>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+
+    let catalog_db_path = temp_dir.path().join("catalog.db");
+    let catalog_dsn = format!("sqlite://{}", catalog_db_path.display());
+
+    let mut config = Configuration::default();
+    config.discovery = Some(common::config::DiscoveryConfig {
+        dsn: catalog_dsn.clone(),
+        heartbeat_interval: Duration::from_secs(30),
+        poll_interval: Duration::from_secs(60),
+        ttl: Duration::from_secs(300),
+    });
+
+    config.schema = common::config::SchemaConfig {
+        catalog_type: "sql".to_string(),
+        catalog_uri: catalog_dsn,
+        default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
+    };
+
+    config.auth = common::config::AuthConfig {
+        admin_api_key: None,
+        internal_service_key: None,
+        default_limits: Default::default(),
+        storage_usage_refresh_interval: Duration::from_secs(60),
+        tenants: vec![common::config::TenantConfig {
+            id: TEST_TENANT.to_string(),
+            slug: TEST_TENANT.to_string(),
+            name: "Test Tenant".to_string(),
+            default_dataset: Some(TEST_DATASET.to_string()),
+            datasets: vec![common::config::DatasetConfig {
+                id: TEST_DATASET.to_string(),
+                slug: TEST_DATASET.to_string(),
+                is_default: true,
+                storage: None,
+            }],
+            api_keys: vec![common::config::ApiKeyConfig {
+                key: TEST_API_KEY.to_string(),
+                name: Some("Test Key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }],
+    };
+
+    let service_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Acceptor,
+        "127.0.0.1:4317".to_string(),
+    )
+    .await
+    .expect("Failed to initialize service bootstrap");
+
+    let catalog = Arc::new(service_bootstrap.catalog().clone());
+    let auth_config = service_bootstrap.config().auth.clone();
+
+    let flight_transport = Arc::new(InMemoryFlightTransport::new(service_bootstrap));
+
+    let wal_dir = temp_dir.path().join("wal");
+    let wal_manager = Arc::new(WalManager::new(
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir),
+    ));
+
+    let rate_limiter = Arc::new(common::ratelimit::TenantRateLimiter::from_auth_config(
+        &auth_config,
+    ));
+    let storage_usage =
+        Arc::new(common::storage_usage::StorageUsageTracker::from_auth_config(&auth_config));
+
+    let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+
+    let trace_handler = Arc::new(TraceHandler::new(flight_transport, wal_manager.clone()));
+
+    let app = traces_http_router(authenticator, trace_handler, rate_limiter, storage_usage);
+
+    (app, wal_manager, temp_dir)
+}
+
+/// Count WAL entries recorded for the test tenant's traces WAL.
+async fn traces_wal_entry_count(wal_manager: &WalManager) -> usize {
+    let wal = wal_manager
+        .get_wal(TEST_TENANT, TEST_DATASET, "traces")
+        .await
+        .expect("Failed to open traces WAL");
+    wal.get_entries()
+        .await
+        .expect("Failed to read WAL entries")
+        .iter()
+        .filter(|e| matches!(e.operation, WalOperation::WriteTraces))
+        .count()
+}
+
+#[tokio::test]
+async fn otlp_http_traces_protobuf_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    let body = sample_trace_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated protobuf trace export"
+    );
+    assert_eq!(
+        traces_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the trace export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_traces_json_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    // OTLP/JSON (protojson) encoding: trace/span ids are hex strings.
+    let body = serde_json::to_vec(&sample_trace_request()).unwrap();
+    let json_text = String::from_utf8(body.clone()).unwrap();
+    assert!(
+        json_text.contains("0102030405060708090a0b0c0d0e0f10"),
+        "OTLP/JSON must hex-encode trace ids, got: {json_text}"
+    );
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated JSON trace export"
+    );
+    assert_eq!(
+        traces_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the trace export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_traces_invalid_api_key_is_unauthorized() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    let body = sample_trace_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", "Bearer wrong-key")
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for an invalid API key"
+    );
+    assert_eq!(
+        traces_wal_entry_count(&wal_manager).await,
+        0,
+        "Rejected exports must not be recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_traces_missing_auth_headers_is_rejected() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    let body = sample_trace_request().encode_to_vec();
+
+    // No Authorization / X-Tenant-ID headers at all.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a request without auth headers"
+    );
+    assert_eq!(traces_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_traces_malformed_protobuf_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(vec![0xff, 0xfe, 0xfd, 0xfc]))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed protobuf payload"
+    );
+    assert_eq!(traces_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_traces_malformed_json_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_traces_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/traces")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from("{\"resourceSpans\": \"not-an-array\"}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed JSON payload"
+    );
+    assert_eq!(traces_wal_entry_count(&wal_manager).await, 0);
+}


### PR DESCRIPTION
## Summary

Fixes #750

`POST /v1/traces` on the OTLP/HTTP port (4318) was a stub: it deserialized the body as arbitrary JSON, logged the payload size, and returned 200 — silently discarding all spans, and without any authentication. The gRPC path on 4317 was fully implemented.

This implements real OTLP/HTTP trace ingestion with the same semantics as the gRPC path:

- **Both OTLP/HTTP encodings per spec**: `application/x-protobuf` (`ExportTraceServiceRequest`) and `application/json` (protojson encoding — trace/span ids as hex strings, handled by opentelemetry-proto's `with-serde` support).
- **Tenant auth**: the route now goes through the same `auth_middleware` as the Prometheus remote_write and profiles HTTP routes (`Authorization: Bearer <key>` + `X-Tenant-ID`, dataset falling back to the tenant default).
- **Reuses the gRPC handler**: `TraceHandler::handle_grpc_otlp_traces` — WAL write + flush for durability, then Flight forward to the writer (WAL retry consumer covers forward failures).
- **Rate limiting / storage quotas**: same per-tenant ingest rate limit and storage quota checks as the profiles HTTP route (HTTP 429).
- **Proper responses**: 200 with an `ExportTraceServiceResponse` body in the request's encoding, 400 for malformed payloads, 401/403 for auth failures (400 for missing auth headers, consistent with the other HTTP routes).
- The stub `handle_traces` is removed; `acceptor_router()` now only serves `/health`, and the traces route lives in a new `traces_http_router` mirroring `profiles_http_router`.

No `/v1/logs` or `/v1/metrics` HTTP routes existed, so the change stays scoped to traces.

## Tests (TDD, `src/acceptor/tests/otlp_http_traces.rs`)

- `otlp_http_traces_protobuf_with_auth_lands_in_wal`
- `otlp_http_traces_json_with_auth_lands_in_wal` (asserts hex-encoded trace ids in the JSON payload)
- `otlp_http_traces_invalid_api_key_is_unauthorized` (401, nothing in WAL)
- `otlp_http_traces_missing_auth_headers_is_rejected` (400, nothing in WAL)
- `otlp_http_traces_malformed_protobuf_is_bad_request`
- `otlp_http_traces_malformed_json_is_bad_request`

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features`, and `cargo test -p acceptor` (62 tests) all pass.