### PR TITLE
fix(wal): honor [wal].wal_dir for acceptor and writer WAL directories

### DIFF
--- a/.claude/skills/configuration/SKILL.md
+++ b/.claude/skills/configuration/SKILL.md
@@ -58,7 +58,7 @@ max_buffer_entries = 1000
 flush_interval = "30s"
 max_buffer_size_bytes = 134217728    # 128 MB
 ```
-Env: `WRITER_WAL_DIR`, `ACCEPTOR_WAL_DIR` (read directly by the binaries, not via figment). Sizing knobs use the double-underscore form: `SIGNALDB__WAL__MAX_SEGMENT_SIZE`, `SIGNALDB__WAL__MAX_BUFFER_ENTRIES`, `SIGNALDB__WAL__FLUSH_INTERVAL`.
+`wal_dir` is the base directory: the acceptor uses `{wal_dir}/acceptor` and the writer `{wal_dir}/writer` (default `.data/wal/acceptor` / `.data/wal/writer`). The service-specific env overrides `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` (read directly by the binaries, not via figment; also available as `--wal-dir`) point at the full service directory and win over `[wal].wal_dir`. Sizing knobs use the double-underscore form: `SIGNALDB__WAL__MAX_SEGMENT_SIZE`, `SIGNALDB__WAL__MAX_BUFFER_ENTRIES`, `SIGNALDB__WAL__FLUSH_INTERVAL` (as does `SIGNALDB__WAL__WAL_DIR`).
 
 ### Iceberg Schema Catalog
 ```toml

--- a/.claude/skills/storage-layout/SKILL.md
+++ b/.claude/skills/storage-layout/SKILL.md
@@ -109,8 +109,11 @@ pub struct WalConfig {
 }
 ```
 
-Note: `WalConfig::default()` uses `.wal` as the base directory; the TOML-level
-`[wal] wal_dir` (see the `configuration` skill) is what sets `.data/wal` in dev.
+Note: the runtime `WalConfig::default()` uses `.wal` as the base directory, but
+the services resolve their WAL directory from the TOML-level `[wal] wal_dir`
+(see the `configuration` skill): acceptor `{wal_dir}/acceptor`, writer
+`{wal_dir}/writer` (default `.data/wal/{service}`), overridable per service via
+`ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR`.
 
 ### Segment Lifecycle
 1. **Write**: Append to current segment's `.log` and `.data`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -473,7 +473,9 @@ dsn = "file:///.data/storage"
 # dsn = "memory://"
 # dsn = "s3://bucket/prefix"
 
-# WAL configuration
+# WAL configuration. wal_dir is the base directory: the acceptor writes
+# to {wal_dir}/acceptor and the writer to {wal_dir}/writer, overridable
+# per service via ACCEPTOR_WAL_DIR / WRITER_WAL_DIR.
 [wal]
 wal_dir = ".data/wal"
 max_segment_size = 67108864          # 64 MB

--- a/docs/architecture/storage-layout.md
+++ b/docs/architecture/storage-layout.md
@@ -490,7 +490,7 @@ The WAL is organized by tenant, dataset, and signal type under the configured ba
 
 ### Concrete Example
 
-The runtime `WalConfig` (`src/common/src/wal/mod.rs`) defaults to `wal_dir = ".wal"`; the `.data/wal` path shown below is the `[wal]` config-file default used by the dev scripts. With `wal_dir = ".data/wal"`:
+The runtime `WalConfig` (`src/common/src/wal/mod.rs`) defaults to `wal_dir = ".wal"`, but the services derive their WAL directory from the `[wal].wal_dir` config value (default `.data/wal`) with a per-service suffix: the acceptor uses `{wal_dir}/acceptor` and the writer `{wal_dir}/writer`, overridable via `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR`. The tenant tree shown below sits under the acceptor's service directory; with the defaults that is `.data/wal/acceptor`:
 
 ```
 .data/wal/

--- a/docs/operations/wal-persistence.md
+++ b/docs/operations/wal-persistence.md
@@ -33,21 +33,30 @@ OTLP Client → Acceptor → WAL (Disk) → Writer → Parquet Storage
 
 ### Service WAL Usage
 
-- **Acceptor Service**: Uses WAL at `ACCEPTOR_WAL_DIR` (default: `.wal/acceptor`)
-- **Writer Service**: Uses WAL at `WRITER_WAL_DIR` (default: `.wal/writer`)
+Each service keeps its WAL in a per-service subdirectory of the configured base directory (`[wal].wal_dir`, default `.data/wal`):
+
+- **Acceptor Service**: `{wal_dir}/acceptor` (default: `.data/wal/acceptor`), overridable via `ACCEPTOR_WAL_DIR`
+- **Writer Service**: `{wal_dir}/writer` (default: `.data/wal/writer`), overridable via `WRITER_WAL_DIR`
 
 ⚠️ **Production Warning**: Default WAL directories use local paths that **will not persist** across container or pod restarts. Configure persistent volumes for production deployments.
 
 ## Configuration
 
+The WAL base directory is set in the `[wal]` TOML section and applies to both services. Precedence per service:
+
+1. Service-specific override (`ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` env var, or `--wal-dir` CLI flag) — points at the **full** service directory
+2. `[wal].wal_dir` from `signaldb.toml` (or `SIGNALDB__WAL__WAL_DIR`) with `/acceptor` or `/writer` appended
+3. Built-in default `.data/wal`, i.e. `.data/wal/acceptor` and `.data/wal/writer`
+
 ### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ACCEPTOR_WAL_DIR` | `.wal/acceptor` | WAL directory for acceptor service |
-| `WRITER_WAL_DIR` | `.wal/writer` | WAL directory for writer service |
+| `ACCEPTOR_WAL_DIR` | `{wal_dir}/acceptor` | Full WAL directory for acceptor service (override) |
+| `WRITER_WAL_DIR` | `{wal_dir}/writer` | Full WAL directory for writer service (override) |
+| `SIGNALDB__WAL__WAL_DIR` | `.data/wal` | Base WAL directory (figment; equivalent to `[wal].wal_dir`) |
 
-These are the only WAL-related environment variables. Per-service WAL directories are set exclusively through them (there are no `[wal.acceptor]`/`[wal.writer]` TOML subsections).
+There are no `[wal.acceptor]`/`[wal.writer]` TOML subsections; the per-service overrides are env/CLI only.
 
 ### TOML Configuration
 
@@ -62,7 +71,7 @@ flush_interval = "30s"          # Flush every 30 seconds
 max_buffer_size_bytes = 134217728  # 128MB
 ```
 
-Note: segment size, buffer, and flush tuning currently ship as built-in defaults compiled into the services (64MB segments, 1000-entry buffer, 30s flush; the acceptor uses more aggressive per-signal settings for logs and metrics). The `[wal]` TOML block matches these defaults but the services do not yet read the tuning knobs from it — only the directory env vars above change runtime behavior.
+Note: segment size, buffer, and flush tuning currently ship as built-in defaults compiled into the services (64MB segments, 1000-entry buffer, 30s flush; the acceptor uses more aggressive per-signal settings for logs and metrics). The `[wal]` TOML block matches these defaults but the services do not yet read the tuning knobs from it — of the `[wal]` settings, only `wal_dir` changes runtime behavior today.
 
 ## Docker Compose Configuration
 

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -205,6 +205,11 @@ ttl = "300s"
 
 [wal]
 # Write-Ahead Log configuration
+#
+# Base directory for WAL files. Each service appends its own suffix:
+# the acceptor writes to {wal_dir}/acceptor and the writer to
+# {wal_dir}/writer. The ACCEPTOR_WAL_DIR / WRITER_WAL_DIR environment
+# variables (full service directory) override this per service.
 wal_dir = ".data/wal"
 max_segment_size = 67108864           # 64MB
 max_buffer_entries = 1000

--- a/src/acceptor/src/main.rs
+++ b/src/acceptor/src/main.rs
@@ -33,10 +33,9 @@ struct Cli {
     #[arg(
         long,
         env = "ACCEPTOR_WAL_DIR",
-        help = "WAL directory path",
-        default_value = ".wal/acceptor"
+        help = "WAL directory path (overrides [wal].wal_dir + \"/acceptor\"; default: .data/wal/acceptor)"
     )]
-    wal_dir: PathBuf,
+    wal_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -114,7 +113,13 @@ async fn main() -> Result<()> {
     let advertise_addr =
         std::env::var("ACCEPTOR_ADVERTISE_ADDR").unwrap_or_else(|_| grpc_addr.to_string());
 
-    let resources = init_acceptor_resources(config.clone(), advertise_addr, cli.wal_dir.clone())
+    // WAL directory: --wal-dir / ACCEPTOR_WAL_DIR override wins, otherwise
+    // [wal].wal_dir from the configuration with the service suffix appended.
+    let wal_dir = config
+        .wal
+        .wal_dir_for_service("acceptor", cli.wal_dir.clone());
+
+    let resources = init_acceptor_resources(config.clone(), advertise_addr, wal_dir)
         .await
         .context("Failed to initialize acceptor resources")?;
 

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -344,6 +344,25 @@ pub struct WalConfig {
     pub max_buffer_size_bytes: usize,
 }
 
+impl WalConfig {
+    /// Resolve the effective WAL directory for a service.
+    ///
+    /// Precedence:
+    /// 1. `override_dir` — a service-specific override pointing at the full
+    ///    service directory (from `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` or a
+    ///    `--wal-dir` CLI flag) wins outright.
+    /// 2. Otherwise `[wal].wal_dir` with the service name appended, e.g.
+    ///    `.data/wal/acceptor`. Tenant/dataset/signal subdirectories are
+    ///    created below this path at runtime.
+    pub fn wal_dir_for_service(
+        &self,
+        service: &str,
+        override_dir: Option<std::path::PathBuf>,
+    ) -> std::path::PathBuf {
+        override_dir.unwrap_or_else(|| std::path::Path::new(&self.wal_dir).join(service))
+    }
+}
+
 impl Default for WalConfig {
     fn default() -> Self {
         Self {
@@ -1249,6 +1268,80 @@ mod tests {
             assert_eq!(config.querier.max_search_limit, 50);
             Ok(())
         });
+    }
+
+    #[test]
+    fn wal_dir_for_service_appends_service_suffix_to_default() {
+        let config = Configuration::default();
+        assert_eq!(
+            config.wal.wal_dir_for_service("acceptor", None),
+            std::path::PathBuf::from(".data/wal/acceptor")
+        );
+        assert_eq!(
+            config.wal.wal_dir_for_service("writer", None),
+            std::path::PathBuf::from(".data/wal/writer")
+        );
+    }
+
+    #[test]
+    fn wal_dir_for_service_honors_toml_wal_dir() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "signaldb.toml",
+                r#"
+                [wal]
+                wal_dir = "/data/wal"
+                "#,
+            )?;
+            let config: Configuration = Figment::new()
+                .merge(Serialized::defaults(Configuration::default()))
+                .merge(figment::providers::Toml::file("signaldb.toml"))
+                .extract()?;
+            assert_eq!(
+                config.wal.wal_dir_for_service("acceptor", None),
+                std::path::PathBuf::from("/data/wal/acceptor")
+            );
+            assert_eq!(
+                config.wal.wal_dir_for_service("writer", None),
+                std::path::PathBuf::from("/data/wal/writer")
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn wal_dir_for_service_env_wal_dir_flows_through_figment() {
+        Jail::expect_with(|jail| {
+            jail.set_env("SIGNALDB__WAL__WAL_DIR", "/env/wal");
+            let config: Configuration = Figment::new()
+                .merge(Serialized::defaults(Configuration::default()))
+                .merge(Env::prefixed("SIGNALDB__").split("__"))
+                .extract()?;
+            assert_eq!(
+                config.wal.wal_dir_for_service("acceptor", None),
+                std::path::PathBuf::from("/env/wal/acceptor")
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn wal_dir_for_service_override_wins_over_configured_dir() {
+        let config = Configuration {
+            wal: WalConfig {
+                wal_dir: "/data/wal".to_string(),
+                ..WalConfig::default()
+            },
+            ..Configuration::default()
+        };
+        // Service-specific override (ACCEPTOR_WAL_DIR / WRITER_WAL_DIR or
+        // --wal-dir) points at the full service directory and wins outright.
+        assert_eq!(
+            config
+                .wal
+                .wal_dir_for_service("acceptor", Some("/custom/acceptor-wal".into())),
+            std::path::PathBuf::from("/custom/acceptor-wal")
+        );
     }
 
     #[test]

--- a/src/signaldb-bin/src/main.rs
+++ b/src/signaldb-bin/src/main.rs
@@ -140,10 +140,13 @@ async fn main() -> Result<()> {
     let object_store = common::storage::create_object_store(&config.storage)
         .context("Failed to initialize object store")?;
 
-    let writer_wal_dir =
-        std::env::var("WRITER_WAL_DIR").unwrap_or_else(|_| ".data/wal/writer".to_string());
+    // WRITER_WAL_DIR override wins, otherwise [wal].wal_dir + "/writer".
+    let writer_wal_dir = config.wal.wal_dir_for_service(
+        "writer",
+        std::env::var("WRITER_WAL_DIR").ok().map(Into::into),
+    );
     let writer_wal_config = WalConfig {
-        wal_dir: writer_wal_dir.into(),
+        wal_dir: writer_wal_dir,
         ..Default::default()
     };
 
@@ -298,10 +301,12 @@ async fn main() -> Result<()> {
         None
     };
 
-    // Initialize shared acceptor resources for both gRPC and HTTP servers
-    let wal_dir = std::env::var("ACCEPTOR_WAL_DIR")
-        .unwrap_or_else(|_| ".wal/acceptor".to_string())
-        .into();
+    // Initialize shared acceptor resources for both gRPC and HTTP servers.
+    // ACCEPTOR_WAL_DIR override wins, otherwise [wal].wal_dir + "/acceptor".
+    let wal_dir = config.wal.wal_dir_for_service(
+        "acceptor",
+        std::env::var("ACCEPTOR_WAL_DIR").ok().map(Into::into),
+    );
     let grpc_addr = SocketAddr::from(([0, 0, 0, 0], 4317));
     let http_addr = SocketAddr::from(([0, 0, 0, 0], 4318));
     let advertise_addr =

--- a/src/writer/src/main.rs
+++ b/src/writer/src/main.rs
@@ -29,10 +29,9 @@ struct Cli {
     #[arg(
         long,
         env = "WRITER_WAL_DIR",
-        help = "WAL directory path",
-        default_value = ".wal/writer"
+        help = "WAL directory path (overrides [wal].wal_dir + \"/writer\"; default: .data/wal/writer)"
     )]
-    wal_dir: PathBuf,
+    wal_dir: Option<PathBuf>,
 
     #[arg(long, help = "Bind address for servers", default_value = "0.0.0.0")]
     bind: String,
@@ -144,9 +143,15 @@ async fn main() -> anyhow::Result<()> {
     let object_store = common::storage::create_object_store(&config.storage)
         .context("Failed to initialize object store")?;
 
-    // Initialize WAL for durability
+    // Initialize WAL for durability. The --wal-dir / WRITER_WAL_DIR override
+    // wins, otherwise [wal].wal_dir from the configuration with the service
+    // suffix appended.
+    let wal_dir = config
+        .wal
+        .wal_dir_for_service("writer", cli.wal_dir.clone());
+    tracing::info!(wal_dir = %wal_dir.display(), "Initializing writer WAL");
     let wal_config = WalConfig {
-        wal_dir: cli.wal_dir,
+        wal_dir,
         ..Default::default()
     };
 


### PR DESCRIPTION
Fixes #751

## Problem

Setting `[wal] wal_dir = "/data/wal"` in `signaldb.toml` was silently ignored. The acceptor hardcoded `.wal/acceptor` and the writer `.data/wal/writer` (monolithic) / `.wal/writer` (standalone), honoring only the `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` environment variables. The `[wal]` TOML section's directory setting never reached service startup.

## Fix

`[wal].wal_dir` is now the single source of truth for the WAL base directory, resolved through a new `WalConfig::wal_dir_for_service(service, override_dir)` helper in `common`:

1. **Service-specific override wins**: `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` env vars (or the `--wal-dir` CLI flag), pointing at the full service directory as today — backward compatible with compose/k8s manifests and `scripts/run-dev.sh`.
2. **Otherwise** `[wal].wal_dir` (TOML or `SIGNALDB__WAL__WAL_DIR`) with the service suffix appended: `{wal_dir}/acceptor` and `{wal_dir}/writer`.
3. **Default**: `.data/wal`, i.e. `.data/wal/acceptor` and `.data/wal/writer`.

The tenant/dataset/signal layout below the service directory is unchanged. Wired through all three entry points: `signaldb-acceptor`, `signaldb-writer`, and the monolithic `signaldb` binary.

## ⚠️ Behavior change (default paths only)

Anyone relying on the previously undocumented defaults will see WAL directories move (no migration logic is included; set the env vars to keep old paths):

| Service | Before | After |
|---------|--------|-------|
| Acceptor (standalone + monolithic) | `.wal/acceptor` | `.data/wal/acceptor` |
| Writer (standalone) | `.wal/writer` | `.data/wal/writer` |
| Writer (monolithic) | `.data/wal/writer` | `.data/wal/writer` (unchanged) |

Deployments that set `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` (docker compose, k8s, dokku docs, dev scripts) are unaffected — the env override still wins.

## Tests (TDD)

New tests in `src/common/src/config/mod.rs`:
- `wal_dir_for_service_appends_service_suffix_to_default`
- `wal_dir_for_service_honors_toml_wal_dir` (figment Jail, TOML file)
- `wal_dir_for_service_env_wal_dir_flows_through_figment` (`SIGNALDB__WAL__WAL_DIR`)
- `wal_dir_for_service_override_wins_over_configured_dir`

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features` clean; `cargo test -p common -p acceptor -p writer` green (one pre-existing testcontainers test requires Docker and was skipped locally as the daemon was unavailable).

## Docs

Updated `docs/operations/wal-persistence.md` (precedence + new defaults), `docs/architecture/storage-layout.md`, `signaldb.dist.toml` comments, and the `configuration` / `storage-layout` skills.