### PR TITLE
ci(docker): build static musl binaries on runners, copy into images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,20 +230,150 @@ jobs:
           path: target/release/signaldb*
           retention-days: 7
 
-  # Docker image build - split by architecture for native builds
+  # Static musl binaries for container images. Built on the host runner
+  # where rust-cache + sccache make rebuilds incremental, instead of inside
+  # docker where layer caching is all-or-nothing and misses on every
+  # Cargo.toml change. The docker jobs below just copy these in.
+  build-musl-amd64:
+    name: Build musl Binaries (amd64)
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          cache: false  # Using Swatinem/rust-cache instead
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "musl-amd64"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools mold clang
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Build musl binaries
+        run: |
+          export RUSTC_WRAPPER=sccache
+          cargo build --release --target x86_64-unknown-linux-musl \
+            --bin signaldb-acceptor \
+            --bin signaldb-router \
+            --bin signaldb-writer \
+            --bin signaldb-querier \
+            --bin signaldb-compactor \
+            --bin signaldb
+
+      - name: Stage binaries
+        run: |
+          mkdir -p dist
+          cp target/x86_64-unknown-linux-musl/release/signaldb \
+             target/x86_64-unknown-linux-musl/release/signaldb-acceptor \
+             target/x86_64-unknown-linux-musl/release/signaldb-router \
+             target/x86_64-unknown-linux-musl/release/signaldb-writer \
+             target/x86_64-unknown-linux-musl/release/signaldb-querier \
+             target/x86_64-unknown-linux-musl/release/signaldb-compactor \
+             dist/
+
+      - name: Upload musl binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: musl-binaries-amd64
+          path: dist/
+          retention-days: 7
+
+  build-musl-arm64:
+    name: Build musl Binaries (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: aarch64-unknown-linux-musl
+          cache: false  # Using Swatinem/rust-cache instead
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "musl-arm64"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools mold clang
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Build musl binaries
+        run: |
+          export RUSTC_WRAPPER=sccache
+          cargo build --release --target aarch64-unknown-linux-musl \
+            --bin signaldb-acceptor \
+            --bin signaldb-router \
+            --bin signaldb-writer \
+            --bin signaldb-querier \
+            --bin signaldb-compactor \
+            --bin signaldb
+
+      - name: Stage binaries
+        run: |
+          mkdir -p dist
+          cp target/aarch64-unknown-linux-musl/release/signaldb \
+             target/aarch64-unknown-linux-musl/release/signaldb-acceptor \
+             target/aarch64-unknown-linux-musl/release/signaldb-router \
+             target/aarch64-unknown-linux-musl/release/signaldb-writer \
+             target/aarch64-unknown-linux-musl/release/signaldb-querier \
+             target/aarch64-unknown-linux-musl/release/signaldb-compactor \
+             dist/
+
+      - name: Upload musl binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: musl-binaries-arm64
+          path: dist/
+          retention-days: 7
+
+  # Docker image build - copy-only images from prebuilt musl binaries,
+  # split by architecture. No layer caching needed: the expensive compile
+  # happens in the build-musl-* jobs above.
   # Docker build for amd64 (runs on all events)
   docker-build-amd64:
     name: Build Docker Image (amd64)
     runs-on: ubuntu-latest
-    needs: check
+    needs: build-musl-amd64
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v7
 
-      - name: Init submodules
-        run: git submodule update --init --recursive
+      - name: Download musl binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: musl-binaries-amd64
+          path: dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -271,18 +401,18 @@ jobs:
           context: .
           file: Dockerfile
           target: monolithic
+          build-args: |
+            BUILDER=prebuilt
           platforms: linux/amd64
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64,ignore-error=true
 
   # Docker build for arm64 (only on main branch, not PRs)
   docker-build-arm64:
     name: Build Docker Image (arm64)
     runs-on: ubuntu-24.04-arm
-    needs: check
+    needs: build-musl-arm64
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -290,8 +420,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Init submodules
-        run: git submodule update --init --recursive
+      - name: Download musl binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: musl-binaries-arm64
+          path: dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -317,12 +450,12 @@ jobs:
           context: .
           file: Dockerfile
           target: monolithic
+          build-args: |
+            BUILDER=prebuilt
           platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=arm64
-          cache-to: type=gha,mode=max,scope=arm64,ignore-error=true
 
   # Merge architecture-specific images into multi-arch manifest (main only)
   docker-manifest:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -123,13 +123,144 @@ jobs:
             target/${{ matrix.target }}/release/signaldb-monolithic-${{ matrix.target }}.*
             target/${{ matrix.target }}/release/signaldb-microservices-${{ matrix.target }}.*
 
-  docker-build:
-    name: Build Docker Images
+  # Static musl binaries for the release images, built natively per arch
+  # (the previous single docker-build job compiled arm64 under QEMU).
+  # Shared rust-cache keys with the CI musl jobs make this incremental.
+  build-musl-amd64:
+    name: Build musl Binaries (amd64)
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          cache: false  # Using Swatinem/rust-cache instead
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "musl-amd64"
+          save-if: false  # CI populates this cache on main
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools mold clang
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Build musl binaries
+        run: |
+          export RUSTC_WRAPPER=sccache
+          cargo build --release --target x86_64-unknown-linux-musl \
+            --bin signaldb-acceptor \
+            --bin signaldb-router \
+            --bin signaldb-writer \
+            --bin signaldb-querier \
+            --bin signaldb-compactor \
+            --bin signaldb
+
+      - name: Stage binaries
+        run: |
+          mkdir -p dist
+          cp target/x86_64-unknown-linux-musl/release/signaldb \
+             target/x86_64-unknown-linux-musl/release/signaldb-acceptor \
+             target/x86_64-unknown-linux-musl/release/signaldb-router \
+             target/x86_64-unknown-linux-musl/release/signaldb-writer \
+             target/x86_64-unknown-linux-musl/release/signaldb-querier \
+             target/x86_64-unknown-linux-musl/release/signaldb-compactor \
+             dist/
+
+      - name: Upload musl binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-musl-binaries-amd64
+          path: dist/
+          retention-days: 7
+
+  build-musl-arm64:
+    name: Build musl Binaries (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: aarch64-unknown-linux-musl
+          cache: false  # Using Swatinem/rust-cache instead
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "musl-arm64"
+          save-if: false  # CI populates this cache on main
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools mold clang
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Build musl binaries
+        run: |
+          export RUSTC_WRAPPER=sccache
+          cargo build --release --target aarch64-unknown-linux-musl \
+            --bin signaldb-acceptor \
+            --bin signaldb-router \
+            --bin signaldb-writer \
+            --bin signaldb-querier \
+            --bin signaldb-compactor \
+            --bin signaldb
+
+      - name: Stage binaries
+        run: |
+          mkdir -p dist
+          cp target/aarch64-unknown-linux-musl/release/signaldb \
+             target/aarch64-unknown-linux-musl/release/signaldb-acceptor \
+             target/aarch64-unknown-linux-musl/release/signaldb-router \
+             target/aarch64-unknown-linux-musl/release/signaldb-writer \
+             target/aarch64-unknown-linux-musl/release/signaldb-querier \
+             target/aarch64-unknown-linux-musl/release/signaldb-compactor \
+             dist/
+
+      - name: Upload musl binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-musl-binaries-arm64
+          path: dist/
+          retention-days: 7
+
+  docker-build-amd64:
+    name: Build Docker Image (amd64)
+    runs-on: ubuntu-latest
+    needs: [release-please, build-musl-amd64]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download musl binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: release-musl-binaries-amd64
+          path: dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -147,10 +278,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-amd64
 
       - name: Build and push monolithic image
         uses: docker/build-push-action@v7
@@ -158,17 +286,94 @@ jobs:
           context: .
           file: Dockerfile
           target: monolithic
-          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILDER=prebuilt
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+
+  docker-build-arm64:
+    name: Build Docker Image (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [release-please, build-musl-arm64]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download musl binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: release-musl-binaries-arm64
+          path: dist/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-arm64
+
+      - name: Build and push monolithic image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: monolithic
+          build-args: |
+            BUILDER=prebuilt
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-manifest:
+    name: Create Multi-Arch Release Manifest
+    runs-on: ubuntu-latest
+    needs: [release-please, docker-build-amd64, docker-build-arm64]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
+
+      - name: Create and push manifests
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            docker buildx imagetools create -t "$tag" \
+              "ghcr.io/${{ github.repository }}:${version}-amd64" \
+              "ghcr.io/${{ github.repository }}:${version}-arm64"
+          done <<< "${{ steps.meta.outputs.tags }}"
 
   upload-assets:
     name: Upload Release Assets
     runs-on: ubuntu-latest
-    needs: [release-please, build-release, docker-build]
+    needs: [release-please, build-release, docker-manifest]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ ENV/
 *.swp
 
 node_modules/
+
+# Staged binaries for prebuilt Docker images (CI)
+/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 # Multi-stage production Dockerfile for SignalDB services
 # Uses Alpine Linux for minimal image sizes (~15-25MB per service)
+#
+# Two builder paths, selected via --build-arg BUILDER=<source|prebuilt>:
+#   source   (default) - compile everything inside the container; used by
+#              docker compose and local builds
+#   prebuilt - copy static musl binaries staged in dist/ by CI, skipping
+#              the in-container compile entirely
+ARG BUILDER=source
 
 # Builder stage - compile all services with musl for Alpine compatibility
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97-alpine AS builder-source
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -98,6 +105,18 @@ RUN strip target/release/signaldb-acceptor && \
     strip target/release/signaldb-querier && \
     strip target/release/signaldb-compactor && \
     strip target/release/signaldb
+
+# Prebuilt-binary path - CI builds static musl binaries on the host runner
+# (where sccache/rust-cache make rebuilds incremental) and stages them in
+# dist/; nothing is compiled inside the container
+FROM alpine:3.24 AS builder-prebuilt
+
+WORKDIR /build
+COPY --chmod=755 dist/ target/release/
+
+# Builder selection - the service stages below copy from whichever
+# builder path the BUILDER build-arg picked
+FROM builder-${BUILDER} AS builder
 
 # Runtime base image - minimal Alpine with required libraries
 FROM alpine:3.24 AS runtime-base

--- a/docs/operations/dokku.md
+++ b/docs/operations/dokku.md
@@ -43,7 +43,7 @@ dokku git:from-image signaldb ghcr.io/cedricziel/signaldb:<version>
 
 ## From source (git push)
 
-Dokku will build using the production `Dockerfile` with the `monolithic` target:
+Dokku will build using the production `Dockerfile` with the `monolithic` target. The Dockerfile's default `BUILDER=source` path compiles everything inside the container (the `BUILDER=prebuilt` variant is only used by CI, which supplies pre-compiled musl binaries), so no extra build arguments are needed:
 
 ```bash
 dokku apps:create signaldb


### PR DESCRIPTION
## Why

The Docker image jobs are the slowest part of CI: on the last green `main` run the amd64 image build took **94 minutes** (18 min dummy-dep layer + 72 min real build), arm64 took 68 min. Root causes:

- The whole FDAP workspace is compiled **twice inside `docker build`** on a 4-vCPU runner (dummy-source dependency layer, then the real build).
- The `type=gha` layer cache is effectively useless here: the dep layer is invalidated by any `Cargo.toml`/`Cargo.lock` change (release-please bumps versions regularly), and `mode=max` for two arch scopes with multi-GB `target/` layers blows through GitHub's 10 GB per-repo cache limit, so entries are evicted before reuse. In the inspected run, only the `apk add` layers were `CACHED`.

## What

- **New `build-musl-amd64` / `build-musl-arm64` jobs** compile the six service binaries for `x86_64-`/`aarch64-unknown-linux-musl` directly on the runners, with `Swatinem/rust-cache` + sccache (same caching setup as the other Rust jobs, which works incrementally instead of all-or-nothing). Binaries are staged in `dist/` and uploaded as artifacts. The arm64 job keeps the existing main-only gating.
- **Dockerfile gains a `BUILDER` build-arg** (`source` | `prebuilt`): `prebuilt` is a copy-only stage that takes the staged `dist/` binaries (`COPY --chmod=755`); `source` is the unchanged in-container build and remains the default, so `docker compose up --build` and local builds behave exactly as before. BuildKit only builds the selected stage, so the unused path never runs.
- **Docker jobs become copy-only**: download the matching artifact into `dist/`, build with `BUILDER=prebuilt`. The gha layer cache and submodule init are dropped from these jobs (nothing is compiled there anymore).
- `dist/` added to `.gitignore`.

No OpenSSL concerns for the host-side musl build: the lockfile has no `openssl-sys`; TLS is ring/aws-lc, which build with `musl-tools`. `mold`/`clang` are installed because build scripts still target the gnu host, which `.cargo/config.toml` links with mold.

## Expected effect

- Cold cache: one compile per arch instead of two, on cacheable infrastructure.
- Warm cache: musl jobs should drop to a few minutes (incremental rebuild of changed crates), and the Docker jobs to ~1–2 min (download + copy + push).

## Validation

Intentionally not built locally — this PR's own CI run is the validation: `build-musl-amd64` → `docker-build-amd64` must go green. The arm64 + manifest path only runs after merge on `main`, so watch the first `main` run for `build-musl-arm64` / `docker-manifest`.