### PR TITLE
fix(ci): keep per-arch release image jobs from pushing plain latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,9 @@ jobs:
   docker-build-amd64:
     name: Build Docker Image (amd64)
     runs-on: ubuntu-latest
-    needs: build-musl-amd64
+    # test gates the image push: a commit with a red test suite must not
+    # be published to ghcr, even though the binaries already built
+    needs: [build-musl-amd64, test]
     permissions:
       contents: read
       packages: write
@@ -412,7 +414,8 @@ jobs:
   docker-build-arm64:
     name: Build Docker Image (arm64)
     runs-on: ubuntu-24.04-arm
-    needs: build-musl-arm64
+    # test gates the image push; see docker-build-amd64
+    needs: [build-musl-arm64, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -277,6 +277,11 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # latest=false: metadata-action's latest=auto default would add a
+          # plain (unsuffixed) latest tag here, letting a single-arch image
+          # overwrite it; the manifest job owns the multi-arch latest tag.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-amd64
 
@@ -322,6 +327,9 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # latest=false: see the amd64 job; the manifest job owns latest.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-arm64
 


### PR DESCRIPTION
Follow-up to #761. `docker/metadata-action` defaults to `flavor: latest=auto`, which adds a plain (unsuffixed) `latest` tag for any non-prerelease `type=semver` entry. In the rewired release workflow that meant each per-arch job (`docker-build-amd64` / `docker-build-arm64`) would push a **single-arch** image to `:latest`, overwriting each other — with the final winner decided by job ordering.

Fix: `latest=false` on the two per-arch metadata steps. The `docker-manifest` job keeps the default and already emits `latest` in its tag list, so releases still publish a proper multi-arch `:latest` as before.

Only exercises on the next release; this is workflow-config only, so it can be admin-merged like #761.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker image publishing now waits for tests to complete successfully.
  * Prevented architecture-specific builds from incorrectly publishing the generic `latest` tag.
  * Ensured the multi-architecture release process remains responsible for publishing `latest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->