### PR TITLE
feat(compactor)!: enable compaction and 30d retention by default

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -20,6 +20,7 @@ SignalDB is built on Flight, DataFusion, Arrow, Parquet:
 - **Parquet**: Persistent columnar storage via Iceberg table format
 
 **Critical rule**: Always use Arrow/Parquet types re-exported by DataFusion to ensure version compatibility:
+
 ```rust
 // CORRECT
 use datafusion::arrow::array::StringArray;
@@ -40,6 +41,7 @@ OTLP Client (gRPC :4317 / HTTP :4318)
 ```
 
 Key details:
+
 1. Acceptor writes to WAL before acknowledging client
 2. Acceptor converts OTLP protobuf -> Arrow RecordBatches using Flight schemas (v1)
 3. Writer transforms v1 Flight schema -> v2 Iceberg schema (field renames, type conversions, computed partition fields, materialized `label_<key>` columns for configured attributes across all four signals, allowlists resolved per tenant (tenant schema override replaces the global set); new tables (all signals) store attributes as typed `Map<String,String>` columns for exact any-attribute matching)
@@ -58,6 +60,7 @@ HTTP Client (Tempo / Pyroscope / Loki APIs)
 ```
 
 Key details:
+
 1. Router validates auth, discovers Queriers via `QueryExecution` capability
 2. Flight tickets encode query type + tenant context: `find_trace:{tenant}:{dataset}:{trace_id}[:{start}:{end}]` (optional unix-second time hints)
 3. Querier uses `TenantCatalog` to bridge DataFusion 3-level model to Iceberg 2-level namespace
@@ -70,21 +73,22 @@ Key details:
 
 ## Service Components
 
-| Service | Ports | Capability | Key Files |
-|---------|-------|------------|-----------|
-| **Acceptor** | gRPC:4317, HTTP:4318 | `TraceIngestion` | `src/acceptor/` |
-| **Writer** | Flight:50061 (standalone), 50051 (mono) | `TraceIngestion`, `Storage` | `src/writer/` |
-| **Router** | HTTP:3000, Flight:50053 | `Routing` | `src/router/` |
-| **Querier** | Flight:50054 | `QueryExecution` | `src/querier/` |
-| **Compactor** | None (background task) | `Compaction` | `src/compactor/` |
+| Service       | Ports                                   | Capability                  | Key Files        |
+| ------------- | --------------------------------------- | --------------------------- | ---------------- |
+| **Acceptor**  | gRPC:4317, HTTP:4318                    | `TraceIngestion`            | `src/acceptor/`  |
+| **Writer**    | Flight:50061 (standalone), 50051 (mono) | `TraceIngestion`, `Storage` | `src/writer/`    |
+| **Router**    | HTTP:3000, Flight:50053                 | `Routing`                   | `src/router/`    |
+| **Querier**   | Flight:50054                            | `QueryExecution`            | `src/querier/`   |
+| **Compactor** | None (background task)                  | `Compaction`                | `src/compactor/` |
 
 ## Deployment Models
 
-- **Monolithic** (`cargo run --bin signaldb`): All services in one process, shared SQLite catalog. Compactor included if enabled in config.
+- **Monolithic** (`cargo run --bin signaldb`): All services in one process, shared SQLite catalog. Compactor included (enabled by default; opt out with `[compactor].enabled = false`).
 - **Microservices**: Independent binaries, shared catalog (PostgreSQL or SQLite)
 - **Hybrid**: Mix of co-located and distributed services
 
-**Note**: Monolithic mode integrates the Compactor service (Phases 1-3 complete) when `[compactor].enabled = true`. The compactor provides:
+**Note**: Monolithic mode integrates the Compactor service (Phases 1-3 complete) when `[compactor].enabled = true` (the default; retention enforcement is also on by default with 30d per signal). The compactor provides:
+
 - **Phase 1**: Dry-run compaction planning
 - **Phase 2**: Active Parquet file compaction for storage efficiency
 - **Phase 3**: Retention enforcement, snapshot expiration, and orphan file cleanup

--- a/.claude/skills/configuration/SKILL.md
+++ b/.claude/skills/configuration/SKILL.md
@@ -16,13 +16,16 @@ defaults -> TOML file (`signaldb.toml`) -> environment variables (`SIGNALDB_*`)
 ## All Configuration Sections
 
 ### Database (Service Catalog)
+
 ```toml
 [database]
 dsn = "sqlite://.data/signaldb.db"   # or postgres://user:pass@host/db
 ```
+
 Env: `SIGNALDB_DATABASE_DSN`
 
 ### Discovery (Service Registration)
+
 ```toml
 [discovery]
 dsn = "sqlite://.data/signaldb.db"   # Falls back to [database].dsn
@@ -30,18 +33,22 @@ heartbeat_interval = "30s"
 poll_interval = "60s"
 ttl = "300s"
 ```
+
 Env: `SIGNALDB_DISCOVERY_DSN`, `SIGNALDB_DISCOVERY_TTL`. Multi-word fields need the double-underscore form: `SIGNALDB__DISCOVERY__HEARTBEAT_INTERVAL`, `SIGNALDB__DISCOVERY__POLL_INTERVAL` (the single-underscore form splits to `discovery.heartbeat.interval` and silently does nothing).
 
 ### Storage (Object Store for Parquet)
+
 ```toml
 [storage]
 dsn = "file:///.data/storage"
 # dsn = "memory://"
 # dsn = "s3://bucket/prefix"
 ```
+
 Env: `SIGNALDB_STORAGE_DSN`
 
 For S3/MinIO:
+
 ```bash
 AWS_ENDPOINT_URL=http://localhost:9000
 AWS_ACCESS_KEY_ID=minioadmin
@@ -50,6 +57,7 @@ AWS_REGION=us-east-1
 ```
 
 ### WAL
+
 ```toml
 [wal]
 wal_dir = ".data/wal"
@@ -58,23 +66,28 @@ max_buffer_entries = 1000
 flush_interval = "30s"
 max_buffer_size_bytes = 134217728    # 128 MB
 ```
+
 `wal_dir` is the base directory: the acceptor uses `{wal_dir}/acceptor` and the writer `{wal_dir}/writer` (default `.data/wal/acceptor` / `.data/wal/writer`). The service-specific env overrides `ACCEPTOR_WAL_DIR` / `WRITER_WAL_DIR` (read directly by the binaries, not via figment; also available as `--wal-dir`) point at the full service directory and win over `[wal].wal_dir`. Sizing knobs use the double-underscore form: `SIGNALDB__WAL__MAX_SEGMENT_SIZE`, `SIGNALDB__WAL__MAX_BUFFER_ENTRIES`, `SIGNALDB__WAL__FLUSH_INTERVAL` (as does `SIGNALDB__WAL__WAL_DIR`).
 
 ### Iceberg Schema Catalog
+
 ```toml
 [schema]
 catalog_type = "sql"
 catalog_uri = "sqlite::memory:"      # or sqlite:///path/to/catalog.db
 ```
+
 Env: `SIGNALDB__SCHEMA__CATALOG_TYPE`, `SIGNALDB__SCHEMA__CATALOG_URI` (double-underscore form). Beware: `signaldb.dist.toml` and `scripts/run-dev.sh` mention/set the single-underscore forms `SIGNALDB_SCHEMA_CATALOG_TYPE`/`SIGNALDB_SCHEMA_CATALOG_URI`, which split to `schema.catalog.type` and silently do nothing.
 
 **Note**: Only SQLite supported for Iceberg catalog (not PostgreSQL).
 
 #### Materialized labels
+
 ```toml
 [schema.materialized_labels]
 logs = ["namespace", "pod"]   # also: traces / metrics / profiles
 ```
+
 Per-signal allowlists of attribute keys promoted from the `*_attributes` JSON into dedicated `label_<key>` columns at ingest, so they match exactly (and support regex / ordered comparisons) instead of the substring-in-JSON approximation. Default empty. Applies to tables created after the change; older tables fall back to JSON matching. Per-tenant: a tenant schema override (`[auth.tenants.schema.materialized_labels]`) replaces the global set wholesale — resolved at table creation and in the writer's transforms. See `docs/architecture/storage-layout.md#materialized-labels`.
 
 ### Authentication
@@ -129,9 +142,10 @@ max_query_requests_per_sec = 200
 ```
 
 ### Compactor
+
 ```toml
 [compactor]
-enabled = false                        # Default disabled
+enabled = true                        # Default enabled
 tick_interval = "5m"                  # Planning cycle interval
 target_file_size_mb = 128             # Target size after compaction
 file_count_threshold = 10             # Min files to trigger compaction
@@ -142,24 +156,26 @@ max_per_tenant = 5                    # Max candidates per tenant per cycle (0 =
 lease_ttl_seconds = 300               # Compaction lease validity without renewal
 metrics_addr = "0.0.0.0:9091"         # Observability HTTP endpoint ("" = disabled)
 ```
+
 Env: `SIGNALDB__COMPACTOR__ENABLED`, `SIGNALDB__COMPACTOR__TICK_INTERVAL`, `SIGNALDB__COMPACTOR__TARGET_FILE_SIZE_MB`, `SIGNALDB__COMPACTOR__FILE_COUNT_THRESHOLD`, `SIGNALDB__COMPACTOR__MIN_INPUT_FILE_SIZE_KB`, `SIGNALDB__COMPACTOR__MAX_FILES_PER_JOB`, `SIGNALDB__COMPACTOR__MAX_CANDIDATES_PER_CYCLE`, `SIGNALDB__COMPACTOR__MAX_PER_TENANT`, `SIGNALDB__COMPACTOR__LEASE_TTL_SECONDS`, `SIGNALDB__COMPACTOR__METRICS_ADDR` (or `COMPACTOR_METRICS_ADDR`)
 
 **Note**: Environment variables for compactor use double-underscore (`__`) separator to support field names with underscores.
 
 #### Retention Enforcement (Phase 3)
+
 ```toml
 [compactor.retention]
-enabled = false                       # Enable retention enforcement (opt-in)
-dry_run = true                        # Log actions without executing (safe default)
+enabled = true                        # Enabled by default; deletes data past retention!
+dry_run = false                       # Default false; set true to log without deleting
 retention_check_interval = "1h"       # Interval between retention checks
 grace_period = "1h"                   # Safety margin before cutoff
 timezone = "UTC"                      # Timezone for logging
 snapshots_to_keep = 10                # Keep last N snapshots per table (default: 10)
 
-# Global defaults (per signal type, humantime durations)
-traces = "7d"
+# Global defaults (per signal type, humantime durations; default 30d each)
+traces = "30d"
 logs = "30d"
-metrics = "90d"
+metrics = "30d"
 
 # Tenant overrides (optional) -- a map keyed by tenant ID
 [compactor.retention.tenant_overrides.production]
@@ -171,9 +187,11 @@ metrics = "90d"
 [compactor.retention.tenant_overrides.production.dataset_overrides.critical]
 traces = "90d"
 ```
+
 Env: `SIGNALDB__COMPACTOR__RETENTION__ENABLED`, `SIGNALDB__COMPACTOR__RETENTION__DRY_RUN`, `SIGNALDB__COMPACTOR__RETENTION__RETENTION_CHECK_INTERVAL`, `SIGNALDB__COMPACTOR__RETENTION__TRACES`, `SIGNALDB__COMPACTOR__RETENTION__LOGS`, `SIGNALDB__COMPACTOR__RETENTION__METRICS`, `SIGNALDB__COMPACTOR__RETENTION__GRACE_PERIOD`, `SIGNALDB__COMPACTOR__RETENTION__TIMEZONE`, `SIGNALDB__COMPACTOR__RETENTION__SNAPSHOTS_TO_KEEP`
 
 #### Attribute Auto-Promotion (epic #737)
+
 ```toml
 [compactor.attr_promotion]
 enabled = false               # Decision pass off by default
@@ -184,9 +202,11 @@ min_query_hits = 1            # Min accumulated query demand
 promote_streak = 3            # Consecutive over-threshold cycles (hysteresis)
 max_promotions_per_cycle = 4
 ```
+
 Scores persisted attribute stats (compactor scan stats + querier demand counters in the catalog's `attribute_stats` table) as demand × presence; rejects capped-cardinality and generated-looking keys; pinned `[schema.materialized_labels]` entries are never demoted. Env: `SIGNALDB__COMPACTOR__ATTR_PROMOTION__*`.
 
 #### Orphan Cleanup (Phase 3)
+
 ```toml
 [compactor.orphan_cleanup]
 enabled = false                       # Enable orphan cleanup (opt-in)
@@ -198,9 +218,11 @@ max_snapshot_age_hours = 720          # Consider snapshots within last N hours
 batch_size = 1000                     # Process N files per batch
 max_live_files_threshold = 500000     # Skip cleanup when estimated live files exceed this (0 = no cap)
 ```
+
 Env: `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__ENABLED`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__DRY_RUN`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__CLEANUP_INTERVAL_HOURS`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__GRACE_PERIOD_HOURS`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__REVALIDATE_BEFORE_DELETE`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__MAX_SNAPSHOT_AGE_HOURS`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__BATCH_SIZE`, `SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__MAX_LIVE_FILES_THRESHOLD`
 
 ### Querier (Resource Limits)
+
 ```toml
 [querier]
 memory_limit_mb = 4096                # Unset = unbounded (startup warning)
@@ -212,6 +234,7 @@ max_concurrent_queries_per_tenant = 8 # Unset = unlimited
 ```
 
 ### Self-Monitoring (Dogfooding)
+
 ```toml
 [self_monitoring]
 enabled = false
@@ -223,6 +246,7 @@ trace_sample_ratio = 0.1              # 0.0-1.0; OTEL_TRACES_SAMPLER env vars wi
 ```
 
 ### Profiling (Continuous Profiling)
+
 ```toml
 [profiling]
 enabled = false
@@ -232,6 +256,7 @@ memory_profiling = false              # Needs `jemalloc-profiling` build feature
 ```
 
 ### Tenants (Per-Tenant Schema Overrides)
+
 ```toml
 [tenants]
 default_tenant = "default"            # Tenant ID used when none is specified
@@ -240,15 +265,15 @@ default_tenant = "default"            # Tenant ID used when none is specified
 
 ## Service Ports (Defaults)
 
-| Service | Protocol | Port |
-|---------|----------|------|
-| Acceptor | gRPC | 4317 |
-| Acceptor | HTTP | 4318 |
-| Writer | Flight | 50061 (standalone), 50051 (monolithic) |
-| Router | HTTP | 3000 |
-| Router | Flight | 50053 |
-| Querier | Flight | 50054 |
-| Compactor | Flight | 50055 (`COMPACTOR_FLIGHT_ADDR`) |
+| Service   | Protocol                     | Port                                          |
+| --------- | ---------------------------- | --------------------------------------------- |
+| Acceptor  | gRPC                         | 4317                                          |
+| Acceptor  | HTTP                         | 4318                                          |
+| Writer    | Flight                       | 50061 (standalone), 50051 (monolithic)        |
+| Router    | HTTP                         | 3000                                          |
+| Router    | Flight                       | 50053                                         |
+| Querier   | Flight                       | 50054                                         |
+| Compactor | Flight                       | 50055 (`COMPACTOR_FLIGHT_ADDR`)               |
 | Compactor | HTTP (metrics/status/health) | 9091 (`metrics_addr`, default `0.0.0.0:9091`) |
 
 ## Key File

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,23 +203,26 @@ RUST_LOG=debug,compactor=trace cargo run --bin signaldb-compactor
 ### Phase 3: Retention & Lifecycle Management
 
 **Key Features:**
+
 - 3-tier retention policies (Global → Tenant → Dataset)
 - Per-signal type retention (traces/logs/metrics)
 - Automatic partition dropping
 - Snapshot expiration
 - Orphan file cleanup
 
+**Defaults:** the compactor and retention enforcement are enabled by default with `dry_run = false` and 30-day retention for traces, logs, and metrics — a default deployment deletes data older than 30 days. Set `[compactor.retention].enabled = false` for infinite retention. Orphan cleanup stays opt-in.
+
 **Configuration Example:**
 
 ```toml
 [compactor.retention]
-enabled = true
-dry_run = false  # Start with true for testing
+enabled = true   # default: true
+dry_run = false  # default: false; set true to log without deleting
 retention_check_interval = "1h"
 grace_period = "1h"
-traces = "7d"
+traces = "30d"   # default: 30d for all three signal types
 logs = "30d"
-metrics = "90d"
+metrics = "30d"
 snapshots_to_keep = 10
 
 # Tenant override (map keyed by tenant id)
@@ -273,6 +276,7 @@ curl -s localhost:9091/metrics | grep compactor
 - README: `src/compactor/README.md`
 
 **Important Notes:**
+
 - Always test retention with `dry_run = true` first
 - Use grace periods to prevent accidental deletion
 - Monitor `compactor_deletion_failures_total` metric

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -75,26 +75,26 @@ Parquet storage with DataFusion query processing:
 
 ### Workspace Members
 
-| Crate | Path | Type | Description |
-|-------|------|------|-------------|
-| **acceptor** | `src/acceptor/` | Binary + Library | OTLP gRPC/HTTP ingestion endpoint |
-| **router** | `src/router/` | Binary + Library | HTTP API + Flight routing layer |
-| **writer** | `src/writer/` | Binary + Library | Iceberg-based data persistence (the "Ingester") |
-| **querier** | `src/querier/` | Binary + Library | Query execution engine via DataFusion |
-| **compactor** | `src/compactor/` | Binary + Library | Storage maintenance: compaction, retention (bin `signaldb-compactor`) |
-| **common** | `src/common/` | Library | Shared config, auth, WAL, Flight, catalog, schema |
-| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
-| **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
-| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
-| **prometheus-api** | `src/prometheus-api/` | Library | Prometheus HTTP API response types (PromQL query surface) |
-| **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
-| **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
-| **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI and TUI for tenant, API key, and dataset management |
-| **signaldb-sdk** | `src/signaldb-sdk/` | Library | Generated SDK client |
-| **grafana-plugin** | `src/grafana-plugin/backend` | Plugin | Grafana datasource (TypeScript frontend + Rust backend; the backend is a standalone cargo workspace excluded from the root workspace, since grafana-plugin-sdk pins its own Arrow major) |
-| **signal-producer** | `src/signal-producer/` | Binary | Test data generator (OTLP traces) |
-| **tests-integration** | `tests-integration/` | Test crate | Integration test suite |
-| **xtask** | `xtask/` | Binary | Build automation tasks |
+| Crate                 | Path                         | Type             | Description                                                                                                                                                                              |
+| --------------------- | ---------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **acceptor**          | `src/acceptor/`              | Binary + Library | OTLP gRPC/HTTP ingestion endpoint                                                                                                                                                        |
+| **router**            | `src/router/`                | Binary + Library | HTTP API + Flight routing layer                                                                                                                                                          |
+| **writer**            | `src/writer/`                | Binary + Library | Iceberg-based data persistence (the "Ingester")                                                                                                                                          |
+| **querier**           | `src/querier/`               | Binary + Library | Query execution engine via DataFusion                                                                                                                                                    |
+| **compactor**         | `src/compactor/`             | Binary + Library | Storage maintenance: compaction, retention (bin `signaldb-compactor`)                                                                                                                    |
+| **common**            | `src/common/`                | Library          | Shared config, auth, WAL, Flight, catalog, schema                                                                                                                                        |
+| **pyroscope-api**     | `src/pyroscope-api/`         | Library          | Pyroscope-compatible API types (flamebearer, profile types)                                                                                                                              |
+| **tempo-api**         | `src/tempo-api/`             | Library          | Grafana Tempo API types and protobuf definitions                                                                                                                                         |
+| **loki-api**          | `src/loki-api/`              | Library          | Loki HTTP API response types (LogQL query surface)                                                                                                                                       |
+| **prometheus-api**    | `src/prometheus-api/`        | Library          | Prometheus HTTP API response types (PromQL query surface)                                                                                                                                |
+| **signaldb-bin**      | `src/signaldb-bin/`          | Binary           | Monolithic mode runner (all services in one process)                                                                                                                                     |
+| **signaldb-api**      | `src/signaldb-api/`          | Library          | OpenAPI-generated admin API types                                                                                                                                                        |
+| **signaldb-cli**      | `src/signaldb-cli/`          | Binary           | CLI and TUI for tenant, API key, and dataset management                                                                                                                                  |
+| **signaldb-sdk**      | `src/signaldb-sdk/`          | Library          | Generated SDK client                                                                                                                                                                     |
+| **grafana-plugin**    | `src/grafana-plugin/backend` | Plugin           | Grafana datasource (TypeScript frontend + Rust backend; the backend is a standalone cargo workspace excluded from the root workspace, since grafana-plugin-sdk pins its own Arrow major) |
+| **signal-producer**   | `src/signal-producer/`       | Binary           | Test data generator (OTLP traces)                                                                                                                                                        |
+| **tests-integration** | `tests-integration/`         | Test crate       | Integration test suite                                                                                                                                                                   |
+| **xtask**             | `xtask/`                     | Binary           | Build automation tasks                                                                                                                                                                   |
 
 ### Data Flow Overview
 
@@ -152,12 +152,12 @@ flowchart LR
 
 **Purpose**: OTLP data ingestion with multi-protocol support
 
-| Property | Value |
-|----------|-------|
-| **Ports** | gRPC: 4317, HTTP: 4318 |
-| **Capability** | `TraceIngestion` |
-| **Protocols** | OTLP/gRPC, OTLP/HTTP, Prometheus remote_write |
-| **Signal types** | Traces, Logs, Metrics |
+| Property         | Value                                         |
+| ---------------- | --------------------------------------------- |
+| **Ports**        | gRPC: 4317, HTTP: 4318                        |
+| **Capability**   | `TraceIngestion`                              |
+| **Protocols**    | OTLP/gRPC, OTLP/HTTP, Prometheus remote_write |
+| **Signal types** | Traces, Logs, Metrics                         |
 
 - Runs separate gRPC (tonic) and HTTP (Axum) servers in parallel
 - `WalManager` creates per-tenant/dataset/signal WAL instances with tuned configs:
@@ -171,12 +171,12 @@ flowchart LR
 
 **Purpose**: Data persistence to Apache Iceberg tables
 
-| Property | Value |
-|----------|-------|
-| **Port** | Flight: 50061 (standalone), 50051 (monolithic) |
-| **Capabilities** | `TraceIngestion`, `Storage` |
-| **Input** | Arrow data via Flight `do_put` from Acceptors |
-| **Output** | Iceberg tables (Parquet + metadata) to object store |
+| Property         | Value                                               |
+| ---------------- | --------------------------------------------------- |
+| **Port**         | Flight: 50061 (standalone), 50051 (monolithic)      |
+| **Capabilities** | `TraceIngestion`, `Storage`                         |
+| **Input**        | Arrow data via Flight `do_put` from Acceptors       |
+| **Output**       | Iceberg tables (Parquet + metadata) to object store |
 
 - `IcebergWriterFlightService`: Flight server accepting `do_put` for trace/log/metric data
 - Transforms v1 Flight schema to v2 Iceberg schema before WAL write
@@ -188,65 +188,65 @@ flowchart LR
 
 **Purpose**: HTTP API gateway and query routing
 
-| Property | Value |
-|----------|-------|
-| **Ports** | HTTP: 3000, Flight: 50053 |
-| **Capability** | `Routing` |
-| **APIs** | Tempo-compatible, Pyroscope-compatible, Loki-compatible (stubs), Admin API, OpenAPI |
+| Property       | Value                                                                               |
+| -------------- | ----------------------------------------------------------------------------------- |
+| **Ports**      | HTTP: 3000, Flight: 50053                                                           |
+| **Capability** | `Routing`                                                                           |
+| **APIs**       | Tempo-compatible, Pyroscope-compatible, Loki-compatible (stubs), Admin API, OpenAPI |
 
 **Tempo API Endpoints**:
 
-| Endpoint | Status |
-|----------|--------|
-| `GET /tempo/api/echo` | Implemented |
-| `GET /tempo/api/traces/{trace_id}` | Implemented -- routes to Querier |
-| `GET /tempo/api/v2/traces/{trace_id}` | Implemented -- same handler as v1 |
-| `GET /tempo/api/search` | Implemented -- routes to Querier |
-| `GET /tempo/api/search/tags` | Implemented -- static list of resource + intrinsic tag names |
-| `GET /tempo/api/search/tag/{tag_name}/values` | Implemented -- distinct column values via Querier; 501 for attribute tags without an index |
-| `GET /tempo/api/v2/search/tags` | Implemented -- same tag names, v2 scoped response |
-| `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented -- same lookup, v2 response shape |
-| `GET /tempo/api/metrics/query` | 501 Not Implemented (TraceQL metrics) |
-| `GET /tempo/api/metrics/query_range` | 501 Not Implemented (TraceQL metrics) |
+| Endpoint                                         | Status                                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `GET /tempo/api/echo`                            | Implemented                                                                                |
+| `GET /tempo/api/traces/{trace_id}`               | Implemented -- routes to Querier                                                           |
+| `GET /tempo/api/v2/traces/{trace_id}`            | Implemented -- same handler as v1                                                          |
+| `GET /tempo/api/search`                          | Implemented -- routes to Querier                                                           |
+| `GET /tempo/api/search/tags`                     | Implemented -- static list of resource + intrinsic tag names                               |
+| `GET /tempo/api/search/tag/{tag_name}/values`    | Implemented -- distinct column values via Querier; 501 for attribute tags without an index |
+| `GET /tempo/api/v2/search/tags`                  | Implemented -- same tag names, v2 scoped response                                          |
+| `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented -- same lookup, v2 response shape                                              |
+| `GET /tempo/api/metrics/query`                   | 501 Not Implemented (TraceQL metrics)                                                      |
+| `GET /tempo/api/metrics/query_range`             | 501 Not Implemented (TraceQL metrics)                                                      |
 
 **Pyroscope API Endpoints** (profiles, nested at `/pyroscope` plus `/api/profiles`):
 
-| Endpoint | Status |
-|----------|--------|
-| `GET /pyroscope/render` | Implemented -- flamegraph via Querier |
-| `GET /pyroscope/render-diff` | Implemented -- differential flamegraph |
-| `GET /pyroscope/label-names`, `/label-values`, `/profile-types` | Implemented -- discovery via Querier |
-| `GET /api/profiles/trace/{trace_id}` | Implemented -- profiles linked to a trace |
+| Endpoint                                                        | Status                                    |
+| --------------------------------------------------------------- | ----------------------------------------- |
+| `GET /pyroscope/render`                                         | Implemented -- flamegraph via Querier     |
+| `GET /pyroscope/render-diff`                                    | Implemented -- differential flamegraph    |
+| `GET /pyroscope/label-names`, `/label-values`, `/profile-types` | Implemented -- discovery via Querier      |
+| `GET /api/profiles/trace/{trace_id}`                            | Implemented -- profiles linked to a trace |
 
 **Loki API Endpoints** (logs, nested at `/loki`; see epic #366):
 
-| Endpoint | Status |
-|----------|--------|
-| `GET /loki/api/v1/query` | Implemented -- log query over a one-hour window ending at `time` |
-| `GET /loki/api/v1/query_range` | Implemented -- transpiles LogQL to a querier filter, returns Loki streams |
-| `GET /loki/api/v1/labels` | Implemented -- known + attribute label names via Querier |
-| `GET /loki/api/v1/label/{name}/values` | Implemented -- distinct label values via Querier |
-| `GET /loki/api/v1/series` | Implemented -- label sets matching a selector via Querier |
-| `GET /loki/api/v1/detected_fields` | Implemented -- sampled attribute-field discovery (name, type, cardinality) |
-| `GET /loki/api/v1/tail` | Not implemented (WebSocket streaming, #380) |
+| Endpoint                                                         | Status                                                                                                      |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `GET /loki/api/v1/query`                                         | Implemented -- log query over a one-hour window ending at `time`                                            |
+| `GET /loki/api/v1/query_range`                                   | Implemented -- transpiles LogQL to a querier filter, returns Loki streams                                   |
+| `GET /loki/api/v1/labels`                                        | Implemented -- known + attribute label names via Querier                                                    |
+| `GET /loki/api/v1/label/{name}/values`                           | Implemented -- distinct label values via Querier                                                            |
+| `GET /loki/api/v1/series`                                        | Implemented -- label sets matching a selector via Querier                                                   |
+| `GET /loki/api/v1/detected_fields`                               | Implemented -- sampled attribute-field discovery (name, type, cardinality)                                  |
+| `GET /loki/api/v1/tail`                                          | Not implemented (WebSocket streaming, #380)                                                                 |
 | LogQL metric queries (`rate`, `count_over_time`, `sum by (...)`) | Implemented via `query_range` -- `date_bin(step)` bucketed matrix (no binary ops / `topk` / `quantile` yet) |
 
 **Prometheus API Endpoints** (metrics, nested at `/prometheus`; see epic #328):
 
-| Endpoint | Status |
-|----------|--------|
-| `GET\|POST /prometheus/api/v1/query_range` | Implemented -- PromQL over `metrics_gauge`+`metrics_sum`, `date_bin(step)` matrix |
-| `GET\|POST /prometheus/api/v1/query` | Implemented -- instant vector (latest sample per series) |
+| Endpoint                                                           | Status                                                                            |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `GET\|POST /prometheus/api/v1/query_range`                         | Implemented -- PromQL over `metrics_gauge`+`metrics_sum`, `date_bin(step)` matrix |
+| `GET\|POST /prometheus/api/v1/query`                               | Implemented -- instant vector (latest sample per series)                          |
 | `GET /prometheus/api/v1/labels`, `/label/{name}/values`, `/series` | Implemented -- metric label names/values and `{__name__, job}` series via Querier |
-| PromQL `rate`/`increase` | Implemented -- counter delta over `date_bin` buckets |
-| PromQL `histogram_quantile(phi, metric)` | Implemented -- interpolated per series from `metrics_histogram` OTLP buckets |
-| PromQL `histogram_quantile` over `rate()`, binary ops, `topk` | Not implemented yet (#335) |
+| PromQL `rate`/`increase`                                           | Implemented -- counter delta over `date_bin` buckets                              |
+| PromQL `histogram_quantile(phi, metric)`                           | Implemented -- interpolated per series from `metrics_histogram` OTLP buckets      |
+| PromQL `histogram_quantile` over `rate()`, binary ops, `topk`      | Not implemented yet (#335)                                                        |
 
 **Admin API Endpoints** (requires `admin_api_key`):
 
-| Endpoint | Description |
-|----------|-------------|
-| `/api/v1/admin/tenants` | CRUD for tenants |
+| Endpoint                              | Description            |
+| ------------------------------------- | ---------------------- |
+| `/api/v1/admin/tenants`               | CRUD for tenants       |
 | `/api/v1/admin/tenants/{id}/api-keys` | Manage tenant API keys |
 | `/api/v1/admin/tenants/{id}/datasets` | Manage tenant datasets |
 
@@ -257,11 +257,11 @@ flowchart LR
 
 **Purpose**: Query execution against Iceberg tables via DataFusion
 
-| Property | Value |
-|----------|-------|
-| **Port** | Flight: 50054 (standalone mode also serves Tempo's `tempopb.Querier` gRPC protocol on this port) |
-| **Capability** | `QueryExecution` |
-| **Engine** | DataFusion with Iceberg integration |
+| Property       | Value                                                                                            |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| **Port**       | Flight: 50054 (standalone mode also serves Tempo's `tempopb.Querier` gRPC protocol on this port) |
+| **Capability** | `QueryExecution`                                                                                 |
+| **Engine**     | DataFusion with Iceberg integration                                                              |
 
 - Creates a DataFusion `SessionContext` with per-tenant `TenantCatalog` wrappers
 - `TenantCatalog` bridges DataFusion's 3-level model (`catalog.schema.table`) to Iceberg's 2-level namespace (`[tenant_slug, dataset_slug]`)
@@ -275,18 +275,18 @@ flowchart LR
 
 **Purpose**: Storage maintenance -- Parquet compaction and data lifecycle
 
-| Property | Value |
-|----------|-------|
-| **Ports** | Flight admin: 50055 (standalone, `COMPACTOR_FLIGHT_ADDR`), metrics HTTP: 9091 (`[compactor].metrics_addr`) |
-| **Capability** | `StorageMaintenance` |
-| **Binary** | `signaldb-compactor` |
+| Property       | Value                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Ports**      | Flight admin: 50055 (standalone, `COMPACTOR_FLIGHT_ADDR`), metrics HTTP: 9091 (`[compactor].metrics_addr`) |
+| **Capability** | `StorageMaintenance`                                                                                       |
+| **Binary**     | `signaldb-compactor`                                                                                       |
 
 - Plans compaction candidates from Iceberg manifest data on a `tick_interval` loop
 - Distributed leases (`compactor_leases` catalog table) prevent concurrent compaction of the same partition
 - Flight admin interface exposes only `do_action` commands (`compact_now`, `compact_status`, `compact_dry_run`) and `list_actions`; all other Flight RPCs return `unimplemented`
 - Retention enforcement and orphan-file cleanup, configured via `[compactor.retention]` and `[compactor.orphan_cleanup]`
 - Advisory attribute-stats pass on every rewrite: logs per-key presence / approximate cardinality, persists the statistics to the catalog's `attribute_stats` table, and — when `[compactor.attr_promotion]` is enabled — logs a dry-run promotion/demotion decision (demand × presence under a schema-width budget with streak hysteresis; epic #737 Layer 4)
-- Disabled by default; enable with `[compactor].enabled = true`
+- Enabled by default (retention enforcement included, 30d per signal); disable with `[compactor].enabled = false`
 
 ## Multi-Tenancy and Authentication
 
@@ -315,13 +315,13 @@ Tenant (e.g., "acme")
 
 ### Isolation Layers
 
-| Layer | Isolation Mechanism |
-|-------|-------------------|
-| **WAL** | Separate directories: `{wal_dir}/{tenant}/{dataset}/{signal_type}/` |
-| **Iceberg Namespace** | Per-tenant/dataset: `[tenant_slug, dataset_slug]` |
-| **Object Store** | Per-tenant/dataset paths: `{base}/{tenant_slug}/{dataset_slug}/{table}/` |
-| **DataFusion** | Per-tenant catalog registration in SessionContext |
-| **Storage Backend** | Per-dataset storage override (different datasets can use different backends) |
+| Layer                 | Isolation Mechanism                                                          |
+| --------------------- | ---------------------------------------------------------------------------- |
+| **WAL**               | Separate directories: `{wal_dir}/{tenant}/{dataset}/{signal_type}/`          |
+| **Iceberg Namespace** | Per-tenant/dataset: `[tenant_slug, dataset_slug]`                            |
+| **Object Store**      | Per-tenant/dataset paths: `{base}/{tenant_slug}/{dataset_slug}/{table}/`     |
+| **DataFusion**        | Per-tenant catalog registration in SessionContext                            |
+| **Storage Backend**   | Per-dataset storage override (different datasets can use different backends) |
 
 ### Configuration
 
@@ -358,13 +358,13 @@ name = "Production Key"
 
 Services register with specific capabilities enabling automatic routing:
 
-| Service | Capabilities | Discovery Pattern |
-|---------|-------------|------------------|
-| Acceptor | `TraceIngestion` | Clients connect directly via OTLP |
-| Writer | `TraceIngestion`, `Storage` | Acceptors discover via `Storage` capability |
-| Router | `Routing` | Clients connect directly via HTTP |
-| Querier | `QueryExecution` | Routers discover via `QueryExecution` capability |
-| Compactor | `StorageMaintenance` | Registered for observability; not discovered by other services |
+| Service   | Capabilities                | Discovery Pattern                                              |
+| --------- | --------------------------- | -------------------------------------------------------------- |
+| Acceptor  | `TraceIngestion`            | Clients connect directly via OTLP                              |
+| Writer    | `TraceIngestion`, `Storage` | Acceptors discover via `Storage` capability                    |
+| Router    | `Routing`                   | Clients connect directly via HTTP                              |
+| Querier   | `QueryExecution`            | Routers discover via `QueryExecution` capability               |
+| Compactor | `StorageMaintenance`        | Registered for observability; not discovered by other services |
 
 The `ServiceCapability` enum (`src/common/src/flight/transport.rs`) defines six variants: `TraceIngestion`, `QueryExecution`, `Routing`, `Storage`, `KafkaIngestion`, and `StorageMaintenance`. `KafkaIngestion` is defined but not registered by any service today.
 
@@ -410,12 +410,13 @@ cargo run --bin signaldb
 ```
 
 Starts Acceptor, Router, Writer, and Querier in a single process:
+
 - Acceptor: `0.0.0.0:4317` (gRPC), `0.0.0.0:4318` (HTTP)
 - Router: `0.0.0.0:3000` (HTTP), `0.0.0.0:50053` (Flight)
 - Writer: `0.0.0.0:50051` (Flight)
 - Querier: `0.0.0.0:50054` (Flight)
 
-When `[compactor].enabled = true`, the monolithic binary also runs the compactor planning loop (no compactor Flight/HTTP endpoints in this mode).
+When `[compactor].enabled = true` (the default), the monolithic binary also runs the compactor planning loop (no compactor Flight/HTTP endpoints in this mode).
 
 Shared SQLite database for both service catalog and Iceberg catalog. Zero-config startup with sensible defaults.
 

--- a/docs/operations/compactor/phase3-configuration.md
+++ b/docs/operations/compactor/phase3-configuration.md
@@ -25,11 +25,13 @@ Complete reference for configuring SignalDB Compactor Phase 3: Retention Enforce
 Phase 3 configuration is located in the `[compactor]` section of `signaldb.toml` or via environment variables with the `SIGNALDB__COMPACTOR__` prefix (double underscores separate nesting levels).
 
 **Configuration Precedence:**
+
 1. Environment variables (highest priority)
 2. `signaldb.toml` configuration file
 3. Default values (lowest priority)
 
 **Configuration Files:**
+
 - **Production:** `/etc/signaldb/signaldb.toml`
 - **Development:** `./signaldb.toml` (copy from `signaldb.dist.toml`)
 - **Container:** the compactor's `--config` flag defaults to `./signaldb.toml` relative to the working directory. If you mount a config file elsewhere (e.g. `/config/signaldb.toml`), you must pass `--config /config/signaldb.toml` explicitly or the mounted file is silently ignored.
@@ -44,14 +46,15 @@ Controls automatic retention enforcement and partition lifecycle management.
 
 #### Basic Settings
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | `bool` | `false` | Enable retention enforcement (opt-in) |
-| `dry_run` | `bool` | `true` | Log actions without executing (safe default) |
-| `retention_check_interval` | duration string | `"1h"` | Interval between retention checks |
-| `timezone` | `string` | `"UTC"` | Timezone for logging (internal uses UTC) |
+| Field                      | Type            | Default | Description                                  |
+| -------------------------- | --------------- | ------- | -------------------------------------------- |
+| `enabled`                  | `bool`          | `true`  | Enable retention enforcement (on by default) |
+| `dry_run`                  | `bool`          | `false` | When `true`, log actions without executing   |
+| `retention_check_interval` | duration string | `"1h"`  | Interval between retention checks            |
+| `timezone`                 | `string`        | `"UTC"` | Timezone for logging (internal uses UTC)     |
 
 **Example:**
+
 ```toml
 [compactor.retention]
 enabled = true
@@ -64,13 +67,16 @@ timezone = "America/New_York"  # For logging only
 
 Default retention periods for all tenants/datasets (unless overridden).
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `traces` | duration string | `"7d"` | Trace data retention |
-| `logs` | duration string | `"30d"` | Log data retention |
-| `metrics` | duration string | `"90d"` | Metric data retention |
+| Field     | Type            | Default | Description           |
+| --------- | --------------- | ------- | --------------------- |
+| `traces`  | duration string | `"30d"` | Trace data retention  |
+| `logs`    | duration string | `"30d"` | Log data retention    |
+| `metrics` | duration string | `"30d"` | Metric data retention |
+
+> **Warning:** Retention enforcement is enabled by default with `dry_run = false`, so a default deployment deletes data older than 30 days. To keep data indefinitely, set `[compactor.retention].enabled = false`; to keep it longer, raise the per-signal durations or use tenant/dataset overrides.
 
 **Example:**
+
 ```toml
 [compactor.retention]
 traces = "7d"
@@ -79,18 +85,20 @@ metrics = "90d"
 ```
 
 **Signal Type Mapping:**
+
 - `traces` → `traces` table
 - `logs` → `logs` table
 - `metrics` → any table whose name starts with `metrics_` (`metrics_gauge`, `metrics_sum`, `metrics_histogram` by default)
 
 #### Safety Settings
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `grace_period` | duration string | `"1h"` | Safety margin before cutoff |
-| `snapshots_to_keep` | `usize` (optional) | `10` | Minimum snapshots to retain per table |
+| Field               | Type               | Default | Description                           |
+| ------------------- | ------------------ | ------- | ------------------------------------- |
+| `grace_period`      | duration string    | `"1h"`  | Safety margin before cutoff           |
+| `snapshots_to_keep` | `usize` (optional) | `10`    | Minimum snapshots to retain per table |
 
 **Example:**
+
 ```toml
 [compactor.retention]
 grace_period = "2h"     # 2-hour safety margin
@@ -120,6 +128,7 @@ Partitions older than 2026-02-02 09:00:00 are dropped.
 Override global retention periods for specific tenants. `tenant_overrides` is a map keyed by tenant ID.
 
 **Structure:**
+
 ```toml
 [compactor.retention.tenant_overrides.<tenant-id>]
 traces = "14d"    # Optional override
@@ -128,6 +137,7 @@ metrics = "60d"   # Optional override
 ```
 
 **Example:**
+
 ```toml
 # Production tenant keeps data longer
 [compactor.retention.tenant_overrides.production]
@@ -157,6 +167,7 @@ traces = "90d"  # Only override traces
 Override retention periods for specific tenant+dataset combinations (highest priority). `dataset_overrides` is a map keyed by dataset ID, nested inside a tenant override.
 
 **Structure:**
+
 ```toml
 [compactor.retention.tenant_overrides.<tenant-id>.dataset_overrides.<dataset-id>]
 traces = "90d"    # Optional override
@@ -165,6 +176,7 @@ metrics = "180d"  # Optional override
 ```
 
 **Example:**
+
 ```toml
 [compactor.retention.tenant_overrides.acme]
 traces = "14d"  # Tenant default: 14 days
@@ -181,6 +193,7 @@ traces = "3d"  # Dataset override: 3 days
 **Resolution Example:**
 
 With this configuration:
+
 ```toml
 [compactor.retention]
 traces = "7d"  # Global default
@@ -193,6 +206,7 @@ traces = "90d"  # Dataset override
 ```
 
 Results:
+
 - `acme/critical` → **90 days** (dataset override)
 - `acme/production` → **14 days** (tenant override)
 - `other/anything` → **7 days** (global default)
@@ -249,13 +263,14 @@ Controls automatic detection and deletion of orphaned Parquet files.
 
 #### Basic Settings
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | `bool` | `false` | Enable orphan cleanup (opt-in) |
-| `dry_run` | `bool` | `true` | Log orphans without deleting (safe default) |
-| `cleanup_interval_hours` | `u64` | `24` | Interval between cleanup runs (hours) |
+| Field                    | Type   | Default | Description                                 |
+| ------------------------ | ------ | ------- | ------------------------------------------- |
+| `enabled`                | `bool` | `false` | Enable orphan cleanup (opt-in)              |
+| `dry_run`                | `bool` | `true`  | Log orphans without deleting (safe default) |
+| `cleanup_interval_hours` | `u64`  | `24`    | Interval between cleanup runs (hours)       |
 
 **Example:**
+
 ```toml
 [compactor.orphan_cleanup]
 enabled = true
@@ -265,13 +280,14 @@ cleanup_interval_hours = 24  # Run once per day
 
 #### Safety Settings
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `grace_period_hours` | `u64` | `24` | Don't delete files younger than this (hours) |
-| `revalidate_before_delete` | `bool` | `true` | Re-check file status before deletion |
-| `max_snapshot_age_hours` | `u64` | `720` | Consider snapshots within this age (hours) |
+| Field                      | Type   | Default | Description                                  |
+| -------------------------- | ------ | ------- | -------------------------------------------- |
+| `grace_period_hours`       | `u64`  | `24`    | Don't delete files younger than this (hours) |
+| `revalidate_before_delete` | `bool` | `true`  | Re-check file status before deletion         |
+| `max_snapshot_age_hours`   | `u64`  | `720`   | Consider snapshots within this age (hours)   |
 
 **Example:**
+
 ```toml
 [compactor.orphan_cleanup]
 grace_period_hours = 48          # 2-day grace period
@@ -298,12 +314,13 @@ max_snapshot_age_hours = 168     # 7-day snapshot window
 
 #### Performance Settings
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `batch_size` | `usize` | `1000` | Files to process per batch |
+| Field                      | Type    | Default  | Description                                                                                                                                                                |
+| -------------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `batch_size`               | `usize` | `1000`   | Files to process per batch                                                                                                                                                 |
 | `max_live_files_threshold` | `usize` | `500000` | Skip cleanup for tables whose estimated live file count exceeds this cap (`0` disables the cap; bounds memory; skips recorded in `compactor_orphan_cleanup_skipped_total`) |
 
 **Example:**
+
 ```toml
 [compactor.orphan_cleanup]
 batch_size = 500                    # Smaller batches = more checkpoints
@@ -356,6 +373,7 @@ SIGNALDB__COMPACTOR__<SECTION>__<FIELD>
 ### Retention Environment Variables
 
 **Basic:**
+
 ```bash
 SIGNALDB__COMPACTOR__RETENTION__ENABLED=true
 SIGNALDB__COMPACTOR__RETENTION__DRY_RUN=false
@@ -364,6 +382,7 @@ SIGNALDB__COMPACTOR__RETENTION__TIMEZONE="UTC"
 ```
 
 **Retention Periods:**
+
 ```bash
 SIGNALDB__COMPACTOR__RETENTION__TRACES=7d
 SIGNALDB__COMPACTOR__RETENTION__LOGS=30d
@@ -371,6 +390,7 @@ SIGNALDB__COMPACTOR__RETENTION__METRICS=90d
 ```
 
 **Safety:**
+
 ```bash
 SIGNALDB__COMPACTOR__RETENTION__GRACE_PERIOD=1h
 SIGNALDB__COMPACTOR__RETENTION__SNAPSHOTS_TO_KEEP=10
@@ -396,7 +416,7 @@ SIGNALDB__COMPACTOR__ORPHAN_CLEANUP__MAX_LIVE_FILES_THRESHOLD=500000
 ### Example: Docker Compose
 
 ```yaml
-version: '3.8'
+version: "3.8"
 services:
   signaldb:
     image: signaldb:latest

--- a/docs/operations/compactor/phase3-operations.md
+++ b/docs/operations/compactor/phase3-operations.md
@@ -30,19 +30,22 @@ Phase 3 provides automatic data lifecycle management through:
 
 All operations respect Iceberg's transactional guarantees and snapshot isolation.
 
+> **Default behavior:** The compactor and retention enforcement are **enabled by default** with `dry_run = false` and a 30-day retention period for traces, logs, and metrics. A default deployment deletes data older than 30 days. To keep data indefinitely, set `[compactor.retention].enabled = false`; to keep it longer, raise the per-signal durations. Orphan cleanup remains opt-in (`enabled = false`, `dry_run = true`).
+
 ## Enabling Retention Enforcement
 
 ### Step 1: Plan Your Retention Policies
 
 Determine appropriate retention periods for each signal type:
 
-| Signal Type | Typical Retention | Production Example |
-|-------------|------------------|-------------------|
-| Traces | 7-30 days | 7 days (dev), 30 days (prod) |
-| Logs | 3-14 days | 3 days (dev), 7 days (prod) |
-| Metrics | 30-90 days | 30 days (dev), 90 days (prod) |
+| Signal Type | Typical Retention | Production Example            |
+| ----------- | ----------------- | ----------------------------- |
+| Traces      | 7-30 days         | 7 days (dev), 30 days (prod)  |
+| Logs        | 3-14 days         | 3 days (dev), 7 days (prod)   |
+| Metrics     | 30-90 days        | 30 days (dev), 90 days (prod) |
 
 Consider:
+
 - Regulatory requirements (GDPR, HIPAA, etc.)
 - Storage costs vs. query needs
 - Incident investigation timeframes
@@ -93,6 +96,7 @@ INFO compactor::retention::enforcer: [DRY RUN] Would drop partition tenant_id=ac
 ```
 
 **Validate:**
+
 - Partitions identified for deletion are expected
 - Cutoff timestamps are correct
 - No unexpected data would be deleted
@@ -164,6 +168,7 @@ traces = "90d"  # Critical data kept 90 days
 ```
 
 **Rollout Checklist:**
+
 - [ ] Dry-run validation completed
 - [ ] Test tenant validation successful
 - [ ] Retention periods reviewed and approved
@@ -203,6 +208,7 @@ INFO compactor::orphan::cleaner: Batch deletion complete would_delete=42 would_f
 ```
 
 **Validate:**
+
 - Orphan count seems reasonable (expect 0-5% of total files)
 - Ages are all beyond grace period (24+ hours)
 - No recently modified files flagged
@@ -246,6 +252,7 @@ curl -s localhost:9091/metrics | grep -E "compactor_(orphan_candidates_identifie
 ```
 
 **Validation:**
+
 - `compactor_files_deleted_total` should equal `compactor_orphan_candidates_identified_total`
 - `compactor_bytes_freed_total` shows actual storage reclaimed
 - No deletion failures (`compactor_deletion_failures_total` = 0)
@@ -259,6 +266,7 @@ All Phase 3 counters are exported at `localhost:9091/metrics` (see `src/compacto
 #### Retention Enforcement
 
 **Partitions Dropped:**
+
 ```promql
 # Partitions dropped (last 24h)
 increase(compactor_partitions_dropped_total[24h])
@@ -268,12 +276,14 @@ increase(compactor_partitions_evaluated_total[24h])
 ```
 
 **Retention Duration:**
+
 ```promql
 # Wall-clock milliseconds spent enforcing retention per second
 rate(compactor_retention_duration_ms_total[5m])
 ```
 
 **Bytes Reclaimed by Retention:**
+
 ```promql
 increase(compactor_bytes_reclaimed_total[24h])
 ```
@@ -281,6 +291,7 @@ increase(compactor_bytes_reclaimed_total[24h])
 #### Orphan Cleanup
 
 **Storage Reclaimed:**
+
 ```promql
 # Total storage freed (last 24h)
 increase(compactor_bytes_freed_total[24h])
@@ -290,6 +301,7 @@ rate(compactor_bytes_freed_total[5m])
 ```
 
 **Cleanup Success Rate:**
+
 ```promql
 # Success rate (should be ~100%)
 sum(rate(compactor_files_deleted_total[5m]))
@@ -298,12 +310,14 @@ sum(rate(compactor_orphan_candidates_identified_total[5m]))
 ```
 
 **Deletion Failures:**
+
 ```promql
 # Should be 0 or very low
 increase(compactor_deletion_failures_total[1h])
 ```
 
 **Skipped Cleanups:**
+
 ```promql
 # Cleanup runs skipped because the live-file estimate exceeded
 # max_live_files_threshold
@@ -315,6 +329,7 @@ increase(compactor_orphan_cleanup_skipped_total[24h])
 #### Critical Alerts
 
 **High Deletion Failure Rate:**
+
 ```yaml
 alert: CompactorHighDeletionFailureRate
 expr: |
@@ -328,6 +343,7 @@ annotations:
 ```
 
 **Retention Enforcement Stuck:**
+
 ```yaml
 # No last-run timestamp metric exists; alert on the cutoff-computation
 # counter stalling instead (it increments on every retention cycle).
@@ -344,6 +360,7 @@ annotations:
 #### Warning Alerts
 
 **High Orphan Rate:**
+
 ```yaml
 alert: CompactorHighOrphanRate
 expr: |
@@ -357,6 +374,7 @@ annotations:
 ```
 
 **Orphan Cleanup Skipped:**
+
 ```yaml
 alert: CompactorOrphanCleanupSkipped
 expr: |
@@ -373,6 +391,7 @@ annotations:
 Example dashboard queries:
 
 **Panel: Storage Reclaimed (Bytes)**
+
 ```promql
 # Orphan cleanup
 increase(compactor_bytes_freed_total[24h])
@@ -381,11 +400,13 @@ increase(compactor_bytes_reclaimed_total[24h])
 ```
 
 **Panel: Partitions Dropped Over Time**
+
 ```promql
 rate(compactor_partitions_dropped_total[5m]) * 300
 ```
 
 **Panel: Retention Duration**
+
 ```promql
 rate(compactor_retention_duration_ms_total[5m])
 ```
@@ -538,6 +559,7 @@ systemctl restart signaldb-compactor
 ```
 
 **Investigate** (against compactor stdout, journalctl, or `.data/logs/monolithic.log`):
+
 ```bash
 # Check revalidation logs
 grep -i "revalidation" .data/logs/monolithic.log
@@ -573,6 +595,7 @@ jq '.snapshots[] | {snapshot_id: ."snapshot-id", timestamp_ms: ."timestamp-ms", 
 3. **Restore:** rolling the table back to the pre-drop snapshot requires manual Iceberg surgery with external Iceberg tooling; it is not currently possible through SignalDB itself.
 
 **Prevention:**
+
 - Always test retention in dry-run mode first
 - Use test tenants before production rollout
 - Keep `snapshots_to_keep` high enough for recovery window
@@ -583,6 +606,7 @@ jq '.snapshots[] | {snapshot_id: ."snapshot-id", timestamp_ms: ."timestamp-ms", 
 ### Retention Enforcement Performance
 
 **Symptoms:**
+
 - Retention checks taking too long (> 5 minutes)
 - High CPU usage during retention cycles
 
@@ -600,6 +624,7 @@ snapshots_to_keep = 3
 ### Orphan Cleanup Performance
 
 **Symptoms:**
+
 - Cleanup taking hours to complete
 - High memory usage during cleanup
 - Object store rate limiting
@@ -623,6 +648,7 @@ max_live_files_threshold = 500000
 ```
 
 **Memory Optimization:**
+
 ```rust
 // For very large tables (millions of files), consider:
 // - Incremental scanning (scan per partition)
@@ -633,6 +659,7 @@ max_live_files_threshold = 500000
 ### Concurrent Operation Tuning
 
 **Symptoms:**
+
 - Queries failing during retention operations
 - Snapshot conflicts
 

--- a/docs/operations/compactor/phase3-troubleshooting.md
+++ b/docs/operations/compactor/phase3-troubleshooting.md
@@ -76,6 +76,7 @@ chmod +x /tmp/compactor_status.sh
 ### Issue 1: No Partitions Being Dropped
 
 **Symptoms:**
+
 - `compactor_partitions_dropped_total` metric is 0
 - Data older than retention period still exists
 - No drop operations in logs
@@ -103,13 +104,13 @@ find .data/storage/<tenant>/<dataset>/traces -name "*.parquet" -mtime +7 | head
 
 **Common Causes and Solutions:**
 
-| Cause | Verification | Solution |
-|-------|-------------|----------|
-| Retention disabled | `enabled = false` in config | Set `enabled = true` |
-| Dry-run mode enabled | `dry_run = true` in config | Set `dry_run = false` |
-| Grace period too large | Check `grace_period` | Reduce grace period |
-| No data old enough | Check partition timestamps | Wait for data to age |
-| Retention check hasn't run | Check `compactor_retention_cutoffs_computed_total` | Restart compactor or wait for interval |
+| Cause                      | Verification                                       | Solution                                                                                                   |
+| -------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Retention disabled         | `enabled = false` in config                        | Set `enabled = true` (retention is enabled by default; `enabled = false` only appears when set explicitly) |
+| Dry-run mode enabled       | `dry_run = true` in config                         | Set `dry_run = false` (the default is `false`)                                                             |
+| Grace period too large     | Check `grace_period`                               | Reduce grace period                                                                                        |
+| No data old enough         | Check partition timestamps                         | Wait for data to age                                                                                       |
+| Retention check hasn't run | Check `compactor_retention_cutoffs_computed_total` | Restart compactor or wait for interval                                                                     |
 
 **Example Fix:**
 
@@ -129,6 +130,7 @@ traces = "7d"
 ### Issue 2: Partitions Dropped Too Aggressively
 
 **Symptoms:**
+
 - More partitions dropped than expected
 - Data deleted sooner than configured retention
 - Unexpected partition drop logs
@@ -187,6 +189,7 @@ grace_period = "0s"  # ← No safety margin
 ### Issue 3: Retention Check Not Running
 
 **Symptoms:**
+
 - `compactor_retention_cutoffs_computed_total` not increasing
 - No retention logs in recent time window
 - Partitions not being evaluated
@@ -241,6 +244,7 @@ retention_check_interval = "24h"  # Won't run often
 ### Issue 4: Snapshot Expiration Not Working
 
 **Symptoms:**
+
 - Snapshot count keeps growing
 - `compactor_snapshots_expired_total` is 0
 - Metadata size increasing
@@ -287,6 +291,7 @@ curl -s localhost:9091/metrics | grep compactor_snapshots_expired_total
 ### Issue 5: Orphan Files Not Being Deleted
 
 **Symptoms:**
+
 - `compactor_orphan_candidates_identified_total` > 0
 - `compactor_files_deleted_total` = 0
 - Orphan files identified but not removed
@@ -306,13 +311,13 @@ journalctl -u signaldb-compactor | grep -i "revalidation" | tail -10
 
 **Common Causes:**
 
-| Cause | Verification | Solution |
-|-------|-------------|----------|
-| Dry-run mode enabled | `dry_run = true` | Set `dry_run = false` |
-| Revalidation finding files live | Check revalidation logs | Normal - files no longer orphaned |
-| Permission errors | Check error logs for "Permission denied" | Fix object store permissions |
-| Grace period not met | Check file ages | Wait for grace period to elapse |
-| Object store unavailable | Check network/S3 connectivity | Restore object store access |
+| Cause                           | Verification                             | Solution                          |
+| ------------------------------- | ---------------------------------------- | --------------------------------- |
+| Dry-run mode enabled            | `dry_run = true`                         | Set `dry_run = false`             |
+| Revalidation finding files live | Check revalidation logs                  | Normal - files no longer orphaned |
+| Permission errors               | Check error logs for "Permission denied" | Fix object store permissions      |
+| Grace period not met            | Check file ages                          | Wait for grace period to elapse   |
+| Object store unavailable        | Check network/S3 connectivity            | Restore object store access       |
 
 **Example Fix:**
 
@@ -333,6 +338,7 @@ revalidate_before_delete = true
 ### Issue 6: False Orphan Detection
 
 **Symptoms:**
+
 - High orphan count (> 10% of total files)
 - Recently written files flagged as orphans
 - Revalidation preventing most deletions
@@ -377,6 +383,7 @@ Compaction creates new files that reference data from old files. The old files b
 ### Issue 7: Orphan Cleanup Taking Too Long
 
 **Symptoms:**
+
 - Cleanup runs for hours
 - High memory usage during cleanup
 - Cleanup skipped with `compactor_orphan_cleanup_skipped_total` increasing
@@ -426,6 +433,7 @@ reduce file counts before raising the threshold.
 ### Issue 8: High CPU Usage During Retention
 
 **Symptoms:**
+
 - CPU spikes during retention check
 - Retention check duration > 5 minutes
 - System slowdown during retention
@@ -467,6 +475,7 @@ If many partitions exist, consider implementing partition pruning in the query p
 ### Issue 9: High Memory Usage
 
 **Symptoms:**
+
 - OOM errors during orphan cleanup
 - Memory usage growing over time
 - System swapping during cleanup
@@ -504,7 +513,7 @@ max_snapshot_age_hours = 168  # 7 days
 # compose.yml
 services:
   compactor:
-    mem_limit: 4g  # Increase from default
+    mem_limit: 4g # Increase from default
 ```
 
 ## Data Integrity Issues
@@ -512,6 +521,7 @@ services:
 ### Issue 10: Queries Failing After Retention
 
 **Symptoms:**
+
 - "Snapshot not found" errors
 - "Partition not found" errors
 - Query failures correlated with retention runs
@@ -550,6 +560,7 @@ Configure query service to refresh snapshot references more frequently.
 ### Issue 11: Accidental Data Deletion
 
 **Symptoms:**
+
 - More data deleted than expected
 - Incorrect retention cutoff applied
 - Production data missing
@@ -715,16 +726,20 @@ find .data/storage -name "*.parquet" -mtime -1 -ls
 ### Error: "Table retention enforcement failed"
 
 **Full Message:**
+
 ```
 WARN compactor::retention::enforcer: Table retention enforcement failed tenant_id=acme dataset_id=prod table_name=traces error=Failed to commit partition drop: ...
 ```
 
 **Causes:**
+
 - Catalog connection lost
 - Concurrent modification conflict (snapshot conflicts are retried a few times first; look for "Partition drop hit a snapshot conflict; retrying against fresh metadata")
 
 **Solutions:**
+
 1. Check catalog connectivity:
+
    ```bash
    psql -h localhost -U signaldb -d signaldb -c "SELECT 1"
    ```
@@ -734,23 +749,28 @@ WARN compactor::retention::enforcer: Table retention enforcement failed tenant_i
 ### Error: "Failed to delete orphan file"
 
 **Full Message:**
+
 ```
 ERROR compactor::orphan::cleaner: Failed to delete orphan file path=acme/prod/traces/data/data-001.parquet error=Failed to delete file: ... table=acme/prod/traces
 ```
 
 **Causes:**
+
 - Insufficient object store permissions
 - Object store credentials invalid
 - Object store unavailable
 
 **Solutions:**
+
 1. Check object store credentials:
+
    ```bash
    env | grep AWS
    # Verify AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
    ```
 
 2. Test object store access:
+
    ```bash
    aws s3 ls s3://signaldb-data/
    ```
@@ -762,6 +782,7 @@ ERROR compactor::orphan::cleaner: Failed to delete orphan file path=acme/prod/tr
 ### Warning: "File no longer orphan after revalidation, skipping deletion"
 
 **Full Message:**
+
 ```
 WARN compactor::orphan::cleaner: File no longer orphan after revalidation, skipping deletion path=acme/prod/traces/data/data-001.parquet table=acme/prod/traces
 ```
@@ -773,6 +794,7 @@ WARN compactor::orphan::cleaner: File no longer orphan after revalidation, skipp
 ### Debug: "Skipping recent file (within grace period)"
 
 **Full Message:**
+
 ```
 DEBUG compactor::orphan::detector: Skipping recent file (within grace period) path=acme/prod/traces/data/data-001.parquet last_modified=2026-02-09T09:30:00Z cutoff_time=2026-02-08T10:00:00Z grace_period_hours=24
 ```

--- a/signaldb.dist.toml
+++ b/signaldb.dist.toml
@@ -251,7 +251,7 @@ max_search_limit = 1000
 #   Phase 3: Retention enforcement and lifecycle management (NEW)
 #
 # Phase 2: Compaction Settings
-enabled = false                       # Enable compactor service (opt-in)
+enabled = true                        # Enable compactor service (enabled by default)
 tick_interval = "5m"                  # Interval between compaction planning cycles
 target_file_size_mb = 128             # Target file size after compaction (MB)
 file_count_threshold = 5              # Minimum files to trigger compaction
@@ -276,10 +276,12 @@ metrics_addr = "0.0.0.0:9091"
 # Automatically drops expired partitions based on configurable retention policies.
 # Uses a 3-tier hierarchy: Global defaults → Tenant overrides → Dataset overrides.
 #
-# IMPORTANT: Always test with dry_run = true first!
+# IMPORTANT: Retention enforcement is ON by default and DELETES data older
+# than 30 days. Set enabled = false (or longer durations) to keep data
+# longer; set dry_run = true to log decisions without deleting.
 [compactor.retention]
-enabled = false                       # Enable retention enforcement (opt-in, default: false)
-dry_run = true                        # Log actions without executing (safe default: true)
+enabled = true                        # Enable retention enforcement (default: true)
+dry_run = false                       # Enforce deletions (default: false; set true to only log)
 retention_check_interval = "1h"       # Interval between retention checks (default: 1h)
 grace_period = "1h"                   # Safety margin before cutoff (prevents clock skew issues)
 timezone = "UTC"                      # Timezone for logging (internal storage uses UTC)
@@ -287,9 +289,9 @@ snapshots_to_keep = 5                 # Keep last N snapshots per table (minimum
 
 # Global Default Retention Periods (per signal type)
 # These apply to all tenants/datasets unless overridden below.
-traces = "7d"                         # Trace data retention (default: 7 days)
+traces = "30d"                        # Trace data retention (default: 30 days)
 logs = "30d"                          # Log data retention (default: 30 days)
-metrics = "90d"                       # Metric data retention (default: 90 days)
+metrics = "30d"                       # Metric data retention (default: 30 days)
 
 # Tenant-Specific Retention Overrides (optional)
 # Override global defaults for specific tenants.
@@ -315,14 +317,14 @@ metrics = "90d"                       # Metric data retention (default: 90 days)
 # logs = "1d"                         # Override: Keep staging logs for only 1 day
 #
 # Resolution Example:
-#   Global:    traces = 7 days
+#   Global:    traces = 30 days
 #   Tenant:    traces = 30 days (overrides global)
 #   Dataset:   traces = 90 days (overrides tenant)
 # Result:
 #   - production/critical → 90 days (dataset override)
 #   - production/staging  → 1 day (dataset override)
 #   - production/default  → 30 days (tenant override)
-#   - other/any          → 7 days (global default)
+#   - other/any          → 30 days (global default)
 
 # Phase 3: Orphan File Cleanup Configuration
 # Automatically detects and deletes unreferenced Parquet files to reclaim storage.

--- a/src/common/src/config/mod.rs
+++ b/src/common/src/config/mod.rs
@@ -30,15 +30,15 @@ pub fn redact_dsn(dsn: &str) -> String {
 /// in the compactor crate but lives in common for TOML/env deserialization.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RetentionConfig {
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(with = "humantime_serde", default = "default_retention_check_interval")]
     pub retention_check_interval: Duration,
-    #[serde(with = "humantime_serde", default = "default_traces_retention")]
+    #[serde(with = "humantime_serde", default = "default_signal_retention")]
     pub traces: Duration,
-    #[serde(with = "humantime_serde", default = "default_logs_retention")]
+    #[serde(with = "humantime_serde", default = "default_signal_retention")]
     pub logs: Duration,
-    #[serde(with = "humantime_serde", default = "default_metrics_retention")]
+    #[serde(with = "humantime_serde", default = "default_signal_retention")]
     pub metrics: Duration,
     #[serde(with = "humantime_serde", default = "default_grace_period")]
     pub grace_period: Duration,
@@ -56,16 +56,8 @@ fn default_retention_check_interval() -> Duration {
     Duration::from_secs(3600) // 1 hour
 }
 
-fn default_traces_retention() -> Duration {
-    Duration::from_secs(7 * 24 * 3600) // 7 days
-}
-
-fn default_logs_retention() -> Duration {
-    Duration::from_secs(30 * 24 * 3600) // 30 days
-}
-
-fn default_metrics_retention() -> Duration {
-    Duration::from_secs(90 * 24 * 3600) // 90 days
+fn default_signal_retention() -> Duration {
+    Duration::from_secs(30 * 24 * 3600) // 30 days for traces, logs, and metrics
 }
 
 fn default_grace_period() -> Duration {
@@ -77,17 +69,17 @@ fn default_timezone() -> String {
 }
 
 fn default_dry_run() -> bool {
-    true
+    false // Retention enforces (deletes expired data) by default
 }
 
 impl Default for RetentionConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true, // Retention enforcement is on by default (30d)
             retention_check_interval: default_retention_check_interval(),
-            traces: default_traces_retention(),
-            logs: default_logs_retention(),
-            metrics: default_metrics_retention(),
+            traces: default_signal_retention(),
+            logs: default_signal_retention(),
+            metrics: default_signal_retention(),
             grace_period: default_grace_period(),
             timezone: default_timezone(),
             dry_run: default_dry_run(),
@@ -377,9 +369,9 @@ impl Default for WalConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompactorConfig {
-    /// Enable compactor service
+    /// Enable compactor service (enabled by default)
     /// Env: SIGNALDB__COMPACTOR__ENABLED
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub enabled: bool,
 
     /// Interval between compaction planning cycles
@@ -467,7 +459,7 @@ fn default_compactor_metrics_addr() -> String {
 impl Default for CompactorConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             tick_interval: Duration::from_secs(300), // 5 minutes
             target_file_size_mb: 128,
             file_count_threshold: 10,
@@ -1493,6 +1485,43 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn compactor_defaults_enable_compaction_and_30d_retention() {
+        let config = Configuration::default();
+
+        // Compaction runs by default
+        assert!(config.compactor.enabled, "compactor enabled by default");
+
+        // Retention enforcement is on by default and actually deletes
+        let retention = &config.compactor.retention;
+        assert!(
+            retention.enabled,
+            "retention enforcement enabled by default"
+        );
+        assert!(
+            !retention.dry_run,
+            "retention enforces (not dry-run) by default"
+        );
+
+        // All three signal defaults are 30 days
+        let thirty_days = Duration::from_secs(30 * 24 * 3600);
+        assert_eq!(retention.traces, thirty_days);
+        assert_eq!(retention.logs, thirty_days);
+        assert_eq!(retention.metrics, thirty_days);
+
+        // Unchanged defaults
+        assert_eq!(
+            retention.retention_check_interval,
+            Duration::from_secs(3600)
+        );
+        assert_eq!(retention.grace_period, Duration::from_secs(3600));
+        assert_eq!(retention.snapshots_to_keep, Some(10));
+
+        // Orphan cleanup stays opt-in
+        assert!(!config.compactor.orphan_cleanup.enabled);
+        assert!(config.compactor.orphan_cleanup.dry_run);
     }
 
     #[test]

--- a/src/compactor/README.md
+++ b/src/compactor/README.md
@@ -13,8 +13,14 @@ The Compactor Service manages the data lifecycle for observability signals
    memory guard that skips oversized tables instead of risking OOM)
 
 All operations respect Iceberg's transactional guarantees and snapshot
-isolation. Destructive features default to off (`enabled = false`) and to
-dry-run (`dry_run = true`) when enabled.
+isolation.
+
+> **Default behavior:** Compaction and retention enforcement are **enabled by
+> default**, with `dry_run = false` and a 30-day retention period for traces,
+> logs, and metrics — a default deployment deletes data older than 30 days.
+> Set `[compactor.retention].enabled = false` for infinite retention, or raise
+> the per-signal durations. Orphan cleanup remains opt-in
+> (`enabled = false`, `dry_run = true`).
 
 ## Configuration
 
@@ -29,12 +35,12 @@ enabled = true
 tick_interval = "5m"  # Interval between compaction planning cycles
 
 [compactor.retention]
-enabled = true
-dry_run = true                    # Start with dry-run; set false to enforce
+enabled = true                    # Default: true
+dry_run = false                   # Default: false (set true to log without deleting)
 retention_check_interval = "1h"
-traces = "7d"
+traces = "30d"                    # Default: 30d for all three signal types
 logs = "30d"
-metrics = "90d"
+metrics = "30d"
 grace_period = "1h"
 snapshots_to_keep = 10
 
@@ -91,10 +97,10 @@ PostgreSQL):
 Each instance serves an Arrow Flight admin endpoint (default port `50055`,
 override with `COMPACTOR_FLIGHT_ADDR`) with three DoAction verbs:
 
-| Action | Effect |
-|--------|--------|
-| `compact_now` | Run a full plan → lease → execute cycle immediately |
-| `compact_status` | Return active leases + cumulative metrics as JSON |
+| Action            | Effect                                              |
+| ----------------- | --------------------------------------------------- |
+| `compact_now`     | Run a full plan → lease → execute cycle immediately |
+| `compact_status`  | Return active leases + cumulative metrics as JSON   |
 | `compact_dry_run` | Plan candidates without executing, return JSON list |
 
 Covered by `tests-integration/tests/compactor/multi_instance.rs`.

--- a/src/compactor/src/main.rs
+++ b/src/compactor/src/main.rs
@@ -661,8 +661,11 @@ mod tests {
     #[test]
     fn test_retention_config_defaults() {
         let config = RetentionConfig::default();
-        assert!(!config.enabled, "Retention should be disabled by default");
-        assert!(config.dry_run, "Dry-run should be enabled by default");
+        assert!(config.enabled, "Retention should be enabled by default");
+        assert!(
+            !config.dry_run,
+            "Retention should enforce (not dry-run) by default"
+        );
         assert_eq!(
             config.retention_check_interval,
             Duration::from_secs(3600),

--- a/src/compactor/src/planner.rs
+++ b/src/compactor/src/planner.rs
@@ -536,7 +536,7 @@ mod tests {
     fn test_compactor_config_defaults() {
         let config = CompactorConfig::default();
 
-        assert!(!config.enabled); // Disabled by default
+        assert!(config.enabled); // Compaction is enabled by default
         assert_eq!(config.tick_interval, std::time::Duration::from_secs(300)); // 5 minutes
         assert_eq!(config.target_file_size_mb, 128);
         assert_eq!(config.file_count_threshold, 10);

--- a/src/compactor/src/retention/config.rs
+++ b/src/compactor/src/retention/config.rs
@@ -10,10 +10,10 @@ use thiserror::Error;
 /// Retention policy configuration with support for tenant and dataset overrides.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RetentionConfig {
-    /// Enable retention enforcement.
+    /// Enable retention enforcement (enabled by default).
     ///
     /// Env: SIGNALDB__COMPACTOR__RETENTION__ENABLED
-    #[serde(default)]
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
 
     /// Interval between retention checks.
@@ -77,18 +77,22 @@ fn default_timezone() -> String {
     "UTC".to_string()
 }
 
+fn default_enabled() -> bool {
+    true // Retention enforcement is on by default
+}
+
 fn default_dry_run() -> bool {
-    true // Dry-run enabled by default for safety
+    false // Retention enforces (deletes expired data) by default
 }
 
 impl Default for RetentionConfig {
     fn default() -> Self {
         Self {
-            enabled: false,                                      // Disabled by default for safety
+            enabled: default_enabled(),
             retention_check_interval: Duration::from_secs(3600), // 1 hour
-            traces: Duration::from_secs(7 * 24 * 3600),          // 7 days
+            traces: Duration::from_secs(30 * 24 * 3600),         // 30 days
             logs: Duration::from_secs(30 * 24 * 3600),           // 30 days
-            metrics: Duration::from_secs(90 * 24 * 3600),        // 90 days
+            metrics: Duration::from_secs(30 * 24 * 3600),        // 30 days
             tenant_overrides: HashMap::new(),
             grace_period: default_grace_period(),
             timezone: default_timezone(),

--- a/src/compactor/src/retention/policy.rs
+++ b/src/compactor/src/retention/policy.rs
@@ -270,14 +270,14 @@ mod tests {
         assert_eq!(cutoff.dataset_id, "dataset1");
         assert_eq!(cutoff.signal_type, SignalType::Traces);
         assert_eq!(cutoff.source, RetentionPolicySource::Global);
-        assert_eq!(cutoff.retention_period, Duration::from_secs(7 * 24 * 3600));
+        assert_eq!(cutoff.retention_period, Duration::from_secs(30 * 24 * 3600));
 
-        // Cutoff should be approximately 7 days + 1 hour ago (with grace period)
-        let expected_cutoff = Utc::now() - chrono::Duration::seconds((7 * 24 + 1) * 3600);
+        // Cutoff should be approximately 30 days + 1 hour ago (with grace period)
+        let expected_cutoff = Utc::now() - chrono::Duration::seconds((30 * 24 + 1) * 3600);
         let diff = (cutoff.cutoff_timestamp - expected_cutoff)
             .num_seconds()
             .abs();
-        assert!(diff < 2, "Cutoff should be approximately 7d 1h ago");
+        assert!(diff < 2, "Cutoff should be approximately 30d 1h ago");
     }
 
     #[test]
@@ -336,7 +336,7 @@ mod tests {
     fn test_override_hierarchy_precedence() {
         let mut config = create_default_config();
 
-        // Global: 7 days
+        // Global: 30 days
         // Tenant: 14 days
         // Dataset: 30 days
 
@@ -389,13 +389,20 @@ mod tests {
         assert_eq!(cutoff_other.source, RetentionPolicySource::Global);
         assert_eq!(
             cutoff_other.retention_period,
-            Duration::from_secs(7 * 24 * 3600)
+            Duration::from_secs(30 * 24 * 3600)
         );
     }
 
     #[test]
     fn test_different_signal_types() {
-        let config = create_default_config();
+        // Use distinct per-signal periods so the test proves each signal
+        // type resolves to its own configured duration.
+        let config = RetentionConfig {
+            traces: Duration::from_secs(7 * 24 * 3600),
+            logs: Duration::from_secs(30 * 24 * 3600),
+            metrics: Duration::from_secs(90 * 24 * 3600),
+            ..Default::default()
+        };
         let resolver = RetentionPolicyResolver::new(config).unwrap();
 
         let traces_cutoff = resolver


### PR DESCRIPTION
> [!WARNING]
> **Deliberate destructive-default change.** Once upgraded, a deployment running with default configuration will **delete data older than 30 days**: the compactor is now enabled by default, and retention enforcement runs with `enabled = true` and `dry_run = false`. Operators who want infinite retention must set `[compactor.retention].enabled = false`; operators who want longer retention should raise the per-signal durations. Per-tenant/dataset overrides are unchanged.

## What changed

Default flips in `src/common/src/config/mod.rs` (and the mirror `RetentionConfig` in `src/compactor/src/retention/config.rs`):

| Setting | Before | After |
|---|---|---|
| `[compactor].enabled` | `false` | `true` |
| `[compactor.retention].enabled` | `false` | `true` |
| `[compactor.retention].dry_run` | `true` | `false` |
| `[compactor.retention].traces` | `7d` | `30d` |
| `[compactor.retention].logs` | `30d` | `30d` (unchanged) |
| `[compactor.retention].metrics` | `90d` | `30d` |

Unchanged: `grace_period` (1h), `retention_check_interval` (1h), `snapshots_to_keep` (10), and all `[compactor.orphan_cleanup]` defaults (still opt-in, dry-run).

## Consistency sweep

- `signaldb.dist.toml`: compactor/retention section and comments reflect the new defaults, with a prominent deletion warning (`config.toml.dist` has no compactor section).
- Docs: `docs/operations/compactor/phase3-configuration.md` (default tables + warning), `phase3-operations.md` (default-behavior note), `docs/architecture/overview.md`, `src/compactor/README.md`, `CLAUDE.md`, `.claude/skills/configuration/SKILL.md`.
- Tests (TDD): new `compactor_defaults_enable_compaction_and_30d_retention` in common config; updated default assertions in `compactor/src/planner.rs`, `compactor/src/main.rs`, and `compactor/src/retention/policy.rs` (per-signal test now uses explicit distinct durations so it still discriminates).

## Verification

- `cargo fmt` + `cargo clippy --workspace --all-targets --all-features` clean
- `cargo test -p common -p compactor` green (single local failure is the testcontainers Postgres Flight test — Docker unavailable locally, unrelated)
- `./scripts/check-doc-freshness.sh "origin/main...HEAD"` passes