### PR TITLE
fix(metrics): ingest remote-write v2 native histograms as exponential histograms

### DIFF
--- a/docs/users/prometheus-remote-write.md
+++ b/docs/users/prometheus-remote-write.md
@@ -5,6 +5,7 @@ status: living
 sources:
   - src/acceptor/src/handler/prometheus_handler.rs
   - src/acceptor/src/middleware/auth.rs
+  - src/common/src/flight/conversion/conversion_prometheus/to_otel.rs
 ---
 
 # Send Prometheus metrics via remote_write
@@ -22,7 +23,11 @@ It accepts snappy-compressed protobuf (block format, not framed) with
 `Content-Type: application/x-protobuf`, remote_write protocol v1 and v2
 (v2 adds native histograms and metadata). Incoming samples are converted
 to OpenTelemetry metrics and stored in the same metrics tables as OTLP
-metrics (`metrics_gauge`, `metrics_sum`, `metrics_histogram`).
+metrics (`metrics_gauge`, `metrics_sum`, `metrics_histogram`). Native
+histogram samples (v2) are converted to OpenTelemetry exponential
+histograms and stored in `metrics_exponential_histogram`; custom-bucket
+native histograms (NHCB) cannot be represented as exponential histograms
+and are dropped with a warning in the acceptor logs.
 
 ## Prerequisites
 

--- a/src/common/src/flight/conversion/conversion_prometheus/mod.rs
+++ b/src/common/src/flight/conversion/conversion_prometheus/mod.rs
@@ -749,6 +749,209 @@ mod tests {
         assert_eq!(normalize_unit("requests/second"), "requests_per_second");
     }
 
+    // Native histogram (remote_write v2) → OTLP exponential histogram tests
+
+    /// A native histogram sample equivalent to observations:
+    /// two in (1, 2], one in (2, 4], one in (8, 16], two exactly zero.
+    fn sample_native_histogram() -> PrometheusHistogram {
+        PrometheusHistogram {
+            count: 6,
+            sum: 21.5,
+            schema: 0,
+            zero_threshold: 1e-128,
+            zero_count: 2,
+            // Prometheus positive bucket index 1 = (1, 2], 2 = (2, 4], 4 = (8, 16]
+            positive_spans: vec![
+                BucketSpan {
+                    offset: 1,
+                    length: 2,
+                },
+                BucketSpan {
+                    offset: 1,
+                    length: 1,
+                },
+            ],
+            positive_deltas: vec![2, -1, 0],
+            timestamp: 1_700_000_000_000,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn native_histogram_series_converts_to_exponential_histogram() {
+        let request = PrometheusWriteRequest {
+            timeseries: vec![PrometheusTimeSeries {
+                labels: vec![
+                    PrometheusLabel {
+                        name: "__name__".to_string(),
+                        value: "http_request_latency_seconds".to_string(),
+                    },
+                    PrometheusLabel {
+                        name: "job".to_string(),
+                        value: "api".to_string(),
+                    },
+                    PrometheusLabel {
+                        name: "method".to_string(),
+                        value: "GET".to_string(),
+                    },
+                ],
+                samples: vec![],
+                histograms: vec![sample_native_histogram()],
+            }],
+            metadata: vec![],
+        };
+
+        let result = prometheus_to_otel_metrics(&request);
+
+        assert_eq!(result.resource_metrics.len(), 1);
+        let metrics = &result.resource_metrics[0].scope_metrics[0].metrics;
+        assert_eq!(metrics.len(), 1, "expected exactly one metric");
+        let metric = &metrics[0];
+        assert_eq!(metric.name, "http_request_latency_seconds");
+
+        let Some(Data::ExponentialHistogram(exp)) = &metric.data else {
+            panic!("Expected exponential histogram data, got {:?}", metric.data);
+        };
+        assert_eq!(
+            exp.aggregation_temporality,
+            AggregationTemporality::Cumulative as i32
+        );
+        assert_eq!(exp.data_points.len(), 1);
+
+        let dp = &exp.data_points[0];
+        assert_eq!(dp.count, 6);
+        assert_eq!(dp.sum, Some(21.5));
+        assert_eq!(dp.scale, 0);
+        assert_eq!(dp.zero_count, 2);
+        assert_eq!(dp.zero_threshold, 1e-128);
+        assert_eq!(dp.time_unix_nano, 1_700_000_000_000 * 1_000_000);
+
+        // Prometheus indexes 1,2,4 (upper-bound based) map to OTLP indexes 0,1,3
+        // (lower-bound based); the gap at index 2 is a zero in the dense encoding.
+        let positive = dp.positive.as_ref().expect("positive buckets");
+        assert_eq!(positive.offset, 0);
+        assert_eq!(positive.bucket_counts, vec![2, 1, 0, 1]);
+        assert!(dp.negative.is_none());
+
+        // Attributes keep metric labels but not __name__/job/instance
+        assert!(dp.attributes.iter().any(|kv| kv.key == "method"));
+        assert!(!dp.attributes.iter().any(|kv| kv.key == "__name__"));
+    }
+
+    #[test]
+    fn native_histogram_with_unsupported_schema_is_dropped() {
+        // Schema outside -4..=8 (e.g. custom-bucket NHCB histograms) cannot be
+        // represented as OTLP exponential histograms and must be dropped.
+        for schema in [-53, 127, 9, -5] {
+            let request = PrometheusWriteRequest {
+                timeseries: vec![PrometheusTimeSeries {
+                    labels: vec![PrometheusLabel {
+                        name: "__name__".to_string(),
+                        value: "custom_bucket_histogram".to_string(),
+                    }],
+                    samples: vec![],
+                    histograms: vec![PrometheusHistogram {
+                        schema,
+                        ..sample_native_histogram()
+                    }],
+                }],
+                metadata: vec![],
+            };
+
+            let result = prometheus_to_otel_metrics(&request);
+            let metrics = &result.resource_metrics[0].scope_metrics[0].metrics;
+            assert!(
+                metrics.is_empty(),
+                "schema {schema} should be dropped, got {metrics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_native_histogram_sample_is_skipped() {
+        let mut histogram = sample_native_histogram();
+        histogram.sum = f64::from_bits(0x7ff0000000000002); // stale marker
+
+        let request = PrometheusWriteRequest {
+            timeseries: vec![PrometheusTimeSeries {
+                labels: vec![PrometheusLabel {
+                    name: "__name__".to_string(),
+                    value: "stale_histogram".to_string(),
+                }],
+                samples: vec![],
+                histograms: vec![histogram],
+            }],
+            metadata: vec![],
+        };
+
+        let result = prometheus_to_otel_metrics(&request);
+        let metrics = &result.resource_metrics[0].scope_metrics[0].metrics;
+        assert!(metrics.is_empty(), "stale sample should produce no metric");
+    }
+
+    #[test]
+    fn float_native_histogram_uses_absolute_counts() {
+        let request = PrometheusWriteRequest {
+            timeseries: vec![PrometheusTimeSeries {
+                labels: vec![PrometheusLabel {
+                    name: "__name__".to_string(),
+                    value: "float_histogram".to_string(),
+                }],
+                samples: vec![],
+                histograms: vec![PrometheusHistogram {
+                    count: 5,
+                    sum: 10.0,
+                    schema: 2,
+                    positive_spans: vec![BucketSpan {
+                        offset: 0,
+                        length: 2,
+                    }],
+                    positive_deltas: vec![],
+                    positive_counts: vec![3.0, 2.0],
+                    timestamp: 1_700_000_000_000,
+                    ..Default::default()
+                }],
+            }],
+            metadata: vec![],
+        };
+
+        let result = prometheus_to_otel_metrics(&request);
+        let metrics = &result.resource_metrics[0].scope_metrics[0].metrics;
+        assert_eq!(metrics.len(), 1);
+        let Some(Data::ExponentialHistogram(exp)) = &metrics[0].data else {
+            panic!("Expected exponential histogram data");
+        };
+        let positive = exp.data_points[0].positive.as_ref().expect("positive");
+        assert_eq!(positive.offset, -1);
+        assert_eq!(positive.bucket_counts, vec![3, 2]);
+    }
+
+    #[test]
+    fn native_histogram_metadata_populates_description_and_unit() {
+        let request = PrometheusWriteRequest {
+            timeseries: vec![PrometheusTimeSeries {
+                labels: vec![PrometheusLabel {
+                    name: "__name__".to_string(),
+                    value: "http_request_latency_seconds".to_string(),
+                }],
+                samples: vec![],
+                histograms: vec![sample_native_histogram()],
+            }],
+            metadata: vec![PrometheusMetricMetadata {
+                metric_family_name: "http_request_latency_seconds".to_string(),
+                metric_type: PrometheusMetricType::Histogram,
+                help: "Request latency".to_string(),
+                unit: "seconds".to_string(),
+            }],
+        };
+
+        let result = prometheus_to_otel_metrics(&request);
+        let metric = &result.resource_metrics[0].scope_metrics[0].metrics[0];
+        assert_eq!(metric.description, "Request latency");
+        assert_eq!(metric.unit, "seconds");
+        assert!(matches!(metric.data, Some(Data::ExponentialHistogram(_)),));
+    }
+
     #[test]
     fn test_metric_name_normalization() {
         use from_otel::normalize_metric_name;

--- a/src/common/src/flight/conversion/conversion_prometheus/to_otel.rs
+++ b/src/common/src/flight/conversion/conversion_prometheus/to_otel.rs
@@ -8,8 +8,9 @@ use std::collections::HashMap;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue, any_value};
 use opentelemetry_proto::tonic::metrics::v1::{
-    AggregationTemporality, Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint,
-    ResourceMetrics, ScopeMetrics, Sum, Summary, SummaryDataPoint, metric::Data, number_data_point,
+    AggregationTemporality, ExponentialHistogram, ExponentialHistogramDataPoint, Gauge, Histogram,
+    HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum, Summary,
+    SummaryDataPoint, exponential_histogram_data_point::Buckets, metric::Data, number_data_point,
     summary_data_point::ValueAtQuantile,
 };
 use opentelemetry_proto::tonic::resource::v1::Resource;
@@ -93,6 +94,7 @@ fn proto_to_internal(proto: proto::WriteRequest) -> PrometheusWriteRequest {
                             })
                             .collect(),
                         negative_deltas: h.negative_deltas,
+                        negative_counts: h.negative_counts,
                         positive_spans: h
                             .positive_spans
                             .into_iter()
@@ -102,6 +104,7 @@ fn proto_to_internal(proto: proto::WriteRequest) -> PrometheusWriteRequest {
                             })
                             .collect(),
                         positive_deltas: h.positive_deltas,
+                        positive_counts: h.positive_counts,
                         timestamp: h.timestamp,
                     })
                     .collect(),
@@ -197,11 +200,29 @@ fn convert_resource_group(
     // Extract instrumentation scope from otel_scope_* labels
     let scope = extract_instrumentation_scope(timeseries);
 
-    // Group time series by metric base name for histogram/summary reconstruction
+    // Native histogram series (remote_write v2) map directly onto OTLP
+    // exponential histograms and bypass the classic suffix-based
+    // _bucket/_count/_sum reconstruction.
+    let mut native_histogram_groups: HashMap<String, Vec<&PrometheusTimeSeries>> = HashMap::new();
+
+    // Group classic time series by metric base name for histogram/summary reconstruction
     let mut metric_groups: HashMap<String, Vec<&PrometheusTimeSeries>> = HashMap::new();
 
     for ts in timeseries {
         let metric_name = get_label(&ts.labels, "__name__").unwrap_or_default();
+
+        if !ts.histograms.is_empty() {
+            native_histogram_groups
+                .entry(metric_name.clone())
+                .or_default()
+                .push(ts);
+            // A native histogram series carries no classic samples; only route it
+            // through the classic path if it also has float samples.
+            if ts.samples.is_empty() {
+                continue;
+            }
+        }
+
         let detected = detect_metric_type(&metric_name, metadata_map);
         metric_groups
             .entry(detected.base_name)
@@ -214,6 +235,12 @@ fn convert_resource_group(
 
     for (base_name, series) in metric_groups {
         if let Some(metric) = convert_metric_group(&base_name, &series, metadata_map) {
+            metrics.push(metric);
+        }
+    }
+
+    for (base_name, series) in native_histogram_groups {
+        if let Some(metric) = convert_native_histogram_metric(&base_name, &series, metadata_map) {
             metrics.push(metric);
         }
     }
@@ -602,6 +629,246 @@ impl PartialOrd for OrderedFloat {
     }
 }
 
+/// Valid Prometheus native histogram schema range for standard base-2
+/// exponential buckets. Values outside this range (e.g. -53/127 used for
+/// custom-bucket NHCB histograms) cannot be represented as OTLP exponential
+/// histograms.
+const NATIVE_HISTOGRAM_SCHEMA_RANGE: std::ops::RangeInclusive<i32> = -4..=8;
+
+/// Convert native histogram series (remote_write v2) to an OTLP
+/// ExponentialHistogram metric.
+///
+/// Prometheus native histograms and OTLP exponential histograms share the same
+/// base-2 bucket boundaries (`base = 2^(2^-schema)`), so `schema` maps directly
+/// onto `scale`. The span/delta encoding is decoded into OTLP's dense per-sign
+/// bucket arrays by [`decode_native_buckets`].
+///
+/// Unconvertible samples (unsupported schema, inconsistent span/delta encoding)
+/// are counted and dropped with a warning so the loss is observable.
+fn convert_native_histogram_metric(
+    base_name: &str,
+    series: &[&PrometheusTimeSeries],
+    metadata_map: &HashMap<&str, &PrometheusMetricMetadata>,
+) -> Option<Metric> {
+    let mut data_points = Vec::new();
+    let mut dropped_samples = 0usize;
+
+    for ts in series {
+        let attributes = convert_labels_to_attributes(&ts.labels);
+        let start_time = ts
+            .histograms
+            .first()
+            .map(|h| (h.timestamp as u64) * 1_000_000)
+            .unwrap_or(0);
+
+        for histogram in &ts.histograms {
+            // Stale markers signal series staleness, not data; skip silently
+            // like the classic sample path does.
+            if is_stale_marker(histogram.sum) {
+                continue;
+            }
+            match convert_native_histogram_sample(histogram, attributes.clone(), start_time) {
+                Some(dp) => data_points.push(dp),
+                None => dropped_samples += 1,
+            }
+        }
+    }
+
+    if dropped_samples > 0 {
+        tracing::warn!(
+            metric = base_name,
+            dropped_samples,
+            "Dropped native histogram samples that cannot be converted to OTLP exponential histograms"
+        );
+    }
+
+    if data_points.is_empty() {
+        return None;
+    }
+
+    let (description, unit) = if let Some(metadata) = metadata_map.get(base_name) {
+        (metadata.help.clone(), metadata.unit.clone())
+    } else {
+        (String::new(), String::new())
+    };
+
+    Some(Metric {
+        name: base_name.to_string(),
+        description,
+        unit,
+        data: Some(Data::ExponentialHistogram(ExponentialHistogram {
+            data_points,
+            aggregation_temporality: AggregationTemporality::Cumulative as i32,
+        })),
+        metadata: vec![KeyValue {
+            key_strindex: 0,
+            key: "prometheus.type".to_string(),
+            value: Some(AnyValue {
+                value: Some(any_value::Value::StringValue(
+                    prometheus_type_to_string(PrometheusMetricType::Histogram).to_string(),
+                )),
+            }),
+        }],
+    })
+}
+
+/// Convert a single native histogram sample to an OTLP
+/// ExponentialHistogramDataPoint. Returns `None` (after logging) for samples
+/// that cannot be represented.
+fn convert_native_histogram_sample(
+    histogram: &PrometheusHistogram,
+    attributes: Vec<KeyValue>,
+    start_time_unix_nano: u64,
+) -> Option<ExponentialHistogramDataPoint> {
+    if !NATIVE_HISTOGRAM_SCHEMA_RANGE.contains(&histogram.schema) {
+        tracing::warn!(
+            schema = histogram.schema,
+            "Dropping native histogram sample with unsupported schema (custom-bucket histograms cannot map to exponential buckets)"
+        );
+        return None;
+    }
+
+    let positive = match decode_native_buckets(
+        &histogram.positive_spans,
+        &histogram.positive_deltas,
+        &histogram.positive_counts,
+    ) {
+        Ok(buckets) => buckets,
+        Err(e) => {
+            tracing::warn!(error = %e, "Dropping native histogram sample with invalid positive buckets");
+            return None;
+        }
+    };
+    let negative = match decode_native_buckets(
+        &histogram.negative_spans,
+        &histogram.negative_deltas,
+        &histogram.negative_counts,
+    ) {
+        Ok(buckets) => buckets,
+        Err(e) => {
+            tracing::warn!(error = %e, "Dropping native histogram sample with invalid negative buckets");
+            return None;
+        }
+    };
+
+    Some(ExponentialHistogramDataPoint {
+        attributes,
+        start_time_unix_nano,
+        time_unix_nano: (histogram.timestamp as u64) * 1_000_000, // ms to ns
+        count: histogram.count,
+        sum: Some(histogram.sum),
+        scale: histogram.schema,
+        zero_count: histogram.zero_count,
+        positive,
+        negative,
+        flags: 0,
+        exemplars: vec![],
+        min: None,
+        max: None,
+        zero_threshold: histogram.zero_threshold,
+    })
+}
+
+/// Decode the Prometheus native histogram span/delta bucket encoding into
+/// OTLP's dense bucket encoding.
+///
+/// Prometheus encodes buckets as spans (`offset` + `length`) over a shared
+/// value array. The first span's offset is the absolute bucket index of its
+/// first bucket; subsequent spans are offset relative to the bucket after the
+/// previous span's last bucket. Integer histograms delta-encode counts (each
+/// value relative to the previous bucket's count, starting from 0); float
+/// histograms carry absolute counts.
+///
+/// OTLP uses a single dense `bucket_counts` array starting at `offset`, with
+/// gaps filled by zero counts. Prometheus bucket index `i` covers
+/// `(base^(i-1), base^i]` while OTLP index `i` covers `(base^i, base^(i+1)]`,
+/// so OTLP indexes are shifted down by one.
+///
+/// Returns `Ok(None)` for histograms without buckets on this sign, and an
+/// error for inconsistent encodings (span/count length mismatch, negative
+/// counts, overlapping spans).
+fn decode_native_buckets(
+    spans: &[BucketSpan],
+    deltas: &[i64],
+    counts: &[f64],
+) -> anyhow::Result<Option<Buckets>> {
+    let total_buckets: usize = spans.iter().map(|s| s.length as usize).sum();
+    let use_float_counts = deltas.is_empty() && !counts.is_empty();
+    let value_count = if use_float_counts {
+        counts.len()
+    } else {
+        deltas.len()
+    };
+
+    if total_buckets != value_count {
+        anyhow::bail!(
+            "span lengths sum to {total_buckets} buckets but {value_count} bucket values present"
+        );
+    }
+    if total_buckets == 0 {
+        return Ok(None);
+    }
+
+    let mut bucket_counts: Vec<u64> = Vec::with_capacity(total_buckets);
+    let mut running_count: i64 = 0;
+    let mut value_idx = 0usize;
+    let mut prom_idx: i64 = 0;
+    let mut first_index: Option<i64> = None;
+
+    for (span_idx, span) in spans.iter().enumerate() {
+        prom_idx = if span_idx == 0 {
+            i64::from(span.offset)
+        } else {
+            prom_idx + i64::from(span.offset)
+        };
+
+        for _ in 0..span.length {
+            if let Some(first) = first_index {
+                let dense_pos = usize::try_from(prom_idx - first)
+                    .map_err(|_| anyhow::anyhow!("out-of-order bucket spans"))?;
+                if dense_pos < bucket_counts.len() {
+                    anyhow::bail!("overlapping bucket spans");
+                }
+                // Fill gaps between spans with empty buckets
+                bucket_counts.resize(dense_pos, 0);
+            } else {
+                first_index = Some(prom_idx);
+            }
+
+            let count = if use_float_counts {
+                let c = counts[value_idx];
+                if !c.is_finite() || c < 0.0 {
+                    anyhow::bail!("negative or non-finite float bucket count {c}");
+                }
+                c.round() as u64
+            } else {
+                running_count = running_count
+                    .checked_add(deltas[value_idx])
+                    .ok_or_else(|| anyhow::anyhow!("bucket count delta overflow"))?;
+                if running_count < 0 {
+                    anyhow::bail!("negative cumulative bucket count {running_count}");
+                }
+                running_count as u64
+            };
+            bucket_counts.push(count);
+            value_idx += 1;
+            prom_idx += 1;
+        }
+    }
+
+    let first = first_index
+        .ok_or_else(|| anyhow::anyhow!("no buckets decoded despite non-zero span lengths"))?;
+    // OTLP bucket index = Prometheus bucket index - 1 (upper-bound vs
+    // lower-bound based indexing).
+    let offset = i32::try_from(first - 1)
+        .map_err(|_| anyhow::anyhow!("bucket offset {first} out of range"))?;
+
+    Ok(Some(Buckets {
+        offset,
+        bucket_counts,
+    }))
+}
+
 /// Convert summary component series to OTEL Summary
 fn convert_to_summary(series: &[&PrometheusTimeSeries], created_timestamp: Option<u64>) -> Data {
     // Group series by their attributes (excluding quantile label)
@@ -813,4 +1080,123 @@ fn convert_labels_to_attributes(labels: &[PrometheusLabel]) -> Vec<KeyValue> {
             }),
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spans(spec: &[(i32, u32)]) -> Vec<BucketSpan> {
+        spec.iter()
+            .map(|(offset, length)| BucketSpan {
+                offset: *offset,
+                length: *length,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn decode_native_buckets_single_span_shifts_index_down_by_one() {
+        // Prometheus indexes 1..=3 → OTLP offset 0, cumulative deltas resolved
+        let buckets = decode_native_buckets(&spans(&[(1, 3)]), &[2, 1, -1], &[])
+            .unwrap()
+            .expect("buckets");
+        assert_eq!(buckets.offset, 0);
+        assert_eq!(buckets.bucket_counts, vec![2, 3, 2]);
+    }
+
+    #[test]
+    fn decode_native_buckets_fills_gaps_between_spans_with_zeros() {
+        // Span 1: prometheus indexes 0,1; span 2 starts at 1 + 1 + 2 = 4
+        let buckets = decode_native_buckets(&spans(&[(0, 2), (2, 2)]), &[1, 1, -1, 2], &[])
+            .unwrap()
+            .expect("buckets");
+        assert_eq!(buckets.offset, -1);
+        assert_eq!(buckets.bucket_counts, vec![1, 2, 0, 0, 1, 3]);
+    }
+
+    #[test]
+    fn decode_native_buckets_negative_first_offset() {
+        // Prometheus indexes -2,-1 → OTLP offset -3
+        let buckets = decode_native_buckets(&spans(&[(-2, 2)]), &[4, 4], &[])
+            .unwrap()
+            .expect("buckets");
+        assert_eq!(buckets.offset, -3);
+        assert_eq!(buckets.bucket_counts, vec![4, 8]);
+    }
+
+    #[test]
+    fn decode_native_buckets_empty_returns_none() {
+        assert!(decode_native_buckets(&[], &[], &[]).unwrap().is_none());
+        // Zero-length spans with no values are also empty
+        assert!(
+            decode_native_buckets(&spans(&[(1, 0)]), &[], &[])
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn decode_native_buckets_length_mismatch_is_error() {
+        assert!(decode_native_buckets(&spans(&[(0, 2)]), &[1], &[]).is_err());
+        assert!(decode_native_buckets(&spans(&[(0, 1)]), &[], &[1.0, 2.0]).is_err());
+    }
+
+    #[test]
+    fn decode_native_buckets_negative_cumulative_count_is_error() {
+        assert!(decode_native_buckets(&spans(&[(0, 2)]), &[1, -2], &[]).is_err());
+    }
+
+    #[test]
+    fn decode_native_buckets_overlapping_spans_are_error() {
+        // Second span jumps backwards over the first
+        assert!(decode_native_buckets(&spans(&[(0, 2), (-4, 2)]), &[1, 1, 1, 1], &[]).is_err());
+    }
+
+    #[test]
+    fn decode_native_buckets_float_counts_are_absolute() {
+        let buckets = decode_native_buckets(&spans(&[(2, 2)]), &[], &[1.4, 2.6])
+            .unwrap()
+            .expect("buckets");
+        assert_eq!(buckets.offset, 1);
+        assert_eq!(buckets.bucket_counts, vec![1, 3]);
+    }
+
+    #[test]
+    fn convert_native_histogram_sample_maps_negative_buckets() {
+        let histogram = PrometheusHistogram {
+            count: 4,
+            sum: -3.5,
+            schema: 1,
+            zero_threshold: 0.001,
+            zero_count: 1,
+            negative_spans: spans(&[(0, 2)]),
+            negative_deltas: vec![2, -1],
+            timestamp: 1_700_000_000_000,
+            ..Default::default()
+        };
+
+        let dp = convert_native_histogram_sample(&histogram, vec![], 0).expect("data point");
+        assert_eq!(dp.scale, 1);
+        assert_eq!(dp.zero_count, 1);
+        assert_eq!(dp.zero_threshold, 0.001);
+        assert!(dp.positive.is_none());
+        let negative = dp.negative.expect("negative buckets");
+        assert_eq!(negative.offset, -1);
+        assert_eq!(negative.bucket_counts, vec![2, 1]);
+    }
+
+    #[test]
+    fn convert_native_histogram_sample_rejects_unsupported_schema() {
+        for schema in [-53, -5, 9, 127] {
+            let histogram = PrometheusHistogram {
+                schema,
+                ..Default::default()
+            };
+            assert!(
+                convert_native_histogram_sample(&histogram, vec![], 0).is_none(),
+                "schema {schema} should be rejected"
+            );
+        }
+    }
 }

--- a/src/common/src/flight/conversion/conversion_prometheus/types.rs
+++ b/src/common/src/flight/conversion/conversion_prometheus/types.rs
@@ -41,7 +41,7 @@ pub struct PrometheusSample {
 }
 
 /// A Prometheus native histogram (remote_write v2)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PrometheusHistogram {
     pub count: u64,
     pub sum: f64,
@@ -49,9 +49,17 @@ pub struct PrometheusHistogram {
     pub zero_threshold: f64,
     pub zero_count: u64,
     pub negative_spans: Vec<BucketSpan>,
+    /// Delta-encoded bucket counts (integer histograms); each value is
+    /// relative to the previous bucket count, starting from 0.
     pub negative_deltas: Vec<i64>,
+    /// Absolute bucket counts (float histograms); mutually exclusive with deltas.
+    pub negative_counts: Vec<f64>,
     pub positive_spans: Vec<BucketSpan>,
+    /// Delta-encoded bucket counts (integer histograms); each value is
+    /// relative to the previous bucket count, starting from 0.
     pub positive_deltas: Vec<i64>,
+    /// Absolute bucket counts (float histograms); mutually exclusive with deltas.
+    pub positive_counts: Vec<f64>,
     pub timestamp: i64,
 }
 

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -11,8 +11,8 @@ use axum::{
 use common::auth::Authenticator;
 use common::config::Configuration;
 use common::flight::conversion::{
-    PrometheusLabel, PrometheusMetricMetadata, PrometheusMetricType, PrometheusSample,
-    PrometheusTimeSeries, PrometheusWriteRequest,
+    PrometheusHistogram, PrometheusLabel, PrometheusMetricMetadata, PrometheusMetricType,
+    PrometheusSample, PrometheusTimeSeries, PrometheusWriteRequest,
 };
 use common::flight::transport::InMemoryFlightTransport;
 use common::service_bootstrap::{ServiceBootstrap, ServiceType};
@@ -53,7 +53,45 @@ fn encode_remote_write_request(request: &PrometheusWriteRequest) -> Vec<u8> {
                         )
                         .collect(),
                     exemplars: vec![],
-                    histograms: vec![],
+                    histograms: ts
+                        .histograms
+                        .iter()
+                        .map(|h| {
+                            common::flight::conversion::conversion_prometheus::proto::Histogram {
+                                count: Some(
+                                    common::flight::conversion::conversion_prometheus::proto::histogram::Count::CountInt(h.count),
+                                ),
+                                sum: h.sum,
+                                schema: h.schema,
+                                zero_threshold: h.zero_threshold,
+                                zero_count: Some(
+                                    common::flight::conversion::conversion_prometheus::proto::histogram::ZeroCount::ZeroCountInt(h.zero_count),
+                                ),
+                                negative_spans: h
+                                    .negative_spans
+                                    .iter()
+                                    .map(|s| common::flight::conversion::conversion_prometheus::proto::BucketSpan {
+                                        offset: s.offset,
+                                        length: s.length,
+                                    })
+                                    .collect(),
+                                negative_deltas: h.negative_deltas.clone(),
+                                negative_counts: h.negative_counts.clone(),
+                                positive_spans: h
+                                    .positive_spans
+                                    .iter()
+                                    .map(|s| common::flight::conversion::conversion_prometheus::proto::BucketSpan {
+                                        offset: s.offset,
+                                        length: s.length,
+                                    })
+                                    .collect(),
+                                positive_deltas: h.positive_deltas.clone(),
+                                positive_counts: h.positive_counts.clone(),
+                                reset_hint: 0,
+                                timestamp: h.timestamp,
+                            }
+                        })
+                        .collect(),
                 },
             )
             .collect(),
@@ -89,6 +127,13 @@ fn encode_remote_write_request(request: &PrometheusWriteRequest) -> Vec<u8> {
 
 /// Set up test infrastructure for Prometheus endpoint testing
 async fn setup_prometheus_test() -> (axum::Router, TempDir) {
+    let (app, _wal_manager, temp_dir) = setup_prometheus_test_with_wal().await;
+    (app, temp_dir)
+}
+
+/// Set up test infrastructure and also expose the WAL manager for
+/// asserting what was ingested.
+async fn setup_prometheus_test_with_wal() -> (axum::Router, Arc<WalManager>, TempDir) {
     let temp_dir = TempDir::new().unwrap();
 
     // Set up catalog
@@ -176,7 +221,7 @@ async fn setup_prometheus_test() -> (axum::Router, TempDir) {
     // Build router
     let app = prometheus_router(authenticator, prometheus_handler);
 
-    (app, temp_dir)
+    (app, wal_manager, temp_dir)
 }
 
 #[tokio::test]
@@ -367,6 +412,111 @@ async fn test_prometheus_remote_write_histogram() {
     let response = app.oneshot(http_request).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_prometheus_remote_write_native_histogram() {
+    let (app, wal_manager, _temp_dir) = setup_prometheus_test_with_wal().await;
+
+    let now = chrono::Utc::now().timestamp_millis();
+
+    // A remote_write v2 native histogram sample: span/delta encoded buckets
+    let request = PrometheusWriteRequest {
+        timeseries: vec![PrometheusTimeSeries {
+            labels: vec![
+                PrometheusLabel {
+                    name: "__name__".to_string(),
+                    value: "http_request_latency_seconds".to_string(),
+                },
+                PrometheusLabel {
+                    name: "job".to_string(),
+                    value: "api".to_string(),
+                },
+            ],
+            samples: vec![],
+            histograms: vec![PrometheusHistogram {
+                count: 6,
+                sum: 21.5,
+                schema: 3,
+                zero_threshold: 1e-128,
+                zero_count: 2,
+                positive_spans: vec![
+                    common::flight::conversion::BucketSpan {
+                        offset: 1,
+                        length: 2,
+                    },
+                    common::flight::conversion::BucketSpan {
+                        offset: 1,
+                        length: 1,
+                    },
+                ],
+                positive_deltas: vec![2, -1, 0],
+                timestamp: now,
+                ..Default::default()
+            }],
+        }],
+        metadata: vec![],
+    };
+
+    let body = encode_remote_write_request(&request);
+
+    let http_request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/write")
+        .header(header::CONTENT_TYPE, "application/x-protobuf")
+        .header(header::CONTENT_ENCODING, "snappy")
+        .header("X-Prometheus-Remote-Write-Version", "2.0.0")
+        .header("Authorization", "Bearer test-api-key")
+        .header("X-Tenant-ID", "test-tenant")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(http_request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // The native histogram must land in the exponential histogram table path,
+    // not be silently dropped.
+    let wal = wal_manager
+        .get_wal("test-tenant", "metrics", "metrics")
+        .await
+        .expect("WAL for tenant");
+    let entries = wal.get_entries().await.expect("WAL entries");
+    assert!(!entries.is_empty(), "expected WAL entries for ingestion");
+
+    let exp_entry = entries
+        .iter()
+        .find(|e| {
+            e.metadata
+                .as_deref()
+                .map(|m| m.contains("\"target_table\":\"metrics_exponential_histogram\""))
+                .unwrap_or(false)
+        })
+        .expect("WAL entry targeting metrics_exponential_histogram");
+
+    // Decode the stored batch and verify the metric round-trips
+    let data = wal
+        .read_entry_data(exp_entry)
+        .await
+        .expect("WAL entry data");
+    let batch = common::wal::bytes_to_record_batch(&data).expect("record batch");
+    assert!(batch.num_rows() > 0, "expected rows in exponential batch");
+
+    let schema = batch.schema();
+    let name_idx = schema.index_of("name").expect("name column");
+    let type_idx = schema.index_of("metric_type").expect("metric_type column");
+    let names = batch
+        .column(name_idx)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::StringArray>()
+        .expect("string name column");
+    let types = batch
+        .column(type_idx)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::StringArray>()
+        .expect("string metric_type column");
+
+    assert_eq!(names.value(0), "http_request_latency_seconds");
+    assert_eq!(types.value(0), "exponential_histogram");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Prometheus remote-write v2 native histogram samples were decoded into the internal `PrometheusHistogram` struct but never consumed — only classic `_bucket`/`_count`/`_sum` series were reconstructed into OTLP, so native histograms were lost silently.

This PR converts native histogram samples into OTLP `ExponentialHistogramDataPoint`s and routes them through the existing acceptor partitioning into the `metrics_exponential_histogram` table path.

### Conversion approach

- Prometheus `schema` maps directly onto OTLP `scale` (both use base `2^(2^-scale)` buckets).
- The span/delta encoding is decoded into OTLP's dense per-sign bucket arrays: deltas are cumulative (each relative to the previous bucket count, starting from 0), cross-span gaps become zero counts, and indexes are shifted down by one (Prometheus buckets are upper-bound indexed `(base^(i-1), base^i]`, OTLP lower-bound indexed `(base^i, base^(i+1)]`).
- Zero bucket (`zero_count`/`zero_threshold`), `count`, `sum`, and negative buckets are carried over; float histograms (absolute `positive_counts`/`negative_counts`) are supported too.
- Aggregation temporality is cumulative; stale-marker samples (`sum` = stale NaN) are skipped like classic samples.

### Observability of remaining loss

Unconvertible samples are dropped with structured `warn` logs instead of disappearing silently:
- unsupported schemas (outside `-4..=8`, e.g. custom-bucket NHCB histograms which cannot map to exponential buckets)
- inconsistent encodings (span/count length mismatch, negative cumulative counts, overlapping/out-of-order spans, non-finite float counts)

Plus a per-metric aggregate warn with the dropped-sample count.

### Tests

- Unit tests for the span/delta → dense conversion in `to_otel.rs` (single span index shift, multi-span gap fill, negative first offset, empty histogram, length mismatch, negative cumulative count, overlapping spans, float absolute counts, negative-bucket sample mapping, unsupported schema rejection).
- Public-API tests in `conversion_prometheus/mod.rs` (native series → exponential histogram metric with correct buckets/attributes, unsupported schema dropped, stale sample skipped, float histogram counts, metadata description/unit).
- Integration test `test_prometheus_remote_write_native_histogram`: full HTTP remote-write v2 request with a native histogram → 204, then asserts a WAL entry targeting `metrics_exponential_histogram` whose decoded RecordBatch contains the metric with `metric_type = "exponential_histogram"`.

Querying the `metrics_exponential_histogram` table is out of scope (#746).

Fixes #747