### PR TITLE
feat(acceptor): add OTLP/HTTP logs and metrics ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "prost",
+ "serde",
  "serde_json",
  "tempfile",
  "tikv-jemallocator",

--- a/docs/users/sending-otlp.md
+++ b/docs/users/sending-otlp.md
@@ -13,12 +13,12 @@ sources:
 Goal: point an OpenTelemetry SDK or Collector at SignalDB so traces, logs,
 and metrics are ingested.
 
-SignalDB accepts OTLP over **gRPC on port 4317** for all three signals.
-The OTLP/HTTP port (4318) additionally ingests **traces** at
-`POST /v1/traces` (protobuf and JSON bodies, authenticated); logs and
-metrics remain gRPC-only — see
-[OTLP/HTTP support](#otlphttp-support-is-partial) below. Port 4318 also
-serves [Prometheus remote_write](prometheus-remote-write.md).
+SignalDB accepts OTLP over **gRPC on port 4317** and **HTTP on port
+4318** for all three signals. The OTLP/HTTP endpoints are
+`POST /v1/traces`, `POST /v1/logs`, and `POST /v1/metrics` (protobuf and
+JSON bodies, authenticated) — see
+[OTLP/HTTP support](#otlphttp-support) below. Port 4318 also serves
+[Prometheus remote_write](prometheus-remote-write.md).
 
 ## Prerequisites
 
@@ -31,16 +31,18 @@ serves [Prometheus remote_write](prometheus-remote-write.md).
 
 ### 1. Choose the endpoint
 
-Use the gRPC endpoint — it supports all signals:
+Both protocols support all three signals. gRPC:
 
 ```text
 http://<acceptor-host>:4317
 ```
 
-For traces only, the OTLP/HTTP endpoint is also available:
+OTLP/HTTP:
 
 ```text
 http://<acceptor-host>:4318/v1/traces
+http://<acceptor-host>:4318/v1/logs
+http://<acceptor-host>:4318/v1/metrics
 ```
 
 ### 2. Attach the auth metadata
@@ -105,24 +107,24 @@ successful export response means the data is durable.
 | Signal | OTLP/gRPC :4317 | OTLP/HTTP :4318 | Stored as |
 |---|---|---|---|
 | Traces | yes | yes (`POST /v1/traces`) | `traces` table |
-| Logs | yes | no | `logs` table |
-| Metrics | yes | no | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
+| Logs | yes | yes (`POST /v1/logs`) | `logs` table |
+| Metrics | yes | yes (`POST /v1/metrics`) | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
 | Profiles | yes | yes (`POST /v1development/profiles`) | `profiles` table (see [profiles](profiles.md)) |
 
-## OTLP/HTTP support is partial
+## OTLP/HTTP support
 
-The HTTP server on port 4318 ingests **traces** at `POST /v1/traces` and
+The HTTP server on port 4318 ingests **traces** at `POST /v1/traces`,
+**logs** at `POST /v1/logs`, **metrics** at `POST /v1/metrics`, and
 **profiles** at `POST /v1development/profiles` (see
-[profiles](profiles.md)). Both accept `application/x-protobuf` and
+[profiles](profiles.md)). All accept `application/x-protobuf` and
 `application/json` (protojson encoding: trace and span IDs are hex
 strings) request bodies, require the same auth headers as gRPC, and
 enforce per-tenant rate limits and storage quotas. Compressed
 (`Content-Encoding: gzip`) request bodies are not supported — export
 uncompressed.
 
-A successful trace export returns `200 OK` with an
-`ExportTraceServiceResponse` body in the same encoding as the request.
-Error responses:
+A successful export returns `200 OK` with an `Export*ServiceResponse`
+body in the same encoding as the request. Error responses:
 
 | Status | Meaning |
 |---|---|
@@ -131,11 +133,7 @@ Error responses:
 | `403 Forbidden` | Key does not belong to the tenant/dataset you named |
 | `429 Too Many Requests` | Per-tenant ingest rate limit or storage quota hit |
 
-There are no `/v1/logs` or `/v1/metrics` HTTP routes — an `http/protobuf`
-or `http/json` exporter pointed at SignalDB for logs or metrics gets
-`404 Not Found`. Use gRPC on :4317 for those signals.
-
-To use OTLP/HTTP for traces from the OpenTelemetry Collector:
+To use OTLP/HTTP from the OpenTelemetry Collector:
 
 ```yaml
 exporters:
@@ -150,6 +148,10 @@ service:
   pipelines:
     traces:
       exporters: [otlphttp/signaldb]
+    logs:
+      exporters: [otlphttp/signaldb]
+    metrics:
+      exporters: [otlphttp/signaldb]
 ```
 
 ## Troubleshooting
@@ -162,6 +164,5 @@ service:
 | `PERMISSION_DENIED` | Key does not belong to the tenant/dataset you named | Use a key issued for that tenant |
 | `RESOURCE_EXHAUSTED` | Per-tenant ingest rate limit hit | Back off and retry; ask your operator about tenant limits |
 | `RESOURCE_EXHAUSTED` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
-| `429 Too Many Requests` on `POST /v1/traces` or `POST /v1development/profiles` | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | Back off and retry (rate limit), or talk to your operator (quota) |
-| `400 Bad Request` on `POST /v1/traces` with a JSON body | Payload is not valid protojson (e.g. base64 trace IDs instead of hex) | Use a protojson-compliant encoder; trace/span IDs must be hex strings |
-| `404 Not Found` on `:4318/v1/logs` or `:4318/v1/metrics` | Logs and metrics have no OTLP/HTTP routes | Switch those pipelines to gRPC on :4317 |
+| `429 Too Many Requests` on an OTLP/HTTP endpoint | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | Back off and retry (rate limit), or talk to your operator (quota) |
+| `400 Bad Request` on an OTLP/HTTP endpoint with a JSON body | Payload is not valid protojson (e.g. base64 trace IDs instead of hex) | Use a protojson-compliant encoder; trace/span IDs must be hex strings |

--- a/src/acceptor/Cargo.toml
+++ b/src/acceptor/Cargo.toml
@@ -29,6 +29,7 @@ anyhow.workspace = true
 clap.workspace = true
 axum.workspace = true
 
+serde.workspace = true
 serde_json.workspace = true
 
 opentelemetry.workspace = true

--- a/src/acceptor/src/lib.rs
+++ b/src/acceptor/src/lib.rs
@@ -400,12 +400,52 @@ pub fn profiles_http_router(
         ))
 }
 
-/// Shared state for the OTLP/HTTP traces endpoint
-#[derive(Clone)]
-pub struct TracesHandlerState {
-    pub handler: Arc<TraceHandler>,
+/// Shared per-signal state for OTLP/HTTP export endpoints
+pub struct OtlpHttpState<H> {
+    pub handler: Arc<H>,
     pub rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
     pub storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
+}
+
+// Manual impl: `#[derive(Clone)]` would require `H: Clone`, but only the
+// `Arc`s are cloned.
+impl<H> Clone for OtlpHttpState<H> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            rate_limiter: self.rate_limiter.clone(),
+            storage_quota: self.storage_quota.clone(),
+        }
+    }
+}
+
+/// Shared state for the OTLP/HTTP traces endpoint
+pub type TracesHandlerState = OtlpHttpState<TraceHandler>;
+/// Shared state for the OTLP/HTTP logs endpoint
+pub type LogsHandlerState = OtlpHttpState<LogHandler>;
+/// Shared state for the OTLP/HTTP metrics endpoint
+pub type MetricsHandlerState = OtlpHttpState<MetricsHandler>;
+
+/// Mount a single OTLP/HTTP export route behind the shared auth middleware
+/// and HTTP self-monitoring metrics.
+fn otlp_signal_router<H: Send + Sync + 'static>(
+    path: &str,
+    method_router: axum::routing::MethodRouter,
+    authenticator: Arc<Authenticator>,
+    state: OtlpHttpState<H>,
+) -> Router {
+    use axum::middleware;
+
+    Router::new()
+        .route(path, method_router)
+        .layer(Extension(state))
+        .layer(middleware::from_fn(move |req, next| {
+            let auth = authenticator.clone();
+            async move { auth_middleware(auth, req, next).await }
+        }))
+        .layer(middleware::from_fn(
+            common::self_monitoring::http_metrics_middleware,
+        ))
 }
 
 /// Create a router for the OTLP/HTTP traces ingestion endpoint with authentication
@@ -421,24 +461,153 @@ pub fn traces_http_router(
     rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
     storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
 ) -> Router {
-    use axum::middleware;
+    otlp_signal_router(
+        "/v1/traces",
+        post(handle_http_traces),
+        authenticator,
+        OtlpHttpState {
+            handler: trace_handler,
+            rate_limiter,
+            storage_quota,
+        },
+    )
+}
 
-    let state = TracesHandlerState {
-        handler: trace_handler,
-        rate_limiter,
-        storage_quota,
+/// Create a router for the OTLP/HTTP logs ingestion endpoint with authentication
+///
+/// Handles `POST /v1/logs` with protobuf (`application/x-protobuf`) or JSON
+/// (`application/json`, protojson encoding) request bodies, matching the
+/// OTLP/HTTP specification. Per-tenant ingest rate limits and storage quotas
+/// are enforced with HTTP 429; both are unlimited unless configured.
+pub fn logs_http_router(
+    authenticator: Arc<Authenticator>,
+    log_handler: Arc<LogHandler>,
+    rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
+) -> Router {
+    otlp_signal_router(
+        "/v1/logs",
+        post(handle_http_logs),
+        authenticator,
+        OtlpHttpState {
+            handler: log_handler,
+            rate_limiter,
+            storage_quota,
+        },
+    )
+}
+
+/// Create a router for the OTLP/HTTP metrics ingestion endpoint with authentication
+///
+/// Handles `POST /v1/metrics` with protobuf (`application/x-protobuf`) or
+/// JSON (`application/json`, protojson encoding) request bodies, matching the
+/// OTLP/HTTP specification. Per-tenant ingest rate limits and storage quotas
+/// are enforced with HTTP 429; both are unlimited unless configured.
+pub fn metrics_http_router(
+    authenticator: Arc<Authenticator>,
+    metrics_handler: Arc<MetricsHandler>,
+    rate_limiter: Arc<common::ratelimit::TenantRateLimiter>,
+    storage_quota: Arc<common::storage_usage::StorageUsageTracker>,
+) -> Router {
+    otlp_signal_router(
+        "/v1/metrics",
+        post(handle_http_metrics),
+        authenticator,
+        OtlpHttpState {
+            handler: metrics_handler,
+            rate_limiter,
+            storage_quota,
+        },
+    )
+}
+
+/// Shared OTLP/HTTP export plumbing: enforce per-tenant rate limits and
+/// storage quotas, decode the body by content type (protobuf or protojson),
+/// dispatch to the per-signal handler (WAL durability + Flight forward), and
+/// answer with an empty `Export*ServiceResponse` in the request's encoding.
+async fn handle_otlp_http_export<Req, Resp, F, Fut>(
+    signal: &'static str,
+    rate_limiter: &common::ratelimit::TenantRateLimiter,
+    storage_quota: &common::storage_usage::StorageUsageTracker,
+    tenant_context: &common::auth::TenantContext,
+    headers: &axum::http::HeaderMap,
+    body: axum::body::Bytes,
+    dispatch: F,
+) -> axum::response::Response<axum::body::Body>
+where
+    Req: prost::Message + Default + serde::de::DeserializeOwned,
+    Resp: prost::Message + Default,
+    F: FnOnce(Req) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    // Per-tenant ingest rate limiting (HTTP 429 with the reason)
+    if let Err(e) = rate_limiter.check_ingest(&tenant_context.tenant_id, body.len()) {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
+
+    // Per-tenant storage quota: a tenant at or over max_storage_bytes
+    // must free space (or get a raised quota) before ingesting more.
+    if let Err(e) = storage_quota.check_ingest(&tenant_context.tenant_id) {
+        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
+    }
+
+    let is_json = otlp_http_content_type_is_json(headers);
+
+    let request = if is_json {
+        match serde_json::from_slice::<Req>(&body) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/JSON {signal} payload: {e}"),
+                );
+            }
+        }
+    } else {
+        match Req::decode(body.as_ref()) {
+            Ok(request) => request,
+            Err(e) => {
+                return otlp_http_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    format!("invalid OTLP/protobuf {signal} payload: {e}"),
+                );
+            }
+        }
     };
 
-    Router::new()
-        .route("/v1/traces", post(handle_http_traces))
-        .layer(Extension(state))
-        .layer(middleware::from_fn(move |req, next| {
-            let auth = authenticator.clone();
-            async move { auth_middleware(auth, req, next).await }
-        }))
-        .layer(middleware::from_fn(
-            common::self_monitoring::http_metrics_middleware,
-        ))
+    match dispatch(request).await {
+        Ok(()) => {
+            // Per OTLP/HTTP spec the response body is a full
+            // Export*ServiceResponse in the same encoding as the request.
+            let builder = axum::response::Response::builder().status(axum::http::StatusCode::OK);
+            let response = if is_json {
+                builder
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from("{}"))
+            } else {
+                builder
+                    .header(axum::http::header::CONTENT_TYPE, "application/x-protobuf")
+                    .body(axum::body::Body::from(Resp::default().encode_to_vec()))
+            };
+            match response {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::error!(error = %e, signal, "Failed to build OTLP/HTTP export response");
+                    otlp_http_error(
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to build export response".to_string(),
+                    )
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, signal, "Failed to durably accept export via HTTP");
+            otlp_http_error(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                format!("failed to durably accept {signal} export: {e:#}"),
+            )
+        }
+    }
 }
 
 /// OTLP/HTTP traces export: decode by content type, hand off to the
@@ -457,88 +626,90 @@ async fn handle_http_traces(
     crate::middleware::TenantContextExtractor(tenant_context): crate::middleware::TenantContextExtractor,
     body: axum::body::Bytes,
 ) -> axum::response::Response<axum::body::Body> {
-    use opentelemetry_proto::tonic::collector::trace::v1::{
-        ExportTraceServiceRequest, ExportTraceServiceResponse,
-    };
-    use prost::Message;
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse;
 
-    // Per-tenant ingest rate limiting (HTTP 429 with the reason)
-    if let Err(e) = state
-        .rate_limiter
-        .check_ingest(&tenant_context.tenant_id, body.len())
-    {
-        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
-    }
+    handle_otlp_http_export::<_, ExportTraceServiceResponse, _, _>(
+        "traces",
+        &state.rate_limiter,
+        &state.storage_quota,
+        &tenant_context,
+        &headers,
+        body,
+        |request| {
+            state
+                .handler
+                .handle_grpc_otlp_traces(&tenant_context, request)
+        },
+    )
+    .await
+}
 
-    // Per-tenant storage quota: a tenant at or over max_storage_bytes
-    // must free space (or get a raised quota) before ingesting more.
-    if let Err(e) = state.storage_quota.check_ingest(&tenant_context.tenant_id) {
-        return otlp_http_error(axum::http::StatusCode::TOO_MANY_REQUESTS, e.to_string());
-    }
+/// OTLP/HTTP logs export: decode by content type, hand off to the
+/// log handler (WAL durability + Flight forward), and answer with an
+/// `ExportLogsServiceResponse` in the request's encoding.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        tenant_id = %tenant_context.tenant_id,
+        dataset_id = %tenant_context.dataset_id
+    )
+)]
+async fn handle_http_logs(
+    Extension(state): Extension<LogsHandlerState>,
+    headers: axum::http::HeaderMap,
+    crate::middleware::TenantContextExtractor(tenant_context): crate::middleware::TenantContextExtractor,
+    body: axum::body::Bytes,
+) -> axum::response::Response<axum::body::Body> {
+    use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceResponse;
 
-    let is_json = otlp_http_content_type_is_json(&headers);
+    handle_otlp_http_export::<_, ExportLogsServiceResponse, _, _>(
+        "logs",
+        &state.rate_limiter,
+        &state.storage_quota,
+        &tenant_context,
+        &headers,
+        body,
+        |request| {
+            state
+                .handler
+                .handle_grpc_otlp_logs(&tenant_context, request)
+        },
+    )
+    .await
+}
 
-    let request = if is_json {
-        match serde_json::from_slice::<ExportTraceServiceRequest>(&body) {
-            Ok(request) => request,
-            Err(e) => {
-                return otlp_http_error(
-                    axum::http::StatusCode::BAD_REQUEST,
-                    format!("invalid OTLP/JSON traces payload: {e}"),
-                );
-            }
-        }
-    } else {
-        match ExportTraceServiceRequest::decode(body.as_ref()) {
-            Ok(request) => request,
-            Err(e) => {
-                return otlp_http_error(
-                    axum::http::StatusCode::BAD_REQUEST,
-                    format!("invalid OTLP/protobuf traces payload: {e}"),
-                );
-            }
-        }
-    };
+/// OTLP/HTTP metrics export: decode by content type, hand off to the
+/// metrics handler (WAL durability + Flight forward), and answer with an
+/// `ExportMetricsServiceResponse` in the request's encoding.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        tenant_id = %tenant_context.tenant_id,
+        dataset_id = %tenant_context.dataset_id
+    )
+)]
+async fn handle_http_metrics(
+    Extension(state): Extension<MetricsHandlerState>,
+    headers: axum::http::HeaderMap,
+    crate::middleware::TenantContextExtractor(tenant_context): crate::middleware::TenantContextExtractor,
+    body: axum::body::Bytes,
+) -> axum::response::Response<axum::body::Body> {
+    use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse;
 
-    match state
-        .handler
-        .handle_grpc_otlp_traces(&tenant_context, request)
-        .await
-    {
-        Ok(()) => {
-            // Per OTLP/HTTP spec the response body is a full
-            // ExportTraceServiceResponse in the same encoding as the request.
-            let builder = axum::response::Response::builder().status(axum::http::StatusCode::OK);
-            let response = if is_json {
-                builder
-                    .header(axum::http::header::CONTENT_TYPE, "application/json")
-                    .body(axum::body::Body::from("{}"))
-            } else {
-                builder
-                    .header(axum::http::header::CONTENT_TYPE, "application/x-protobuf")
-                    .body(axum::body::Body::from(
-                        ExportTraceServiceResponse::default().encode_to_vec(),
-                    ))
-            };
-            match response {
-                Ok(response) => response,
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to build OTLP/HTTP traces response");
-                    otlp_http_error(
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        "failed to build export response".to_string(),
-                    )
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to durably accept traces export via HTTP");
-            otlp_http_error(
-                axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                format!("failed to durably accept traces export: {e:#}"),
-            )
-        }
-    }
+    handle_otlp_http_export::<_, ExportMetricsServiceResponse, _, _>(
+        "metrics",
+        &state.rate_limiter,
+        &state.storage_quota,
+        &tenant_context,
+        &headers,
+        body,
+        |request| {
+            state
+                .handler
+                .handle_grpc_otlp_metrics(&tenant_context, request)
+        },
+    )
+    .await
 }
 
 /// Whether an OTLP/HTTP request body is JSON-encoded.
@@ -702,11 +873,36 @@ pub async fn serve_otlp_http(
         config.wal_manager.clone(),
     ));
 
-    // Build combined router with health, traces, Prometheus, and profiles endpoints
+    // Create log handler with shared resources (same WAL + Flight path as gRPC)
+    let log_handler = Arc::new(LogHandler::new(
+        config.flight_transport.clone(),
+        config.wal_manager.clone(),
+    ));
+
+    // Create metrics handler with shared resources (same WAL + Flight path as gRPC)
+    let metrics_handler = Arc::new(MetricsHandler::new(
+        config.flight_transport.clone(),
+        config.wal_manager.clone(),
+    ));
+
+    // Build combined router with health, traces, logs, metrics, Prometheus,
+    // and profiles endpoints
     let app = acceptor_router()
         .merge(traces_http_router(
             config.authenticator.clone(),
             trace_handler,
+            config.rate_limiter.clone(),
+            config.storage_usage.clone(),
+        ))
+        .merge(logs_http_router(
+            config.authenticator.clone(),
+            log_handler,
+            config.rate_limiter.clone(),
+            config.storage_usage.clone(),
+        ))
+        .merge(metrics_http_router(
+            config.authenticator.clone(),
+            metrics_handler,
             config.rate_limiter.clone(),
             config.storage_usage.clone(),
         ))
@@ -722,6 +918,8 @@ pub async fn serve_otlp_http(
         ));
 
     tracing::info!("OTLP traces endpoint enabled at POST /v1/traces");
+    tracing::info!("OTLP logs endpoint enabled at POST /v1/logs");
+    tracing::info!("OTLP metrics endpoint enabled at POST /v1/metrics");
     tracing::info!("Prometheus remote_write endpoint enabled at POST /api/v1/write");
     tracing::info!("OTLP profiles endpoint enabled at POST /v1development/profiles");
 

--- a/src/acceptor/tests/otlp_http_logs.rs
+++ b/src/acceptor/tests/otlp_http_logs.rs
@@ -1,0 +1,321 @@
+//! Integration tests for the OTLP/HTTP logs ingestion endpoint
+//!
+//! Covers the full flow: HTTP request -> auth middleware -> decode
+//! (protobuf and JSON) -> log handler -> WAL durability.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acceptor::handler::WalManager;
+use acceptor::handler::otlp_log_handler::LogHandler;
+use acceptor::logs_http_router;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use common::auth::Authenticator;
+use common::config::Configuration;
+use common::flight::transport::InMemoryFlightTransport;
+use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+use common::wal::{WalConfig, WalOperation};
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use prost::Message;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const TEST_TENANT: &str = "test-tenant";
+const TEST_DATASET: &str = "default";
+const TEST_API_KEY: &str = "test-api-key";
+
+/// Build a minimal but valid OTLP logs export request with one record.
+fn sample_logs_request() -> ExportLogsServiceRequest {
+    ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("test-service".to_string())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    severity_text: "INFO".to_string(),
+                    body: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue(
+                            "test log message".to_string(),
+                        )),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// Set up the OTLP/HTTP logs router with an authenticated test tenant.
+///
+/// Returns the router, the WAL manager (to verify durability), and the
+/// temp dir keeping catalog/WAL files alive.
+async fn setup_logs_test() -> (axum::Router, Arc<WalManager>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+
+    let catalog_db_path = temp_dir.path().join("catalog.db");
+    let catalog_dsn = format!("sqlite://{}", catalog_db_path.display());
+
+    let mut config = Configuration::default();
+    config.discovery = Some(common::config::DiscoveryConfig {
+        dsn: catalog_dsn.clone(),
+        heartbeat_interval: Duration::from_secs(30),
+        poll_interval: Duration::from_secs(60),
+        ttl: Duration::from_secs(300),
+    });
+
+    config.schema = common::config::SchemaConfig {
+        catalog_type: "sql".to_string(),
+        catalog_uri: catalog_dsn,
+        default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
+    };
+
+    config.auth = common::config::AuthConfig {
+        admin_api_key: None,
+        internal_service_key: None,
+        default_limits: Default::default(),
+        storage_usage_refresh_interval: Duration::from_secs(60),
+        tenants: vec![common::config::TenantConfig {
+            id: TEST_TENANT.to_string(),
+            slug: TEST_TENANT.to_string(),
+            name: "Test Tenant".to_string(),
+            default_dataset: Some(TEST_DATASET.to_string()),
+            datasets: vec![common::config::DatasetConfig {
+                id: TEST_DATASET.to_string(),
+                slug: TEST_DATASET.to_string(),
+                is_default: true,
+                storage: None,
+            }],
+            api_keys: vec![common::config::ApiKeyConfig {
+                key: TEST_API_KEY.to_string(),
+                name: Some("Test Key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }],
+    };
+
+    let service_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Acceptor,
+        "127.0.0.1:4317".to_string(),
+    )
+    .await
+    .expect("Failed to initialize service bootstrap");
+
+    let catalog = Arc::new(service_bootstrap.catalog().clone());
+    let auth_config = service_bootstrap.config().auth.clone();
+
+    let flight_transport = Arc::new(InMemoryFlightTransport::new(service_bootstrap));
+
+    let wal_dir = temp_dir.path().join("wal");
+    let wal_manager = Arc::new(WalManager::new(
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir),
+    ));
+
+    let rate_limiter = Arc::new(common::ratelimit::TenantRateLimiter::from_auth_config(
+        &auth_config,
+    ));
+    let storage_usage =
+        Arc::new(common::storage_usage::StorageUsageTracker::from_auth_config(&auth_config));
+
+    let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+
+    let log_handler = Arc::new(LogHandler::new(flight_transport, wal_manager.clone()));
+
+    let app = logs_http_router(authenticator, log_handler, rate_limiter, storage_usage);
+
+    (app, wal_manager, temp_dir)
+}
+
+/// Count WAL entries recorded for the test tenant's logs WAL.
+async fn logs_wal_entry_count(wal_manager: &WalManager) -> usize {
+    let wal = wal_manager
+        .get_wal(TEST_TENANT, TEST_DATASET, "logs")
+        .await
+        .expect("Failed to open logs WAL");
+    wal.get_entries()
+        .await
+        .expect("Failed to read WAL entries")
+        .iter()
+        .filter(|e| matches!(e.operation, WalOperation::WriteLogs))
+        .count()
+}
+
+#[tokio::test]
+async fn otlp_http_logs_protobuf_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let body = sample_logs_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated protobuf logs export"
+    );
+    assert_eq!(
+        logs_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the logs export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_logs_json_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let body = serde_json::to_vec(&sample_logs_request()).unwrap();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated JSON logs export"
+    );
+    assert_eq!(
+        logs_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the logs export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_logs_invalid_api_key_is_unauthorized() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let body = sample_logs_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", "Bearer wrong-key")
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for an invalid API key"
+    );
+    assert_eq!(
+        logs_wal_entry_count(&wal_manager).await,
+        0,
+        "Rejected exports must not be recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_logs_missing_auth_headers_is_rejected() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let body = sample_logs_request().encode_to_vec();
+
+    // No Authorization / X-Tenant-ID headers at all.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a request without auth headers"
+    );
+    assert_eq!(logs_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_logs_malformed_protobuf_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(vec![0xff, 0xfe, 0xfd, 0xfc]))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed protobuf payload"
+    );
+    assert_eq!(logs_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_logs_malformed_json_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_logs_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/logs")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from("{\"resourceLogs\": \"not-an-array\"}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed JSON payload"
+    );
+    assert_eq!(logs_wal_entry_count(&wal_manager).await, 0);
+}

--- a/src/acceptor/tests/otlp_http_metrics.rs
+++ b/src/acceptor/tests/otlp_http_metrics.rs
@@ -1,0 +1,326 @@
+//! Integration tests for the OTLP/HTTP metrics ingestion endpoint
+//!
+//! Covers the full flow: HTTP request -> auth middleware -> decode
+//! (protobuf and JSON) -> metrics handler -> WAL durability.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use acceptor::handler::WalManager;
+use acceptor::handler::otlp_metrics_handler::MetricsHandler;
+use acceptor::metrics_http_router;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use common::auth::Authenticator;
+use common::config::Configuration;
+use common::flight::transport::InMemoryFlightTransport;
+use common::service_bootstrap::{ServiceBootstrap, ServiceType};
+use common::wal::{WalConfig, WalOperation};
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+use opentelemetry_proto::tonic::metrics::v1::{
+    Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric, number_data_point,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use prost::Message;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const TEST_TENANT: &str = "test-tenant";
+const TEST_DATASET: &str = "default";
+const TEST_API_KEY: &str = "test-api-key";
+
+/// Build a minimal but valid OTLP metrics export request with one gauge.
+fn sample_metrics_request() -> ExportMetricsServiceRequest {
+    ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("test-service".to_string())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            scope_metrics: vec![ScopeMetrics {
+                scope: None,
+                metrics: vec![Metric {
+                    name: "test.gauge".to_string(),
+                    description: "a test gauge".to_string(),
+                    unit: "1".to_string(),
+                    data: Some(metric::Data::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            time_unix_nano: 1_700_000_000_000_000_000,
+                            value: Some(number_data_point::Value::AsDouble(42.0)),
+                            ..Default::default()
+                        }],
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// Set up the OTLP/HTTP metrics router with an authenticated test tenant.
+///
+/// Returns the router, the WAL manager (to verify durability), and the
+/// temp dir keeping catalog/WAL files alive.
+async fn setup_metrics_test() -> (axum::Router, Arc<WalManager>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+
+    let catalog_db_path = temp_dir.path().join("catalog.db");
+    let catalog_dsn = format!("sqlite://{}", catalog_db_path.display());
+
+    let mut config = Configuration::default();
+    config.discovery = Some(common::config::DiscoveryConfig {
+        dsn: catalog_dsn.clone(),
+        heartbeat_interval: Duration::from_secs(30),
+        poll_interval: Duration::from_secs(60),
+        ttl: Duration::from_secs(300),
+    });
+
+    config.schema = common::config::SchemaConfig {
+        catalog_type: "sql".to_string(),
+        catalog_uri: catalog_dsn,
+        default_schemas: common::config::DefaultSchemas::default(),
+        materialized_labels: Default::default(),
+    };
+
+    config.auth = common::config::AuthConfig {
+        admin_api_key: None,
+        internal_service_key: None,
+        default_limits: Default::default(),
+        storage_usage_refresh_interval: Duration::from_secs(60),
+        tenants: vec![common::config::TenantConfig {
+            id: TEST_TENANT.to_string(),
+            slug: TEST_TENANT.to_string(),
+            name: "Test Tenant".to_string(),
+            default_dataset: Some(TEST_DATASET.to_string()),
+            datasets: vec![common::config::DatasetConfig {
+                id: TEST_DATASET.to_string(),
+                slug: TEST_DATASET.to_string(),
+                is_default: true,
+                storage: None,
+            }],
+            api_keys: vec![common::config::ApiKeyConfig {
+                key: TEST_API_KEY.to_string(),
+                name: Some("Test Key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }],
+    };
+
+    let service_bootstrap = ServiceBootstrap::new(
+        config.clone(),
+        ServiceType::Acceptor,
+        "127.0.0.1:4317".to_string(),
+    )
+    .await
+    .expect("Failed to initialize service bootstrap");
+
+    let catalog = Arc::new(service_bootstrap.catalog().clone());
+    let auth_config = service_bootstrap.config().auth.clone();
+
+    let flight_transport = Arc::new(InMemoryFlightTransport::new(service_bootstrap));
+
+    let wal_dir = temp_dir.path().join("wal");
+    let wal_manager = Arc::new(WalManager::new(
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir.clone()),
+        WalConfig::with_defaults(wal_dir),
+    ));
+
+    let rate_limiter = Arc::new(common::ratelimit::TenantRateLimiter::from_auth_config(
+        &auth_config,
+    ));
+    let storage_usage =
+        Arc::new(common::storage_usage::StorageUsageTracker::from_auth_config(&auth_config));
+
+    let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+
+    let metrics_handler = Arc::new(MetricsHandler::new(flight_transport, wal_manager.clone()));
+
+    let app = metrics_http_router(authenticator, metrics_handler, rate_limiter, storage_usage);
+
+    (app, wal_manager, temp_dir)
+}
+
+/// Count WAL entries recorded for the test tenant's metrics WAL.
+async fn metrics_wal_entry_count(wal_manager: &WalManager) -> usize {
+    let wal = wal_manager
+        .get_wal(TEST_TENANT, TEST_DATASET, "metrics")
+        .await
+        .expect("Failed to open metrics WAL");
+    wal.get_entries()
+        .await
+        .expect("Failed to read WAL entries")
+        .iter()
+        .filter(|e| matches!(e.operation, WalOperation::WriteMetrics))
+        .count()
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_protobuf_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let body = sample_metrics_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated protobuf metrics export"
+    );
+    assert_eq!(
+        metrics_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the metrics export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_json_with_auth_lands_in_wal() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let body = serde_json::to_vec(&sample_metrics_request()).unwrap();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK for authenticated JSON metrics export"
+    );
+    assert_eq!(
+        metrics_wal_entry_count(&wal_manager).await,
+        1,
+        "Expected the metrics export to be durably recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_invalid_api_key_is_unauthorized() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let body = sample_metrics_request().encode_to_vec();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", "Bearer wrong-key")
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for an invalid API key"
+    );
+    assert_eq!(
+        metrics_wal_entry_count(&wal_manager).await,
+        0,
+        "Rejected exports must not be recorded in the WAL"
+    );
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_missing_auth_headers_is_rejected() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let body = sample_metrics_request().encode_to_vec();
+
+    // No Authorization / X-Tenant-ID headers at all.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a request without auth headers"
+    );
+    assert_eq!(metrics_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_malformed_protobuf_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from(vec![0xff, 0xfe, 0xfd, 0xfc]))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed protobuf payload"
+    );
+    assert_eq!(metrics_wal_entry_count(&wal_manager).await, 0);
+}
+
+#[tokio::test]
+async fn otlp_http_metrics_malformed_json_is_bad_request() {
+    let (app, wal_manager, _temp_dir) = setup_metrics_test().await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/metrics")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("Authorization", format!("Bearer {TEST_API_KEY}"))
+        .header("X-Tenant-ID", TEST_TENANT)
+        .body(Body::from("{\"resourceMetrics\": \"not-an-array\"}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for a malformed JSON payload"
+    );
+    assert_eq!(metrics_wal_entry_count(&wal_manager).await, 0);
+}


### PR DESCRIPTION
## Summary

Adds `POST /v1/logs` and `POST /v1/metrics` to the acceptor's OTLP/HTTP server (port 4318), completing the OTLP/HTTP surface started with traces in #755. Fixes #754.

- Both endpoints sit behind the same auth middleware as `/v1/traces` (`Authorization: Bearer` + explicit `X-Tenant-ID`, optional `X-Dataset-ID` falling back to the tenant default) and enforce per-tenant rate limits and storage quotas (429).
- `application/x-protobuf` (prost) and `application/json` (protojson) bodies are supported; responses are an empty `ExportLogsServiceResponse` / `ExportMetricsServiceResponse` in the request's encoding. gzip request bodies remain unsupported, consistent with traces.
- Requests delegate to the existing gRPC `LogHandler` / `MetricsHandler` (WAL write + flush for durability, then Flight forward), so HTTP and gRPC share one ingestion path.
- The shared HTTP plumbing (rate limit/quota checks, content-type detection, decode, response encoding, error mapping) is factored into a generic `handle_otlp_http_export` helper plus a generic `OtlpHttpState<H>`; the traces endpoint was refactored onto it, so the three signals share one implementation.
- Wired into `serve_otlp_http` with startup log lines for the new endpoints.

## Error semantics (same as traces)

400 malformed body or missing/malformed auth headers, 401 invalid key, 429 rate limit/storage quota, 503 WAL failure.

## Docs

`docs/users/sending-otlp.md`: logs/metrics flipped to supported in the per-signal table, the partial-support section generalized, Collector `otlphttp` example extended to logs/metrics pipelines, and the 404 troubleshooting rows removed. `./scripts/check-doc-freshness.sh` passes.

## Testing

TDD: new integration tests mirroring `otlp_http_traces.rs`, for each of logs and metrics: authed protobuf ingest lands in WAL, authed JSON ingest lands in WAL, invalid key 401, missing auth headers 400, malformed protobuf/JSON 400. `cargo test -p acceptor`, `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --check`, and `cargo machete` all pass.

Fixes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OTLP/HTTP ingestion for logs and metrics through `/v1/logs` and `/v1/metrics`.
  - Supports protobuf and JSON payloads with tenant authentication, rate limits, and storage quota enforcement.
  - Returns clear responses for invalid requests, rate limits, and ingestion failures.

- **Documentation**
  - Updated OTLP setup guidance, endpoint details, collector examples, supported signals, and troubleshooting information.

- **Tests**
  - Added coverage for valid and invalid OTLP/HTTP log and metric requests, including authentication and payload validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->