### PR TITLE
fix(self-monitoring): extend anti-loop guard to writer, querier, and router

### DIFF
--- a/docs/architecture/flight-communication.md
+++ b/docs/architecture/flight-communication.md
@@ -172,6 +172,20 @@ that protocol does not use tickets.
 
 There is no `trace_by_id?id=...` ticket form at the Querier; that command exists only in the Router's metadata path. The Tempo HTTP endpoints bypass the Router's Flight commands entirely and send `find_trace:`/`search_traces:`/SQL tickets straight to the Querier.
 
+#### Self-Monitoring Anti-Loop Guard
+
+When self-monitoring is enabled, both Flight handlers apply the anti-loop
+guard from `src/common/src/self_monitoring/suppress.rs`: requests that touch
+the reserved `_system` tenant are processed with OpenTelemetry export
+suppressed, so handling SignalDB's own telemetry does not generate more of
+it. The Writer's `do_put` suppresses per batch based on the tenant in the
+Flight metadata (its background WAL loop does the same per WAL entry), and
+the Querier's `do_get` resolves the tenant — authenticated caller, the
+`op:{tenant_slug}:...` ticket segment, or the `x-tenant-id` header for raw
+SQL — before creating its processing span. The suppression marker is a tokio
+task-local: it crosses neither the Flight hop between services nor
+`tokio::spawn`, which is why each handler carries its own call site.
+
 ## 5. Implementation Details
 
 ### 5.1 Current Data Flow ✅ **Working**

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -90,18 +90,34 @@ pub async fn auth_middleware(
         }
     };
 
-    log::debug!(
-        "Authenticated request for tenant '{}', dataset '{}' (source: {})",
-        tenant_context.tenant_id,
-        tenant_context.dataset_id,
-        tenant_context.source
-    );
+    // Anti-loop guard: processing the _system tenant's own telemetry must not
+    // generate more self-monitoring telemetry (infinite feedback loop). The
+    // suppression scope covers everything from here through the handler.
+    if crate::self_monitoring::is_self_monitoring_tenant(&tenant_context.tenant_id) {
+        crate::self_monitoring::suppress_self_telemetry(async move {
+            log::debug!(
+                "Authenticated request for tenant '{}', dataset '{}' (source: {})",
+                tenant_context.tenant_id,
+                tenant_context.dataset_id,
+                tenant_context.source
+            );
+            request.extensions_mut().insert(tenant_context);
+            next.run(request).await
+        })
+        .await
+    } else {
+        log::debug!(
+            "Authenticated request for tenant '{}', dataset '{}' (source: {})",
+            tenant_context.tenant_id,
+            tenant_context.dataset_id,
+            tenant_context.source
+        );
+        // Insert TenantContext into request extensions
+        request.extensions_mut().insert(tenant_context);
 
-    // Insert TenantContext into request extensions
-    request.extensions_mut().insert(tenant_context);
-
-    // Continue to next middleware/handler
-    next.run(request).await
+        // Continue to next middleware/handler
+        next.run(request).await
+    }
 }
 
 /// Axum middleware function for admin API authentication
@@ -373,6 +389,96 @@ mod tests {
 
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn system_tenant_requests_are_suppressed_from_otel_export() {
+        use axum::{Router, body::Body, http::Request, middleware, routing::get};
+        use tower::ServiceExt;
+
+        // Regression test for issue #760: the router's HTTP query handling
+        // goes through this middleware, so processing a _system-tenant
+        // request must not emit spans/log records that pass the OTel
+        // export filter (they would be re-ingested as _system telemetry).
+        let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
+        let make_tenant = |id: &str, key: &str| TenantConfig {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: id.to_string(),
+            default_dataset: Some("production".to_string()),
+            datasets: vec![DatasetConfig {
+                id: "production".to_string(),
+                slug: "production".to_string(),
+                is_default: true,
+                storage: None,
+            }],
+            api_keys: vec![ApiKeyConfig {
+                key: key.to_string(),
+                name: Some("test-key".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        };
+        let auth_config = AuthConfig {
+            tenants: vec![
+                make_tenant("_system", "system-key"),
+                make_tenant("acme", "acme-key"),
+            ],
+            ..Default::default()
+        };
+        let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+
+        async fn handler() -> &'static str {
+            tracing::info!("handling query request");
+            "ok"
+        }
+
+        let auth = authenticator.clone();
+        let app = Router::new()
+            .route("/query", get(handler))
+            .layer(middleware::from_fn(move |req, next| {
+                auth_middleware(auth.clone(), req, next)
+            }));
+
+        let send = |app: Router, key: &'static str, tenant: &'static str| async move {
+            let request = Request::builder()
+                .uri("/query")
+                .header("authorization", format!("Bearer {key}"))
+                .header("x-tenant-id", tenant)
+                .body(Body::empty())
+                .unwrap();
+            app.oneshot(request).await.unwrap()
+        };
+
+        // _system-tenant request: nothing may pass the export filter.
+        let probe = crate::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            let response = send(app.clone(), "system-key", "_system").await;
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+        assert_eq!(
+            probe.exported_events(),
+            0,
+            "_system request processing must not export log records"
+        );
+        assert_eq!(
+            probe.exported_spans(),
+            0,
+            "_system request processing must not export spans"
+        );
+
+        // Normal tenant: the handler's telemetry still exports.
+        let probe = crate::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            let response = send(app.clone(), "acme-key", "acme").await;
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+        assert!(
+            probe.exported_events() > 0,
+            "normal tenant request processing must still export telemetry"
+        );
     }
 
     #[test]

--- a/src/common/src/flight/trace_context.rs
+++ b/src/common/src/flight/trace_context.rs
@@ -74,8 +74,18 @@ pub fn inject_context_into_request<T>(request: &mut tonic::Request<T>) {
 /// parent can no longer be changed afterwards. Create the span, call this,
 /// then run the handler via `.instrument(span)`.
 pub fn set_parent_from_request<T>(span: &tracing::Span, request: &tonic::Request<T>) {
+    set_parent_from_metadata(span, request.metadata());
+}
+
+/// Extract the remote trace context from gRPC metadata and set it as
+/// `span`'s parent.
+///
+/// Variant of [`set_parent_from_request`] for call sites that have already
+/// consumed the request and only kept its metadata. Same caveat: must be
+/// called before `span` is first entered.
+pub fn set_parent_from_metadata(span: &tracing::Span, metadata: &tonic::metadata::MetadataMap) {
     let cx = opentelemetry::global::get_text_map_propagator(|propagator| {
-        propagator.extract(&MetadataMapExtractor(request.metadata()))
+        propagator.extract(&MetadataMapExtractor(metadata))
     });
     if let Err(err) = span.set_parent(cx) {
         // Benign when no OTel layer is attached (self-monitoring disabled).

--- a/src/common/src/self_monitoring/mod.rs
+++ b/src/common/src/self_monitoring/mod.rs
@@ -12,8 +12,8 @@ pub use app_metrics::{AppMetrics, app_metrics, http_metrics_middleware, should_c
 pub use profiling::{ProfilingHandle, init_profiling};
 pub use suppress::{
     OtelExportFilter, SELF_MONITORING_DATASET, SELF_MONITORING_TENANT,
-    SelfTelemetrySuppressionFilter, is_self_monitoring_tenant, self_telemetry_suppressed,
-    suppress_self_telemetry, suppress_self_telemetry_sync,
+    SelfTelemetrySuppressionFilter, is_self_monitoring_tenant, maybe_suppress_self_telemetry,
+    self_telemetry_suppressed, suppress_self_telemetry, suppress_self_telemetry_sync,
 };
 
 use anyhow::{Context, Result};

--- a/src/common/src/self_monitoring/suppress.rs
+++ b/src/common/src/self_monitoring/suppress.rs
@@ -11,6 +11,16 @@
 //! [`SelfTelemetrySuppressionFilter`] so that no spans or log records are
 //! exported while the marker is set. Ingestion still happens normally — the
 //! telemetry data itself is stored — it just isn't re-instrumented.
+//!
+//! The marker crosses neither process boundaries nor `tokio::spawn`, so
+//! every service needs its own call sites wherever it touches
+//! `_system`-tenant data: the acceptor's auth middleware and gRPC services,
+//! the writer's `do_put` and background WAL-processing loop, the querier's
+//! Flight query execution, and the HTTP auth middleware used by the router.
+//! When adding a new `_system` processing path (or a background task that
+//! handles `_system` batches), wrap it with one of the suppression helpers —
+//! otherwise its logs/spans are exported and re-ingested as `_system`
+//! telemetry, a self-sustaining feedback loop (issue #760).
 
 use std::future::Future;
 
@@ -44,6 +54,21 @@ pub async fn suppress_self_telemetry<F: Future>(fut: F) -> F::Output {
 /// Run `f` synchronously with self-monitoring telemetry export suppressed.
 pub fn suppress_self_telemetry_sync<T>(f: impl FnOnce() -> T) -> T {
     SUPPRESS_SELF_TELEMETRY.sync_scope((), f)
+}
+
+/// Run `fut` with self-monitoring telemetry export suppressed when
+/// `suppress` is true, unchanged otherwise.
+///
+/// Convenience for code paths that interleave tenants (e.g. the writer's
+/// WAL-processing loop or the querier's query execution): decide per
+/// batch/request with [`is_self_monitoring_tenant`] and wrap the processing
+/// future once.
+pub async fn maybe_suppress_self_telemetry<F: Future>(suppress: bool, fut: F) -> F::Output {
+    if suppress {
+        suppress_self_telemetry(fut).await
+    } else {
+        fut.await
+    }
 }
 
 /// Whether the current task is processing a self-monitoring request.

--- a/src/common/src/testing/mod.rs
+++ b/src/common/src/testing/mod.rs
@@ -24,5 +24,7 @@
 //! ```
 
 mod config_builder;
+mod otel_capture;
 
 pub use config_builder::TestConfigBuilder;
+pub use otel_capture::OtelExportProbe;

--- a/src/common/src/testing/otel_capture.rs
+++ b/src/common/src/testing/otel_capture.rs
@@ -1,0 +1,97 @@
+//! Test probe for the OpenTelemetry export layers.
+//!
+//! Regression harness for the self-monitoring anti-loop guard: processing
+//! `_system`-tenant data must not export any spans or log records (issue
+//! #760). The probe mirrors the production layer stack — a recording layer
+//! guarded by [`OtelExportFilter`] — and counts what would be exported.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::self_monitoring::OtelExportFilter;
+
+/// Counts the tracing events and spans that would reach the OpenTelemetry
+/// export layers, i.e. that pass [`OtelExportFilter`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let probe = OtelExportProbe::default();
+/// {
+///     let _guard = probe.install();
+///     process_system_tenant_batch().await;
+/// }
+/// assert_eq!(probe.exported_events(), 0);
+/// ```
+#[derive(Clone, Default)]
+pub struct OtelExportProbe {
+    events: Arc<AtomicUsize>,
+    spans: Arc<AtomicUsize>,
+}
+
+impl OtelExportProbe {
+    /// Create a new probe with zeroed counters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install a thread-default subscriber that counts everything passing
+    /// the export filter. Counting stops when the returned guard is
+    /// dropped.
+    ///
+    /// Mirrors the production stack built by `cli::utils::init_logging`: a
+    /// global info-level filter (the default log level) plus the per-layer
+    /// [`OtelExportFilter`] guarding the export layers.
+    #[must_use]
+    pub fn install(&self) -> tracing::subscriber::DefaultGuard {
+        let layer = CountingLayer {
+            events: self.events.clone(),
+            spans: self.spans.clone(),
+        };
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::INFO)
+            .with(layer.with_filter(OtelExportFilter));
+        tracing::subscriber::set_default(subscriber)
+    }
+
+    /// Number of events (log records) that passed the export filter.
+    pub fn exported_events(&self) -> usize {
+        self.events.load(Ordering::SeqCst)
+    }
+
+    /// Number of spans that passed the export filter.
+    pub fn exported_spans(&self) -> usize {
+        self.spans.load(Ordering::SeqCst)
+    }
+}
+
+struct CountingLayer {
+    events: Arc<AtomicUsize>,
+    spans: Arc<AtomicUsize>,
+}
+
+impl<S> Layer<S> for CountingLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(
+        &self,
+        _event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        self.events.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        self.spans.fetch_add(1, Ordering::SeqCst);
+    }
+}

--- a/src/querier/Cargo.toml
+++ b/src/querier/Cargo.toml
@@ -39,6 +39,9 @@ promql-parser.workspace = true
 
 # PromQL support
 
+[dev-dependencies]
+common = { path = "../common", features = ["testing"] }
+
 [[bin]]
 name = "signaldb-querier"
 path = "src/main.rs"

--- a/src/querier/src/flight.rs
+++ b/src/querier/src/flight.rs
@@ -1175,102 +1175,58 @@ impl FlightService for QuerierFlightService {
         &self,
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
+        let metadata = request.metadata().clone();
+        // Tenant-scoped caller identity, inserted by the Flight auth
+        // interceptor. None for internal-service callers and for
+        // deployments without Flight auth configured.
+        let caller_tenant = request
+            .extensions()
+            .get::<common::auth::TenantContext>()
+            .cloned();
+        let ticket = request.into_inner();
+        let ticket_content = String::from_utf8(ticket.ticket.to_vec())
+            .map_err(|e| Status::invalid_argument(format!("Invalid ticket: {e}")))?;
+
+        // Anti-loop guard (#760): executing a query over the _system
+        // tenant's own telemetry must not emit logs/spans that get exported
+        // and re-ingested as _system telemetry. The tenant is the
+        // authenticated caller when present, else the one named in the
+        // ticket (every prefixed ticket form is `op:tenant_slug:...`, so a
+        // cheap segment scan suffices before parsing — parsing itself
+        // logs), else (raw SQL from internal callers) the x-tenant-id
+        // header.
+        let suppress = caller_tenant
+            .as_ref()
+            .map(|ctx| ctx.tenant_id.as_str())
+            .or_else(|| metadata.get("x-tenant-id").and_then(|v| v.to_str().ok()))
+            .is_some_and(common::self_monitoring::is_self_monitoring_tenant)
+            || ticket_content
+                .split(':')
+                .nth(1)
+                .is_some_and(common::self_monitoring::is_self_monitoring_tenant);
+
         // Process within a span that joins the caller's distributed trace
         // (e.g. Router -> Querier); the parent must be set before the span
-        // is first entered.
-        let span = tracing::info_span!("flight_do_get");
-        common::flight::trace_context::set_parent_from_request(&span, &request);
-        async move {
-            let metadata = request.metadata().clone();
-            // Tenant-scoped caller identity, inserted by the Flight auth
-            // interceptor. None for internal-service callers and for
-            // deployments without Flight auth configured.
-            let caller_tenant = request
-                .extensions()
-                .get::<common::auth::TenantContext>()
-                .cloned();
-            let ticket = request.into_inner();
-            let ticket_content = String::from_utf8(ticket.ticket.to_vec())
-                .map_err(|e| Status::invalid_argument(format!("Invalid ticket: {e}")))?;
+        // is first entered. The span is created under the suppression scope
+        // so it is itself not exported for _system queries.
+        let make_span = || tracing::info_span!("flight_do_get");
+        let span = if suppress {
+            common::self_monitoring::suppress_self_telemetry_sync(make_span)
+        } else {
+            make_span()
+        };
+        common::flight::trace_context::set_parent_from_metadata(&span, &metadata);
+        common::self_monitoring::maybe_suppress_self_telemetry(
+            suppress,
+            async move {
+                tracing::info!(ticket = %ticket_content, "Processing Flight ticket");
 
-            tracing::info!(ticket = %ticket_content, "Processing Flight ticket");
+                // Parse ticket to determine request type
+                let ticket_request = self.parse_ticket(&ticket_content)?;
 
-            // Parse ticket to determine request type
-            let ticket_request = self.parse_ticket(&ticket_content)?;
-
-            // Tenant-scoped callers may only touch their own tenant's data,
-            // regardless of what the ticket claims.
-            if let Some(ctx) = &caller_tenant {
-                let ticket_tenant = match &ticket_request {
-                    TicketRequest::FindTrace { tenant_slug, .. }
-                    | TicketRequest::SearchTraces { tenant_slug, .. }
-                    | TicketRequest::FindProfile { tenant_slug, .. }
-                    | TicketRequest::SearchProfiles { tenant_slug, .. }
-                    | TicketRequest::ProfileTypes { tenant_slug, .. }
-                    | TicketRequest::ProfileLabelNames { tenant_slug, .. }
-                    | TicketRequest::ProfileLabelValues { tenant_slug, .. }
-                    | TicketRequest::ProfileFlamegraph { tenant_slug, .. }
-                    | TicketRequest::ProfileDiff { tenant_slug, .. }
-                    | TicketRequest::SqlProfiles { tenant_slug, .. }
-                    | TicketRequest::ProfilesByTrace { tenant_slug, .. }
-                    | TicketRequest::QueryLogs { tenant_slug, .. }
-                    | TicketRequest::QueryLogsLabels { tenant_slug, .. }
-                    | TicketRequest::QueryLogsLabelValues { tenant_slug, .. }
-                    | TicketRequest::QueryLogsSeries { tenant_slug, .. }
-                    | TicketRequest::QueryLogsDetectedFields { tenant_slug, .. }
-                    | TicketRequest::QueryMetric { tenant_slug, .. }
-                    | TicketRequest::QueryPromql { tenant_slug, .. }
-                    | TicketRequest::QueryMetricLabels { tenant_slug, .. }
-                    | TicketRequest::QueryMetricLabelValues { tenant_slug, .. }
-                    | TicketRequest::QueryMetricSeries { tenant_slug, .. } => Some(tenant_slug),
-                    TicketRequest::SqlQuery { .. } => None,
-                };
-                if let Some(ticket_tenant) = ticket_tenant
-                    && ticket_tenant != &ctx.tenant_slug
-                {
-                    tracing::warn!(
-                        caller_tenant = %ctx.tenant_slug,
-                        ticket_tenant = %ticket_tenant,
-                        "Rejecting cross-tenant Flight ticket"
-                    );
-                    return Err(Status::permission_denied(
-                        "ticket tenant does not match authenticated tenant",
-                    ));
-                }
-            }
-            let query_type = match &ticket_request {
-                TicketRequest::FindTrace { .. } => "trace_by_id",
-                TicketRequest::SearchTraces { .. } => "trace_search",
-                TicketRequest::FindProfile { .. } => "profile_by_id",
-                TicketRequest::SearchProfiles { .. } => "profile_search",
-                TicketRequest::ProfileTypes { .. } => "profile_types",
-                TicketRequest::ProfileLabelNames { .. } => "profile_label_names",
-                TicketRequest::ProfileLabelValues { .. } => "profile_label_values",
-                TicketRequest::ProfileFlamegraph { .. } => "profile_flamegraph",
-                TicketRequest::ProfileDiff { .. } => "profile_diff",
-                TicketRequest::SqlProfiles { .. } => "sql_profiles",
-                TicketRequest::ProfilesByTrace { .. } => "profiles_by_trace",
-                TicketRequest::QueryLogs { .. } => "query_logs",
-                TicketRequest::QueryLogsLabels { .. } => "query_logs_labels",
-                TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
-                TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
-                TicketRequest::QueryLogsDetectedFields { .. } => "query_logs_detected_fields",
-                TicketRequest::QueryMetric { .. } => "query_metric",
-                TicketRequest::QueryPromql { .. } => "query_promql",
-                TicketRequest::QueryMetricLabels { .. } => "query_metric_labels",
-                TicketRequest::QueryMetricLabelValues { .. } => "query_metric_label_values",
-                TicketRequest::QueryMetricSeries { .. } => "query_metric_series",
-                TicketRequest::SqlQuery { .. } => "sql",
-            };
-
-            // Per-tenant concurrent-query cap. The tenant is the
-            // authenticated caller when present, else the tenant named in
-            // the ticket (internal callers proxy on behalf of tenants).
-            // Internal raw-SQL callers carry no tenant and are exempt.
-            let permit_tenant = caller_tenant
-                .as_ref()
-                .map(|ctx| ctx.tenant_id.clone())
-                .or_else(|| match &ticket_request {
+                // The tenant named in the ticket, when it names one (raw
+                // SQL tickets carry the tenant out of band).
+                let ticket_tenant_slug: Option<String> = match &ticket_request {
                     TicketRequest::FindTrace { tenant_slug, .. }
                     | TicketRequest::SearchTraces { tenant_slug, .. }
                     | TicketRequest::FindProfile { tenant_slug, .. }
@@ -1295,519 +1251,575 @@ impl FlightService for QuerierFlightService {
                         Some(tenant_slug.clone())
                     }
                     TicketRequest::SqlQuery { .. } => None,
-                });
-            // Held until the query's batches are fully computed.
-            let _query_permit = match &permit_tenant {
-                Some(tenant) => self.try_acquire_query_permit(tenant)?,
-                None => None,
-            };
-            let query_start = std::time::Instant::now();
-            let query_future = async {
-                Ok(match ticket_request {
-                    TicketRequest::FindTrace {
-                        tenant_slug,
-                        dataset_slug,
-                        trace_id,
-                        start,
-                        end,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            trace_id = %trace_id,
-                            start = ?start,
-                            end = ?end,
-                            "Executing find_trace"
-                        );
+                };
 
-                        let params = FindTraceByIdParams {
+                // Tenant-scoped callers may only touch their own tenant's data,
+                // regardless of what the ticket claims.
+                if let Some(ctx) = &caller_tenant
+                    && let Some(ticket_tenant) = ticket_tenant_slug.as_deref()
+                    && ticket_tenant != ctx.tenant_slug
+                {
+                    tracing::warn!(
+                        caller_tenant = %ctx.tenant_slug,
+                        ticket_tenant = %ticket_tenant,
+                        "Rejecting cross-tenant Flight ticket"
+                    );
+                    return Err(Status::permission_denied(
+                        "ticket tenant does not match authenticated tenant",
+                    ));
+                }
+                let query_type = match &ticket_request {
+                    TicketRequest::FindTrace { .. } => "trace_by_id",
+                    TicketRequest::SearchTraces { .. } => "trace_search",
+                    TicketRequest::FindProfile { .. } => "profile_by_id",
+                    TicketRequest::SearchProfiles { .. } => "profile_search",
+                    TicketRequest::ProfileTypes { .. } => "profile_types",
+                    TicketRequest::ProfileLabelNames { .. } => "profile_label_names",
+                    TicketRequest::ProfileLabelValues { .. } => "profile_label_values",
+                    TicketRequest::ProfileFlamegraph { .. } => "profile_flamegraph",
+                    TicketRequest::ProfileDiff { .. } => "profile_diff",
+                    TicketRequest::SqlProfiles { .. } => "sql_profiles",
+                    TicketRequest::ProfilesByTrace { .. } => "profiles_by_trace",
+                    TicketRequest::QueryLogs { .. } => "query_logs",
+                    TicketRequest::QueryLogsLabels { .. } => "query_logs_labels",
+                    TicketRequest::QueryLogsLabelValues { .. } => "query_logs_label_values",
+                    TicketRequest::QueryLogsSeries { .. } => "query_logs_series",
+                    TicketRequest::QueryLogsDetectedFields { .. } => "query_logs_detected_fields",
+                    TicketRequest::QueryMetric { .. } => "query_metric",
+                    TicketRequest::QueryPromql { .. } => "query_promql",
+                    TicketRequest::QueryMetricLabels { .. } => "query_metric_labels",
+                    TicketRequest::QueryMetricLabelValues { .. } => "query_metric_label_values",
+                    TicketRequest::QueryMetricSeries { .. } => "query_metric_series",
+                    TicketRequest::SqlQuery { .. } => "sql",
+                };
+
+                // Per-tenant concurrent-query cap. The tenant is the
+                // authenticated caller when present, else the tenant named in
+                // the ticket (internal callers proxy on behalf of tenants).
+                // Internal raw-SQL callers carry no tenant and are exempt.
+                let permit_tenant = caller_tenant
+                    .as_ref()
+                    .map(|ctx| ctx.tenant_id.clone())
+                    .or_else(|| ticket_tenant_slug.clone());
+                // Held until the query's batches are fully computed.
+                let _query_permit = match &permit_tenant {
+                    Some(tenant) => self.try_acquire_query_permit(tenant)?,
+                    None => None,
+                };
+                let query_start = std::time::Instant::now();
+                let query_future = async {
+                    Ok(match ticket_request {
+                        TicketRequest::FindTrace {
+                            tenant_slug,
+                            dataset_slug,
                             trace_id,
                             start,
                             end,
-                        };
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                trace_id = %trace_id,
+                                start = ?start,
+                                end = ?end,
+                                "Executing find_trace"
+                            );
 
-                        match self
-                            .trace_service
-                            .find_by_id_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                        {
-                            Ok(Some(trace)) => {
-                                tracing::info!(span_count = trace.spans.len(), "Found trace");
-                                self.trace_to_record_batches(&trace).await.map_err(|e| {
-                                    Status::internal(format!(
-                                        "Failed to convert trace to batches: {e}"
-                                    ))
-                                })?
-                            }
-                            Ok(None) => {
-                                tracing::info!("No trace found");
-                                let e = crate::query::error::QuerierError::TraceNotFound;
-                                return Err(Status::not_found(e.to_string()));
-                            }
-                            Err(e) => {
-                                tracing::error!(error = ?e, "Error querying trace");
-                                // Mirror the search arm: caller errors are
-                                // surfaced as such instead of a blanket 500.
-                                return Err(match e {
-                                    crate::query::error::QuerierError::InvalidInput(msg) => {
-                                        Status::invalid_argument(msg)
-                                    }
-                                    crate::query::error::QuerierError::Unsupported(msg) => {
-                                        Status::unimplemented(msg)
-                                    }
-                                    other => {
-                                        Status::internal(format!("Trace query failed: {other:?}"))
-                                    }
-                                });
-                            }
-                        }
-                    }
-                    TicketRequest::SearchTraces {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            params = ?params,
-                            "Executing search_traces"
-                        );
+                            let params = FindTraceByIdParams {
+                                trace_id,
+                                start,
+                                end,
+                            };
 
-                        match self
-                            .trace_service
-                            .find_traces_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                        {
-                            Ok(traces) => {
-                                tracing::info!(trace_count = traces.len(), "Found traces");
-
-                                let mut all_batches = Vec::new();
-                                for trace in &traces {
-                                    let trace_batches =
-                                        self.trace_to_record_batches(trace).await.map_err(|e| {
-                                            Status::internal(format!(
-                                                "Failed to convert trace to batches: {e}"
-                                            ))
-                                        })?;
-                                    all_batches.extend(trace_batches);
+                            match self
+                                .trace_service
+                                .find_by_id_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                            {
+                                Ok(Some(trace)) => {
+                                    tracing::info!(span_count = trace.spans.len(), "Found trace");
+                                    self.trace_to_record_batches(&trace).await.map_err(|e| {
+                                        Status::internal(format!(
+                                            "Failed to convert trace to batches: {e}"
+                                        ))
+                                    })?
                                 }
-                                all_batches
-                            }
-                            Err(e) => {
-                                tracing::error!(error = ?e, "Error searching traces");
-                                // Distinguish caller errors from server
-                                // errors so bad or unsupported selectors
-                                // surface as 400/501, not 500.
-                                return Err(match e {
-                                    crate::query::error::QuerierError::InvalidInput(msg) => {
-                                        Status::invalid_argument(msg)
-                                    }
-                                    crate::query::error::QuerierError::Unsupported(msg) => {
-                                        Status::unimplemented(msg)
-                                    }
-                                    other => {
-                                        Status::internal(format!("Trace search failed: {other:?}"))
-                                    }
-                                });
+                                Ok(None) => {
+                                    tracing::info!("No trace found");
+                                    let e = crate::query::error::QuerierError::TraceNotFound;
+                                    return Err(Status::not_found(e.to_string()));
+                                }
+                                Err(e) => {
+                                    tracing::error!(error = ?e, "Error querying trace");
+                                    // Mirror the search arm: caller errors are
+                                    // surfaced as such instead of a blanket 500.
+                                    return Err(match e {
+                                        crate::query::error::QuerierError::InvalidInput(msg) => {
+                                            Status::invalid_argument(msg)
+                                        }
+                                        crate::query::error::QuerierError::Unsupported(msg) => {
+                                            Status::unimplemented(msg)
+                                        }
+                                        other => Status::internal(format!(
+                                            "Trace query failed: {other:?}"
+                                        )),
+                                    });
+                                }
                             }
                         }
-                    }
-                    TicketRequest::FindProfile {
-                        tenant_slug,
-                        dataset_slug,
-                        profile_id,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            profile_id = %profile_id,
-                            "Executing find_profile"
-                        );
-                        let batches = self
-                            .profile_service
-                            .find_by_id_with_tenant(
-                                FindProfileByIdParams { profile_id },
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        if batches.is_empty() {
-                            return Err(Status::not_found("Profile not found"));
+                        TicketRequest::SearchTraces {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                params = ?params,
+                                "Executing search_traces"
+                            );
+
+                            match self
+                                .trace_service
+                                .find_traces_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                            {
+                                Ok(traces) => {
+                                    tracing::info!(trace_count = traces.len(), "Found traces");
+
+                                    let mut all_batches = Vec::new();
+                                    for trace in &traces {
+                                        let trace_batches = self
+                                            .trace_to_record_batches(trace)
+                                            .await
+                                            .map_err(|e| {
+                                                Status::internal(format!(
+                                                    "Failed to convert trace to batches: {e}"
+                                                ))
+                                            })?;
+                                        all_batches.extend(trace_batches);
+                                    }
+                                    all_batches
+                                }
+                                Err(e) => {
+                                    tracing::error!(error = ?e, "Error searching traces");
+                                    // Distinguish caller errors from server
+                                    // errors so bad or unsupported selectors
+                                    // surface as 400/501, not 500.
+                                    return Err(match e {
+                                        crate::query::error::QuerierError::InvalidInput(msg) => {
+                                            Status::invalid_argument(msg)
+                                        }
+                                        crate::query::error::QuerierError::Unsupported(msg) => {
+                                            Status::unimplemented(msg)
+                                        }
+                                        other => Status::internal(format!(
+                                            "Trace search failed: {other:?}"
+                                        )),
+                                    });
+                                }
+                            }
                         }
-                        batches
-                    }
-                    TicketRequest::SearchProfiles {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            params = ?params,
-                            "Executing search_profiles"
-                        );
-                        self.profile_service
-                            .search_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?
-                    }
-                    TicketRequest::ProfileTypes {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let types = self
-                            .profile_service
-                            .profile_types_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("profile_type", types)?]
-                    }
-                    TicketRequest::ProfileLabelNames {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let names = self
-                            .profile_service
-                            .label_names_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("label_name", names)?]
-                    }
-                    TicketRequest::ProfileLabelValues {
-                        tenant_slug,
-                        dataset_slug,
-                        label_name,
-                        params,
-                    } => {
-                        let values = self
-                            .profile_service
-                            .label_values_with_tenant(
-                                &label_name,
-                                params,
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("label_value", values)?]
-                    }
-                    TicketRequest::ProfileFlamegraph {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let flamegraph = self
-                            .profile_service
-                            .flamegraph_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![json_to_batch("flamegraph", &flamegraph)?]
-                    }
-                    TicketRequest::ProfileDiff {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let diff = self
-                            .profile_service
-                            .diff_with_tenant(params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![json_to_batch("diff", &diff)?]
-                    }
-                    TicketRequest::ProfilesByTrace {
-                        tenant_slug,
-                        dataset_slug,
-                        trace_id,
-                        span_id,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            trace_id = %trace_id,
-                            span_id = ?span_id,
-                            "Executing profiles_by_trace"
-                        );
-                        self.profile_service
-                            .find_by_trace_with_tenant(
-                                &trace_id,
-                                span_id.as_deref(),
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?
-                    }
-                    TicketRequest::QueryLogs {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            query = %params.query,
-                            "Executing query_logs"
-                        );
-                        self.logs_service
-                            .query_logs(&params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?
-                    }
-                    TicketRequest::QueryLogsLabels {
-                        tenant_slug,
-                        dataset_slug,
-                        start,
-                        end,
-                    } => {
-                        let labels = self
-                            .logs_service
-                            .get_labels(start, end, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("label", labels)?]
-                    }
-                    TicketRequest::QueryLogsLabelValues {
-                        tenant_slug,
-                        dataset_slug,
-                        label,
-                        start,
-                        end,
-                    } => {
-                        let values = self
-                            .logs_service
-                            .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("value", values)?]
-                    }
-                    TicketRequest::QueryLogsSeries {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let series = self
-                            .logs_service
-                            .get_series(
-                                &params.selector,
-                                params.start,
-                                params.end,
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![json_to_batch("series", &series)?]
-                    }
-                    TicketRequest::QueryLogsDetectedFields {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let fields = self
-                            .logs_service
-                            .detected_fields(&params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![json_to_batch("fields", &fields)?]
-                    }
-                    TicketRequest::QueryMetric {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            query = %params.query,
-                            "Executing query_metric"
-                        );
-                        self.logs_service
-                            .query_metric(&params, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?
-                    }
-                    TicketRequest::QueryPromql {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            query = %params.query,
-                            "Executing query_promql"
-                        );
-                        self.metrics_service
-                            .query_range(
-                                &params.query,
-                                params.start,
-                                params.end,
-                                params.step,
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?
-                    }
-                    TicketRequest::QueryMetricLabels {
-                        tenant_slug,
-                        dataset_slug,
-                        start,
-                        end,
-                    } => {
-                        let labels = self
-                            .metrics_service
-                            .get_labels(start, end, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("label", labels)?]
-                    }
-                    TicketRequest::QueryMetricLabelValues {
-                        tenant_slug,
-                        dataset_slug,
-                        label,
-                        start,
-                        end,
-                    } => {
-                        let values = self
-                            .metrics_service
-                            .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![strings_to_batch("value", values)?]
-                    }
-                    TicketRequest::QueryMetricSeries {
-                        tenant_slug,
-                        dataset_slug,
-                        params,
-                    } => {
-                        let series = self
-                            .metrics_service
-                            .get_series(
-                                &params.selector,
-                                params.start,
-                                params.end,
-                                &tenant_slug,
-                                &dataset_slug,
-                            )
-                            .await
-                            .map_err(querier_error_to_status)?;
-                        vec![json_to_batch("series", &series)?]
-                    }
-                    TicketRequest::SqlProfiles {
-                        tenant_slug,
-                        dataset_slug,
-                        sql,
-                    } => {
-                        tracing::info!(
-                            tenant_slug = %tenant_slug,
-                            dataset_slug = %dataset_slug,
-                            sql = %sql,
-                            "Executing sql_profiles"
-                        );
-                        // Pin the session defaults to the ticket's
-                        // tenant/dataset so unqualified table names like
-                        // `profiles` resolve inside the tenant's catalog.
-                        let request_ctx =
-                            self.session_for_request(Some(&tenant_slug), Some(&dataset_slug));
-                        self.execute_distributed_query(&request_ctx, &sql)
-                            .await
-                            .map_err(|e| {
-                                Status::internal(format!("Profiles SQL query failed: {e}"))
-                            })?
-                    }
-                    TicketRequest::SqlQuery { sql } => {
-                        // Tenant-scoped callers are pinned to their
-                        // authenticated tenant/dataset; only internal or
-                        // unauthenticated callers may scope via headers.
-                        let (tenant_slug, dataset_slug) = match &caller_tenant {
-                            Some(ctx) => (
-                                Some(ctx.tenant_slug.clone()),
-                                Some(ctx.dataset_slug.clone()),
-                            ),
-                            None => (
-                                metadata
-                                    .get("x-tenant-id")
-                                    .and_then(|v| v.to_str().ok())
-                                    .map(|s| s.to_string()),
-                                metadata
-                                    .get("x-dataset-id")
-                                    .and_then(|v| v.to_str().ok())
-                                    .map(|s| s.to_string()),
-                            ),
-                        };
+                        TicketRequest::FindProfile {
+                            tenant_slug,
+                            dataset_slug,
+                            profile_id,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                profile_id = %profile_id,
+                                "Executing find_profile"
+                            );
+                            let batches = self
+                                .profile_service
+                                .find_by_id_with_tenant(
+                                    FindProfileByIdParams { profile_id },
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            if batches.is_empty() {
+                                return Err(Status::not_found("Profile not found"));
+                            }
+                            batches
+                        }
+                        TicketRequest::SearchProfiles {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                params = ?params,
+                                "Executing search_profiles"
+                            );
+                            self.profile_service
+                                .search_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?
+                        }
+                        TicketRequest::ProfileTypes {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let types = self
+                                .profile_service
+                                .profile_types_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("profile_type", types)?]
+                        }
+                        TicketRequest::ProfileLabelNames {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let names = self
+                                .profile_service
+                                .label_names_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("label_name", names)?]
+                        }
+                        TicketRequest::ProfileLabelValues {
+                            tenant_slug,
+                            dataset_slug,
+                            label_name,
+                            params,
+                        } => {
+                            let values = self
+                                .profile_service
+                                .label_values_with_tenant(
+                                    &label_name,
+                                    params,
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("label_value", values)?]
+                        }
+                        TicketRequest::ProfileFlamegraph {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let flamegraph = self
+                                .profile_service
+                                .flamegraph_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![json_to_batch("flamegraph", &flamegraph)?]
+                        }
+                        TicketRequest::ProfileDiff {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let diff = self
+                                .profile_service
+                                .diff_with_tenant(params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![json_to_batch("diff", &diff)?]
+                        }
+                        TicketRequest::ProfilesByTrace {
+                            tenant_slug,
+                            dataset_slug,
+                            trace_id,
+                            span_id,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                trace_id = %trace_id,
+                                span_id = ?span_id,
+                                "Executing profiles_by_trace"
+                            );
+                            self.profile_service
+                                .find_by_trace_with_tenant(
+                                    &trace_id,
+                                    span_id.as_deref(),
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?
+                        }
+                        TicketRequest::QueryLogs {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                query = %params.query,
+                                "Executing query_logs"
+                            );
+                            self.logs_service
+                                .query_logs(&params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?
+                        }
+                        TicketRequest::QueryLogsLabels {
+                            tenant_slug,
+                            dataset_slug,
+                            start,
+                            end,
+                        } => {
+                            let labels = self
+                                .logs_service
+                                .get_labels(start, end, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("label", labels)?]
+                        }
+                        TicketRequest::QueryLogsLabelValues {
+                            tenant_slug,
+                            dataset_slug,
+                            label,
+                            start,
+                            end,
+                        } => {
+                            let values = self
+                                .logs_service
+                                .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("value", values)?]
+                        }
+                        TicketRequest::QueryLogsSeries {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let series = self
+                                .logs_service
+                                .get_series(
+                                    &params.selector,
+                                    params.start,
+                                    params.end,
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![json_to_batch("series", &series)?]
+                        }
+                        TicketRequest::QueryLogsDetectedFields {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let fields = self
+                                .logs_service
+                                .detected_fields(&params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![json_to_batch("fields", &fields)?]
+                        }
+                        TicketRequest::QueryMetric {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                query = %params.query,
+                                "Executing query_metric"
+                            );
+                            self.logs_service
+                                .query_metric(&params, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?
+                        }
+                        TicketRequest::QueryPromql {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                query = %params.query,
+                                "Executing query_promql"
+                            );
+                            self.metrics_service
+                                .query_range(
+                                    &params.query,
+                                    params.start,
+                                    params.end,
+                                    params.step,
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?
+                        }
+                        TicketRequest::QueryMetricLabels {
+                            tenant_slug,
+                            dataset_slug,
+                            start,
+                            end,
+                        } => {
+                            let labels = self
+                                .metrics_service
+                                .get_labels(start, end, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("label", labels)?]
+                        }
+                        TicketRequest::QueryMetricLabelValues {
+                            tenant_slug,
+                            dataset_slug,
+                            label,
+                            start,
+                            end,
+                        } => {
+                            let values = self
+                                .metrics_service
+                                .get_label_values(&label, start, end, &tenant_slug, &dataset_slug)
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![strings_to_batch("value", values)?]
+                        }
+                        TicketRequest::QueryMetricSeries {
+                            tenant_slug,
+                            dataset_slug,
+                            params,
+                        } => {
+                            let series = self
+                                .metrics_service
+                                .get_series(
+                                    &params.selector,
+                                    params.start,
+                                    params.end,
+                                    &tenant_slug,
+                                    &dataset_slug,
+                                )
+                                .await
+                                .map_err(querier_error_to_status)?;
+                            vec![json_to_batch("series", &series)?]
+                        }
+                        TicketRequest::SqlProfiles {
+                            tenant_slug,
+                            dataset_slug,
+                            sql,
+                        } => {
+                            tracing::info!(
+                                tenant_slug = %tenant_slug,
+                                dataset_slug = %dataset_slug,
+                                sql = %sql,
+                                "Executing sql_profiles"
+                            );
+                            // Pin the session defaults to the ticket's
+                            // tenant/dataset so unqualified table names like
+                            // `profiles` resolve inside the tenant's catalog.
+                            let request_ctx =
+                                self.session_for_request(Some(&tenant_slug), Some(&dataset_slug));
+                            self.execute_distributed_query(&request_ctx, &sql)
+                                .await
+                                .map_err(|e| {
+                                    Status::internal(format!("Profiles SQL query failed: {e}"))
+                                })?
+                        }
+                        TicketRequest::SqlQuery { sql } => {
+                            // Tenant-scoped callers are pinned to their
+                            // authenticated tenant/dataset; only internal or
+                            // unauthenticated callers may scope via headers.
+                            let (tenant_slug, dataset_slug) = match &caller_tenant {
+                                Some(ctx) => (
+                                    Some(ctx.tenant_slug.clone()),
+                                    Some(ctx.dataset_slug.clone()),
+                                ),
+                                None => (
+                                    metadata
+                                        .get("x-tenant-id")
+                                        .and_then(|v| v.to_str().ok())
+                                        .map(|s| s.to_string()),
+                                    metadata
+                                        .get("x-dataset-id")
+                                        .and_then(|v| v.to_str().ok())
+                                        .map(|s| s.to_string()),
+                                ),
+                            };
 
-                        tracing::info!(
-                            tenant_id = ?tenant_slug,
-                            dataset_id = ?dataset_slug,
-                            sql = %sql,
-                            "Executing SQL query"
-                        );
+                            tracing::info!(
+                                tenant_id = ?tenant_slug,
+                                dataset_id = ?dataset_slug,
+                                sql = %sql,
+                                "Executing SQL query"
+                            );
 
-                        // Per-request context: tenant/dataset defaults must
-                        // never be applied to the shared session (see
-                        // session_for_request).
-                        let request_ctx = self
-                            .session_for_request(tenant_slug.as_deref(), dataset_slug.as_deref());
+                            // Per-request context: tenant/dataset defaults must
+                            // never be applied to the shared session (see
+                            // session_for_request).
+                            let request_ctx = self.session_for_request(
+                                tenant_slug.as_deref(),
+                                dataset_slug.as_deref(),
+                            );
 
-                        self.execute_distributed_query(&request_ctx, &sql)
-                            .await
-                            .map_err(|e| Status::internal(format!("Query execution failed: {e}")))?
-                    }
-                })
-            };
-            // Bound every query's wall-clock time so a heavy scan cannot
-            // occupy the querier indefinitely.
-            let batches_result: Result<Vec<_>, Status> =
-                match tokio::time::timeout(self.limits.query_timeout, query_future).await {
-                    Ok(result) => result,
-                    Err(_) => Err(Status::deadline_exceeded(format!(
-                        "query exceeded the configured timeout of {:?}",
-                        self.limits.query_timeout
-                    ))),
+                            self.execute_distributed_query(&request_ctx, &sql)
+                                .await
+                                .map_err(|e| {
+                                    Status::internal(format!("Query execution failed: {e}"))
+                                })?
+                        }
+                    })
                 };
+                // Bound every query's wall-clock time so a heavy scan cannot
+                // occupy the querier indefinitely.
+                let batches_result: Result<Vec<_>, Status> =
+                    match tokio::time::timeout(self.limits.query_timeout, query_future).await {
+                        Ok(result) => result,
+                        Err(_) => Err(Status::deadline_exceeded(format!(
+                            "query exceeded the configured timeout of {:?}",
+                            self.limits.query_timeout
+                        ))),
+                    };
 
-            let app_metrics = common::self_monitoring::app_metrics();
-            let query_attrs = [opentelemetry::KeyValue::new("query_type", query_type)];
-            app_metrics
-                .query_duration
-                .record(query_start.elapsed().as_secs_f64(), &query_attrs);
-            app_metrics.flight_request_duration.record(
-                query_start.elapsed().as_secs_f64(),
-                &[opentelemetry::KeyValue::new("rpc.method", "do_get")],
-            );
-            let batches = match batches_result {
-                Ok(batches) => batches,
-                Err(status) => {
-                    app_metrics.query_errors.add(1, &query_attrs);
-                    return Err(status);
+                let app_metrics = common::self_monitoring::app_metrics();
+                let query_attrs = [opentelemetry::KeyValue::new("query_type", query_type)];
+                app_metrics
+                    .query_duration
+                    .record(query_start.elapsed().as_secs_f64(), &query_attrs);
+                app_metrics.flight_request_duration.record(
+                    query_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("rpc.method", "do_get")],
+                );
+                let batches = match batches_result {
+                    Ok(batches) => batches,
+                    Err(status) => {
+                        app_metrics.query_errors.add(1, &query_attrs);
+                        return Err(status);
+                    }
+                };
+                let rows_returned: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+                app_metrics
+                    .query_rows_returned
+                    .record(rows_returned, &query_attrs);
+
+                if batches.is_empty() {
+                    let out = stream::empty().boxed();
+                    return Ok(Response::new(out));
                 }
-            };
-            let rows_returned: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-            app_metrics
-                .query_rows_returned
-                .record(rows_returned, &query_attrs);
 
-            if batches.is_empty() {
-                let out = stream::empty().boxed();
-                return Ok(Response::new(out));
+                // Convert results to Flight data
+                let schema = batches[0].schema();
+                let flight_data = batches_to_flight_data(&schema, batches)
+                    .map_err(|e| Status::internal(format!("Failed to convert results: {e}")))?;
+
+                let out = stream::iter(flight_data.into_iter().map(Ok)).boxed();
+                Ok(Response::new(out))
             }
-
-            // Convert results to Flight data
-            let schema = batches[0].schema();
-            let flight_data = batches_to_flight_data(&schema, batches)
-                .map_err(|e| Status::internal(format!("Failed to convert results: {e}")))?;
-
-            let out = stream::iter(flight_data.into_iter().map(Ok)).boxed();
-            Ok(Response::new(out))
-        }
-        .instrument(span)
+            .instrument(span),
+        )
         .await
     }
 
@@ -2397,6 +2409,59 @@ mod tests {
             Ok(_) => panic!("cross-tenant ticket must be rejected"),
             Err(status) => assert_eq!(status.code(), tonic::Code::PermissionDenied),
         }
+    }
+
+    #[tokio::test]
+    async fn system_tenant_query_is_suppressed_from_otel_export() {
+        // Regression test for issue #760: executing a query for the
+        // _system tenant must not emit spans/log records that pass the
+        // OTel export filter — they would be exported and re-ingested as
+        // _system telemetry (feedback loop). A normal tenant's query
+        // telemetry must still export.
+        let service = make_service().await;
+
+        let query = |tenant: &str| {
+            let mut request = Request::new(Ticket::new(format!(
+                "find_trace:{tenant}:_monitoring:abc123"
+            )));
+            request
+                .extensions_mut()
+                .insert(common::auth::TenantContext::new(
+                    tenant.to_string(),
+                    "_monitoring".to_string(),
+                    tenant.to_string(),
+                    "_monitoring".to_string(),
+                    None,
+                    common::auth::TenantSource::Config,
+                ));
+            request
+        };
+
+        let probe = common::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            let _ = service.do_get(query("_system")).await;
+        }
+        assert_eq!(
+            probe.exported_events(),
+            0,
+            "_system query processing must not export log records"
+        );
+        assert_eq!(
+            probe.exported_spans(),
+            0,
+            "_system query processing must not export spans"
+        );
+
+        let probe = common::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            let _ = service.do_get(query("tenant_a")).await;
+        }
+        assert!(
+            probe.exported_events() > 0,
+            "normal tenant query processing must still export telemetry"
+        );
     }
 
     #[tokio::test]

--- a/src/writer/Cargo.toml
+++ b/src/writer/Cargo.toml
@@ -58,6 +58,7 @@ harness = false
 required-features = ["benchmarks"]
 
 [dev-dependencies]
+common = { workspace = true, features = ["testing"] }
 tokio-stream.workspace = true
 
 [package.metadata.cargo-machete]

--- a/src/writer/src/flight_iceberg.rs
+++ b/src/writer/src/flight_iceberg.rs
@@ -151,12 +151,6 @@ impl FlightService for IcebergWriterFlightService {
             if flight_metadata.is_none() && !d.app_metadata.is_empty() {
                 match extract_flight_metadata(&d.app_metadata) {
                     Ok(metadata) => {
-                        tracing::info!(
-                            schema_version = %metadata.schema_version,
-                            signal_type = ?metadata.signal_type,
-                            target_table = ?metadata.target_table,
-                            "Received data"
-                        );
                         flight_metadata = Some(metadata);
                     }
                     Err(e) => {
@@ -181,9 +175,24 @@ impl FlightService for IcebergWriterFlightService {
             return Err(Status::invalid_argument("No FlightData received"));
         }
 
+        // Anti-loop guard (#760): persisting the _system tenant's own
+        // telemetry must not emit logs/spans that get exported and
+        // re-ingested as _system telemetry.
+        let suppress = flight_metadata
+            .as_ref()
+            .and_then(|m| m.tenant_id.as_deref())
+            .is_some_and(common::self_monitoring::is_self_monitoring_tenant);
+
         // Process within a span that joins the sender's distributed trace
-        // (parent must be set before the span is first entered).
-        let span = tracing::info_span!("flight_do_put");
+        // (parent must be set before the span is first entered). The span is
+        // created under the suppression scope so it is itself not exported
+        // for _system batches.
+        let make_span = || tracing::info_span!("flight_do_put");
+        let span = if suppress {
+            common::self_monitoring::suppress_self_telemetry_sync(make_span)
+        } else {
+            make_span()
+        };
         if let Some(ref metadata) = flight_metadata {
             common::flight::trace_context::set_parent_from_fields(
                 &span,
@@ -191,7 +200,16 @@ impl FlightService for IcebergWriterFlightService {
                 metadata.tracestate.as_deref(),
             );
         }
-        async move {
+        common::self_monitoring::maybe_suppress_self_telemetry(suppress, async move {
+        if let Some(ref metadata) = flight_metadata {
+            tracing::info!(
+                schema_version = %metadata.schema_version,
+                signal_type = ?metadata.signal_type,
+                target_table = ?metadata.target_table,
+                "Received data"
+            );
+        }
+
         // Convert FlightData stream into Arrow RecordBatches
         let batches =
             flight_data_to_batches(&data_vec).map_err(|e| Status::internal(e.to_string()))?;
@@ -321,7 +339,7 @@ impl FlightService for IcebergWriterFlightService {
         let out = stream::once(async move { Ok(result) }).boxed();
         Ok(Response::new(out))
         }
-        .instrument(span)
+        .instrument(span))
         .await
     }
 

--- a/src/writer/src/processor.rs
+++ b/src/writer/src/processor.rs
@@ -100,15 +100,27 @@ impl WalProcessor {
                     continue;
                 }
             };
-            let batch = match self.deserialize_entry_data(&entry).await {
+            let (tenant_id, dataset_id, table_name) = routed;
+            // Anti-loop guard (#760): processing the _system tenant's own
+            // telemetry must not emit logs/spans that get exported and
+            // re-ingested as _system telemetry.
+            let suppress = common::self_monitoring::is_self_monitoring_tenant(&tenant_id);
+            let batch = match common::self_monitoring::maybe_suppress_self_telemetry(
+                suppress,
+                self.deserialize_entry_data(&entry),
+            )
+            .await
+            {
                 Ok(batch) => batch,
                 Err(e) => {
-                    tracing::warn!(entry_id = %entry.id, error = %e, "Failed to deserialize WAL entry");
-                    self.record_entry_failure(entry.id).await;
+                    common::self_monitoring::maybe_suppress_self_telemetry(suppress, async {
+                        tracing::warn!(entry_id = %entry.id, error = %e, "Failed to deserialize WAL entry");
+                        self.record_entry_failure(entry.id).await;
+                    })
+                    .await;
                     continue;
                 }
             };
-            let (tenant_id, dataset_id, table_name) = routed;
 
             grouped_entries
                 .entry((tenant_id, dataset_id, table_name))
@@ -121,28 +133,35 @@ impl WalProcessor {
         // the idempotency-marker invariant.
         for ((tenant_id, dataset_id, table_name), entries) in grouped_entries {
             let group_ids: Vec<Uuid> = entries.iter().map(|(id, _)| *id).collect();
-            match self
-                .process_batch_for_table(&tenant_id, &dataset_id, &table_name, entries)
-                .await
-            {
-                Ok(processed_ids) => {
-                    for entry_id in &processed_ids {
-                        self.entry_failures.remove(entry_id);
+            // Anti-loop guard (#760): suppression is per group because the
+            // loop interleaves tenants — only the _system tenant's batches
+            // must not be re-instrumented.
+            let suppress = common::self_monitoring::is_self_monitoring_tenant(&tenant_id);
+            common::self_monitoring::maybe_suppress_self_telemetry(suppress, async {
+                match self
+                    .process_batch_for_table(&tenant_id, &dataset_id, &table_name, entries)
+                    .await
+                {
+                    Ok(processed_ids) => {
+                        for entry_id in &processed_ids {
+                            self.entry_failures.remove(entry_id);
+                        }
+                        tracing::debug!(
+                            entry_count = processed_ids.len(),
+                            tenant_id = %tenant_id,
+                            table_name = %table_name,
+                            "Processed and marked entries for table"
+                        );
                     }
-                    tracing::debug!(
-                        entry_count = processed_ids.len(),
-                        tenant_id = %tenant_id,
-                        table_name = %table_name,
-                        "Processed and marked entries for table"
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(tenant_id = %tenant_id, table_name = %table_name, error = %e, "Failed to process batch for table");
-                    for entry_id in group_ids {
-                        self.record_entry_failure(entry_id).await;
+                    Err(e) => {
+                        tracing::error!(tenant_id = %tenant_id, table_name = %table_name, error = %e, "Failed to process batch for table");
+                        for entry_id in group_ids {
+                            self.record_entry_failure(entry_id).await;
+                        }
                     }
                 }
-            }
+            })
+            .await;
         }
 
         Ok(())
@@ -360,26 +379,33 @@ impl WalProcessor {
         }
 
         let (tenant_id, dataset_id, table_name) = self.determine_target_table(&entry)?;
-        let batch = self.deserialize_entry_data(&entry).await?;
+        // Anti-loop guard (#760): processing the _system tenant's own
+        // telemetry must not emit logs/spans that get exported and
+        // re-ingested as _system telemetry.
+        let suppress = common::self_monitoring::is_self_monitoring_tenant(&tenant_id);
+        common::self_monitoring::maybe_suppress_self_telemetry(suppress, async {
+            let batch = self.deserialize_entry_data(&entry).await?;
 
-        match self
-            .process_batch_for_table(
-                &tenant_id,
-                &dataset_id,
-                &table_name,
-                vec![(entry_id, batch)],
-            )
-            .await
-        {
-            Ok(_) => {
-                tracing::debug!(entry_id = %entry_id, "Successfully processed single WAL entry");
-                Ok(())
+            match self
+                .process_batch_for_table(
+                    &tenant_id,
+                    &dataset_id,
+                    &table_name,
+                    vec![(entry_id, batch)],
+                )
+                .await
+            {
+                Ok(_) => {
+                    tracing::debug!(entry_id = %entry_id, "Successfully processed single WAL entry");
+                    Ok(())
+                }
+                Err(e) => {
+                    tracing::error!(entry_id = %entry_id, error = %e, "Failed to process WAL entry");
+                    Err(e)
+                }
             }
-            Err(e) => {
-                tracing::error!(entry_id = %entry_id, error = %e, "Failed to process WAL entry");
-                Err(e)
-            }
-        }
+        })
+        .await
     }
 
     /// Get statistics about the processor
@@ -551,6 +577,76 @@ mod tests {
             .join(format!("{}.bin", entry_id.simple()));
         let preserved = tokio::fs::read(&dead_letter_path).await.unwrap();
         assert_eq!(preserved, b"not arrow ipc");
+    }
+
+    #[tokio::test]
+    async fn system_tenant_wal_processing_is_suppressed_from_otel_export() {
+        // Regression test for issue #760: the background WAL-processing
+        // loop must not emit log records that pass the OTel export filter
+        // while processing _system-tenant entries — they would be exported
+        // and re-ingested as _system telemetry (feedback loop). A normal
+        // tenant's processing logs must still export.
+        //
+        // Garbage payloads route fine but fail deserialization, which
+        // makes the loop emit warn-level logs — exactly the kind of
+        // telemetry that fed the loop.
+        let temp_dir = tempdir().unwrap();
+        let wal_config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            max_segment_size: 1024 * 1024,
+            max_buffer_entries: 1000,
+            flush_interval_secs: 5,
+            tenant_id: "default".to_string(),
+            dataset_id: "default".to_string(),
+            retention_secs: 3600,
+            cleanup_interval_secs: 300,
+            compaction_threshold: 0.5,
+        };
+        let wal = Arc::new(Wal::new(wal_config).await.unwrap());
+        let catalog_manager = Arc::new(CatalogManager::new_in_memory().await.unwrap());
+        let object_store = Arc::new(InMemory::new());
+        let mut processor = WalProcessor::new(wal.clone(), catalog_manager, object_store);
+
+        // _system-tenant entry: nothing may pass the export filter.
+        wal.append(
+            WalOperation::WriteTraces,
+            b"not arrow ipc".to_vec(),
+            Some(r#"{"tenant_id":"_system","dataset_id":"_monitoring"}"#.to_string()),
+        )
+        .await
+        .unwrap();
+        wal.flush().await.unwrap();
+
+        let probe = common::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            processor.process_pending_entries().await.unwrap();
+        }
+        assert_eq!(
+            probe.exported_events(),
+            0,
+            "_system WAL entry processing must not export log records"
+        );
+
+        // Normal-tenant entry: processing logs still export.
+        wal.append(
+            WalOperation::WriteTraces,
+            b"not arrow ipc".to_vec(),
+            Some(r#"{"tenant_id":"acme","dataset_id":"production"}"#.to_string()),
+        )
+        .await
+        .unwrap();
+        wal.flush().await.unwrap();
+
+        let probe = common::testing::OtelExportProbe::new();
+        {
+            let _guard = probe.install();
+            processor.process_pending_entries().await.unwrap();
+        }
+        assert!(
+            probe.exported_events() > 0,
+            "normal tenant WAL entry processing must still export telemetry"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #760

## Problem

The self-monitoring anti-loop guard (`suppress_self_telemetry` task-local + the OTel export-layer filters in `src/common/src/self_monitoring/suppress.rs`) was only applied at the acceptor. The writer, querier, and router had no call sites, so logs/spans emitted while processing `_system`-tenant data were exported, re-ingested as `_system` telemetry, and processed again — a self-sustaining feedback hum measured at ~70 ingest batches/min on an idle instance.

## Fix

Guard added at every boundary where `_system`-tenant data is handled, keyed on `is_self_monitoring_tenant()`:

- **Writer** — `do_put` (span created under the suppression scope, whole handler wrapped) and the background WAL-processing loop (`process_pending_entries` / `process_single_entry`), suppressing **per entry/group** since the loop interleaves tenants. The task-local does not cross `tokio::spawn`, so the guard lives inside the processing calls.
- **Querier** — `do_get` resolves the tenant before creating the `flight_do_get` span (authenticated caller → `op:tenant:...` ticket segment → `x-tenant-id` header for raw SQL), creates the span under the suppression scope, and wraps the whole handler. The per-ticket `tenant_slug` match is now computed once and reused for the cross-tenant check and the query permit.
- **Router** — via the shared `common::auth::auth_middleware` (the router's query endpoints authenticate through it), mirroring the acceptor's HTTP auth middleware.

New `maybe_suppress_self_telemetry(suppress, fut)` helper avoids branching at every call site; `trace_context::set_parent_from_metadata` supports setting the span parent after the tonic request is consumed. The suppress module docs now state that each service needs its own call sites (belt-and-suspenders note for future paths).

## Tests (TDD — all written failing first)

- `common`: `auth::middleware::tests::system_tenant_requests_are_suppressed_from_otel_export`
- `writer`: `processor::tests::system_tenant_wal_processing_is_suppressed_from_otel_export`
- `querier`: `flight::tests::system_tenant_query_is_suppressed_from_otel_export`

All use the new `common::testing::OtelExportProbe`, which mirrors the production layer stack (info-level filter + `OtelExportFilter`) and counts events/spans that would reach the OTel export layers: `_system` processing must export nothing while a normal tenant's telemetry still exports.

## Docs

`docs/architecture/flight-communication.md` gains a short section on the anti-loop guard in the Flight handlers. The two remaining freshness flags (`multi-tenancy` skill, `querying-sql.md`) are false positives — no tenant-model or SQL-surface behavior changed — hence the `docs-not-needed` label.