### PR TITLE
feat: native explore UI for logs, traces, and metrics

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -9,38 +9,64 @@ set -o pipefail
 echo "Running pre-commit hooks..."
 echo "Note: All checks are fatal - any failure will prevent commit"
 
-# Check code formatting first (fastest check, most common failure)
-echo "Checking code formatting..."
-cargo fmt --all -- --check || {
-    echo "❌ FATAL: Code formatting check failed!"
-    echo "Run 'cargo fmt' to fix formatting issues."
-    exit 1
-}
+# Gate each toolchain's checks on what is actually staged: UI-only commits
+# should not pay for a full-workspace clippy pass, and Rust commits should
+# not wait on pnpm.
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
 
-# Run clippy with warnings as errors. Clippy is `cargo check` plus lints with
-# the same flags, so a separate check pass would only duplicate a full
-# workspace compile.
-echo "Running clippy..."
-cargo clippy --workspace --all-targets --all-features -- -D warnings || {
-    echo "❌ FATAL: Clippy found issues!"
-    echo "Fix all clippy warnings before committing."
-    exit 1
-}
+rust_staged=$(echo "$staged" | grep -E '\.rs$|(^|/)Cargo\.(toml|lock)$|^deny\.toml$|^rustfmt\.toml$|^\.cargo-husky/' || true)
+ui_staged=$(echo "$staged" | grep -E '^src/ui/' || true)
 
-# Check for unused dependencies
-echo "Checking for unused dependencies..."
-cargo machete --with-metadata || {
-    echo "❌ FATAL: Found unused dependencies!"
-    echo "Remove unused dependencies or update cargo-machete ignores."
-    exit 1
-}
+if [ -n "$rust_staged" ]; then
+    # Check code formatting first (fastest check, most common failure)
+    echo "Checking code formatting..."
+    cargo fmt --all -- --check || {
+        echo "❌ FATAL: Code formatting check failed!"
+        echo "Run 'cargo fmt' to fix formatting issues."
+        exit 1
+    }
 
-# License and security auditing
-echo "Running security and license auditing..."
-cargo deny check || {
-    echo "❌ FATAL: Security or license audit failed!"
-    echo "Review and fix security/license issues before committing."
-    exit 1
-}
+    # Run clippy with warnings as errors. Clippy is `cargo check` plus lints
+    # with the same flags, so a separate check pass would only duplicate a
+    # full workspace compile.
+    echo "Running clippy..."
+    cargo clippy --workspace --all-targets --all-features -- -D warnings || {
+        echo "❌ FATAL: Clippy found issues!"
+        echo "Fix all clippy warnings before committing."
+        exit 1
+    }
+
+    # Check for unused dependencies
+    echo "Checking for unused dependencies..."
+    cargo machete --with-metadata || {
+        echo "❌ FATAL: Found unused dependencies!"
+        echo "Remove unused dependencies or update cargo-machete ignores."
+        exit 1
+    }
+
+    # License and security auditing
+    echo "Running security and license auditing..."
+    cargo deny check || {
+        echo "❌ FATAL: Security or license audit failed!"
+        echo "Review and fix security/license issues before committing."
+        exit 1
+    }
+else
+    echo "No Rust changes staged - skipping cargo checks."
+fi
+
+if [ -n "$ui_staged" ]; then
+    echo "Checking UI (typecheck + lint)..."
+    pnpm --filter signaldb-ui typecheck || {
+        echo "❌ FATAL: UI typecheck failed!"
+        exit 1
+    }
+    pnpm --filter signaldb-ui lint || {
+        echo "❌ FATAL: UI lint failed!"
+        exit 1
+    }
+else
+    echo "No UI changes staged - skipping UI checks."
+fi
 
 echo "✅ All pre-commit checks passed!"

--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -70,6 +70,7 @@ Key details:
    - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series and `detected_fields` (sampled attribute-field discovery: name, inferred type, approx cardinality — epic #737 L3).
    - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix), plus `histogram_quantile(phi, metric)` interpolated from `metrics_histogram` OTLP buckets; `MetricsService` also backs `/prometheus` labels/values/series. `histogram_quantile` over an inner `rate()`, binary ops, and `topk` remain pending (#335).
    - `/pyroscope` (profiles) via `ProfileService`.
+7. Router serves the explore UI (static SPA from `src/ui`) at `/ui` from the directory named by `SIGNALDB_UI_DIR` (`src/router/src/ui.rs`); unset -> placeholder page, set-but-invalid -> startup failure. Container images ship the assets preinstalled.
 
 ## Service Components
 

--- a/.claude/skills/tempo-api/SKILL.md
+++ b/.claude/skills/tempo-api/SKILL.md
@@ -13,18 +13,23 @@ sources:
 
 ## Implemented Endpoints (Router :3000)
 
-| Endpoint | Status | Description |
-|----------|--------|-------------|
-| `GET /tempo/api/echo` | Implemented | Health check |
-| `GET /tempo/api/traces/{trace_id}` | Implemented | Single trace lookup -> routes to Querier; `start`/`end` time hints prune the scanned range |
-| `GET /tempo/api/v2/traces/{trace_id}` | Implemented | Same handler as v1 for now |
-| `GET /tempo/api/search` | Implemented | Trace search with filters -> routes to Querier; `spss` caps spans per span set in the response |
-| `GET /tempo/api/search/tags` | Implemented | Static tag set of actually-queryable tags (`service.name`, `name`, `status`) |
-| `GET /tempo/api/search/tag/{tag_name}/values` | Implemented | Real data: distinct column values via Flight SQL for supported tags; static values for `status`; 501 for unindexed attribute tags |
-| `GET /tempo/api/v2/search/tags` | Implemented | Same tag set, scoped (resource/intrinsic) |
-| `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented | Same backing as v1 tag values |
-| `GET /tempo/api/metrics/query` | 501 Not Implemented | TraceQL metrics not implemented (returns 501 since #552, no fabricated series) |
-| `GET /tempo/api/metrics/query_range` | 501 Not Implemented | Same as above |
+| Endpoint                                         | Status              | Description                                                                                                                       |
+| ------------------------------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /tempo/api/echo`                            | Implemented         | Health check                                                                                                                      |
+| `GET /tempo/api/traces/{trace_id}`               | Implemented         | Single trace lookup -> routes to Querier; `start`/`end` time hints prune the scanned range                                        |
+| `GET /tempo/api/v2/traces/{trace_id}`            | Implemented         | Same handler as v1 for now                                                                                                        |
+| `GET /tempo/api/search`                          | Implemented         | Trace search with filters -> routes to Querier; `spss` caps spans per span set in the response                                    |
+| `GET /tempo/api/search/tags`                     | Implemented         | Static tag set of actually-queryable tags (`service.name`, `name`, `status`)                                                      |
+| `GET /tempo/api/search/tag/{tag_name}/values`    | Implemented         | Real data: distinct column values via Flight SQL for supported tags; static values for `status`; 501 for unindexed attribute tags |
+| `GET /tempo/api/v2/search/tags`                  | Implemented         | Same tag set, scoped (resource/intrinsic)                                                                                         |
+| `GET /tempo/api/v2/search/tag/{tag_name}/values` | Implemented         | Same backing as v1 tag values                                                                                                     |
+| `GET /tempo/api/metrics/query`                   | 501 Not Implemented | TraceQL metrics not implemented (returns 501 since #552, no fabricated series)                                                    |
+| `GET /tempo/api/metrics/query_range`             | 501 Not Implemented | Same as above                                                                                                                     |
+
+Spanset spans carry optional extras beyond Tempo's shape — `name`,
+`parentSpanID`, `serviceName`, `status` (skipped when absent) — populated by
+`internal_trace_to_tempo` in `endpoints/tempo.rs`; the explore UI's waterfall
+depends on them.
 
 ## Query Flow
 
@@ -54,14 +59,14 @@ use SignalDB as a querier (`src/querier/src/services/tempo.rs`):
 
 Requires `admin_api_key` from config:
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v1/admin/tenants` | GET/POST | List/create tenants |
-| `/api/v1/admin/tenants/{id}` | GET/PUT/DELETE | Manage tenant |
-| `/api/v1/admin/tenants/{id}/api-keys` | GET/POST | List/create API keys |
-| `/api/v1/admin/tenants/{id}/api-keys/{key_id}` | DELETE | Revoke API key |
-| `/api/v1/admin/tenants/{id}/datasets` | GET/POST | List/create datasets |
-| `/api/v1/admin/tenants/{id}/datasets/{dataset_id}` | DELETE | Delete dataset |
+| Endpoint                                           | Method         | Description          |
+| -------------------------------------------------- | -------------- | -------------------- |
+| `/api/v1/admin/tenants`                            | GET/POST       | List/create tenants  |
+| `/api/v1/admin/tenants/{id}`                       | GET/PUT/DELETE | Manage tenant        |
+| `/api/v1/admin/tenants/{id}/api-keys`              | GET/POST       | List/create API keys |
+| `/api/v1/admin/tenants/{id}/api-keys/{key_id}`     | DELETE         | Revoke API key       |
+| `/api/v1/admin/tenants/{id}/datasets`              | GET/POST       | List/create datasets |
+| `/api/v1/admin/tenants/{id}/datasets/{dataset_id}` | DELETE         | Delete dataset       |
 
 A separate tenant self-service API is mounted at `/api/v1` (see the
 `multi-tenancy` skill).
@@ -82,10 +87,10 @@ The Router's Tempo-compatible endpoints at `/tempo/api/...` work directly with G
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `src/router/src/endpoints/tempo.rs` | Tempo API HTTP handlers |
-| `src/router/src/endpoints/admin.rs` | Admin API handlers |
-| `src/tempo-api/` | Protobuf definitions and Tempo types |
-| `src/querier/src/flight.rs` | Query execution, ticket parsing |
-| `src/grafana-plugin/` | Native Grafana plugin |
+| File                                | Purpose                              |
+| ----------------------------------- | ------------------------------------ |
+| `src/router/src/endpoints/tempo.rs` | Tempo API HTTP handlers              |
+| `src/router/src/endpoints/admin.rs` | Admin API handlers                   |
+| `src/tempo-api/`                    | Protobuf definitions and Tempo types |
+| `src/querier/src/flight.rs`         | Query execution, ticket parsing      |
+| `src/grafana-plugin/`               | Native Grafana plugin                |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       core: ${{ steps.filter.outputs.core }}
+      ui: ${{ steps.filter.outputs.ui }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -46,17 +47,58 @@ jobs:
             if ! git cat-file -e "$base" 2>/dev/null; then
               # Branch creation or force push: no usable before-SHA.
               echo "core=true" >> "$GITHUB_OUTPUT"
+              echo "ui=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
           changed=$(git diff --name-only "$base" HEAD)
-          core_changed=$(echo "$changed" | grep -vE '^src/grafana-plugin/|^\.github/workflows/grafana-plugin-' || true)
+          # UI and plugin are standalone npm workspaces with their own CI;
+          # skip (not path-filter) the Rust jobs for changes contained there.
+          core_changed=$(echo "$changed" | grep -vE '^src/grafana-plugin/|^src/ui/|^\.github/workflows/grafana-plugin-' || true)
+          ui_changed=$(echo "$changed" | grep -E '^src/ui/|^pnpm-lock\.yaml$|^pnpm-workspace\.yaml$|^\.github/workflows/ci\.yml$' || true)
           if [ -n "$core_changed" ]; then
             echo "core=true" >> "$GITHUB_OUTPUT"
           else
             echo "core=false" >> "$GITHUB_OUTPUT"
-            echo "Only Grafana plugin files changed; core CI will be skipped."
+            echo "Only Grafana plugin / UI files changed; core CI will be skipped."
           fi
+          if [ -n "$ui_changed" ]; then
+            echo "ui=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ui=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Explore UI: typecheck, lint, test, build. Skipped (not path-filtered)
+  # when no UI files changed so a required "UI" context still reports.
+  ui:
+    name: UI
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm --filter signaldb-ui typecheck
+
+      - name: Lint
+        run: pnpm --filter signaldb-ui lint
+
+      - name: Test
+        run: pnpm --filter signaldb-ui test
+
+      - name: Build
+        run: pnpm --filter signaldb-ui build
 
   # Fast preliminary checks - fail fast strategy
   check:

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ node_modules/
 
 # Staged binaries for prebuilt Docker images (CI)
 /dist/
+
+# SignalDB UI
+src/ui/dist/
+.env.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4281,6 +4287,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -6173,12 +6189,14 @@ dependencies = [
  "serde",
  "serde_json",
  "signaldb-api",
+ "tempfile",
  "tempo-api",
  "tikv-jemallocator",
  "tokio",
  "tokio-test",
  "tonic",
  "tower",
+ "tower-http",
  "tracing",
  "uuid",
 ]
@@ -7985,10 +8003,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,23 @@
 #              the in-container compile entirely
 ARG BUILDER=source
 
+# Explore UI builder - always built in-container (fast), consumed by the
+# router and monolithic runtime stages. A failing UI build fails the image
+# build; images never ship silently without their UI.
+FROM node:22-alpine AS ui-builder
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
+
+WORKDIR /build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY src/ui/package.json src/ui/
+COPY src/grafana-plugin/package.json src/grafana-plugin/
+RUN pnpm install --frozen-lockfile --filter signaldb-ui
+
+COPY src/ui/ src/ui/
+RUN pnpm --filter signaldb-ui build
+
 # Builder stage - compile all services with musl for Alpine compatibility
 FROM rust:1.97-alpine AS builder-source
 
@@ -145,6 +162,8 @@ ENTRYPOINT ["/usr/local/bin/signaldb-acceptor"]
 FROM runtime-base AS router
 
 COPY --from=builder /build/target/release/signaldb-router /usr/local/bin/signaldb-router
+COPY --from=ui-builder /build/src/ui/dist /usr/share/signaldb/ui
+ENV SIGNALDB_UI_DIR=/usr/share/signaldb/ui
 
 USER signaldb
 EXPOSE 50053 3001
@@ -180,6 +199,8 @@ ENTRYPOINT ["/usr/local/bin/signaldb-compactor"]
 FROM runtime-base AS monolithic
 
 COPY --from=builder /build/target/release/signaldb /usr/local/bin/signaldb
+COPY --from=ui-builder /build/src/ui/dist /usr/share/signaldb/ui
+ENV SIGNALDB_UI_DIR=/usr/share/signaldb/ui
 
 USER signaldb
 EXPOSE 4317 4318 50051 50053 3000

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -194,6 +194,10 @@ flowchart LR
 | **Capability** | `Routing`                                                                           |
 | **APIs**       | Tempo-compatible, Pyroscope-compatible, Loki-compatible (stubs), Admin API, OpenAPI |
 
+The router also serves the explore UI (a static SPA built from `src/ui`)
+under `/ui`, from the directory named by `SIGNALDB_UI_DIR`. See
+[the explore UI guide](../users/explore-ui.md).
+
 **Tempo API Endpoints**:
 
 | Endpoint                                         | Status                                                                                     |

--- a/docs/operations/dokku.md
+++ b/docs/operations/dokku.md
@@ -56,13 +56,13 @@ git push dokku main
 
 ## Ports
 
-| Port | Protocol | Service |
-|------|----------|---------|
-| 4317 | gRPC | OTLP gRPC ingestion |
-| 4318 | HTTP | OTLP HTTP ingestion |
-| 50051 | gRPC | Writer Flight |
-| 50053 | gRPC | Router Flight |
-| 3000 | HTTP | Tempo-compatible HTTP API |
+| Port  | Protocol | Service                                          |
+| ----- | -------- | ------------------------------------------------ |
+| 4317  | gRPC     | OTLP gRPC ingestion                              |
+| 4318  | HTTP     | OTLP HTTP ingestion                              |
+| 50051 | gRPC     | Writer Flight                                    |
+| 50053 | gRPC     | Router Flight                                    |
+| 3000  | HTTP     | Tempo-compatible HTTP API and explore UI (`/ui`) |
 
 ## Health checks
 

--- a/docs/users/explore-ui.md
+++ b/docs/users/explore-ui.md
@@ -1,0 +1,48 @@
+---
+audience: user
+type: how-to
+status: living
+sources:
+  - src/ui/**
+  - src/router/src/ui.rs
+---
+
+# Explore UI
+
+SignalDB ships a built-in explore UI for logs, traces, and metrics, served
+by the router at `http://<router>:3000/ui/`. It consumes the same
+Loki-, Tempo-, and Prometheus-compatible APIs that Grafana uses, so anything
+visible in the UI is equally queryable from Grafana.
+
+## What it does
+
+- **Logs** — filter chips compiled to LogQL (with an "edit as text" escape
+  hatch), a per-level volume histogram, a virtualized log list with
+  per-attribute filter/exclude actions, a fields sidebar, and live tail.
+- **Traces** — recent-trace search and open-by-ID, a waterfall with span
+  details, and error highlighting.
+- **Metrics** — a PromQL box charting range queries.
+- **Correlation** — log rows with a `trace_id` open the trace waterfall;
+  the span panel links back to logs filtered by that trace.
+- Every view is a URL: time range, filters, and selection live in query
+  parameters, so views can be bookmarked and shared.
+
+## Availability
+
+Container images (router and monolithic) ship the UI preinstalled. For
+source builds, the router serves the directory named by `SIGNALDB_UI_DIR`:
+
+```bash
+pnpm install && pnpm ui:build          # builds src/ui/dist
+SIGNALDB_UI_DIR=src/ui/dist cargo run --bin signaldb
+```
+
+Without `SIGNALDB_UI_DIR`, `/ui` serves a placeholder page. Setting the
+variable to a directory without a built UI fails startup on purpose — a
+misconfigured deployment should not silently ship without its UI.
+
+## Developing the UI
+
+See [src/ui/README.md](../../src/ui/README.md): `pnpm ui:dev` runs a Vite
+dev server with hot reload that proxies API calls to any live SignalDB
+instance (local or remote) with credentials injected from `.env.local`.

--- a/docs/users/tempo-api-reference.md
+++ b/docs/users/tempo-api-reference.md
@@ -15,30 +15,39 @@ authentication headers described in [Authentication](authentication.md)
 
 ## Endpoints
 
-| Method | Path (under `/tempo`) | Status | Notes |
-|---|---|---|---|
-| GET | `/api/echo` | implemented | Returns `echo`; still requires auth headers |
-| GET | `/api/traces/{trace_id}` | implemented | Trace by ID; optional `start`/`end` (unix seconds) prune the scanned time range — pass a window bracketing the whole trace |
-| GET | `/api/v2/traces/{trace_id}` | implemented | Same handler as v1 |
-| GET | `/api/search` | implemented | Trace search, executed by the querier; `spss` caps spans per span set (`matched` still reports the full count; omitted = all spans) |
-| GET | `/api/search/tags` | implemented | Static list of searchable tags: `service.name`, `name`, `status` |
-| GET | `/api/v2/search/tags` | implemented | Same tags, grouped into `resource` and `intrinsic` scopes |
-| GET | `/api/search/tag/{tag}/values` | partial | Real distinct values for `service.name` and `name` (also `resource.`/`span.`-scoped forms); static `ok`/`error`/`unset` for `status`; **501** for any other tag |
-| GET | `/api/v2/search/tag/{tag}/values` | partial | Same behavior as v1, v2 response shape |
-| GET | `/api/metrics/query` | **501** | TraceQL metrics not implemented |
-| GET | `/api/metrics/query_range` | **501** | TraceQL metrics not implemented |
+| Method | Path (under `/tempo`)             | Status      | Notes                                                                                                                                                           |
+| ------ | --------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/echo`                       | implemented | Returns `echo`; still requires auth headers                                                                                                                     |
+| GET    | `/api/traces/{trace_id}`          | implemented | Trace by ID; optional `start`/`end` (unix seconds) prune the scanned time range — pass a window bracketing the whole trace                                      |
+| GET    | `/api/v2/traces/{trace_id}`       | implemented | Same handler as v1                                                                                                                                              |
+| GET    | `/api/search`                     | implemented | Trace search, executed by the querier; `spss` caps spans per span set (`matched` still reports the full count; omitted = all spans)                             |
+| GET    | `/api/search/tags`                | implemented | Static list of searchable tags: `service.name`, `name`, `status`                                                                                                |
+| GET    | `/api/v2/search/tags`             | implemented | Same tags, grouped into `resource` and `intrinsic` scopes                                                                                                       |
+| GET    | `/api/search/tag/{tag}/values`    | partial     | Real distinct values for `service.name` and `name` (also `resource.`/`span.`-scoped forms); static `ok`/`error`/`unset` for `status`; **501** for any other tag |
+| GET    | `/api/v2/search/tag/{tag}/values` | partial     | Same behavior as v1, v2 response shape                                                                                                                          |
+| GET    | `/api/metrics/query`              | **501**     | TraceQL metrics not implemented                                                                                                                                 |
+| GET    | `/api/metrics/query_range`        | **501**     | TraceQL metrics not implemented                                                                                                                                 |
+
+## Span fields beyond Tempo's
+
+Spanset spans in trace and search responses carry four optional fields in
+addition to Tempo's `spanID`/`startTimeUnixNano`/`durationNanos`/
+`attributes`: `name`, `parentSpanID`, `serviceName`, and `status`
+(`ok`/`error`/`unset`). They are omitted when unknown, so Tempo-compatible
+clients are unaffected; SignalDB's own explore UI uses them to rebuild the
+span hierarchy for its waterfall view.
 
 ## Error mapping
 
-| HTTP status | Meaning |
-|---|---|
-| 400 | Invalid search parameters (missing/invalid headers also yield 400 from auth) |
-| 401 / 403 | Authentication or authorization failure |
-| 404 | Trace not found |
-| 429 | Per-tenant query rate limit exceeded |
-| 501 | Feature not implemented (TraceQL metrics, unindexed tag values) |
-| 503 | No querier service available |
-| 504 | Query deadline exceeded |
+| HTTP status | Meaning                                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
+| 400         | Invalid search parameters (missing/invalid headers also yield 400 from auth) |
+| 401 / 403   | Authentication or authorization failure                                      |
+| 404         | Trace not found                                                              |
+| 429         | Per-tenant query rate limit exceeded                                         |
+| 501         | Feature not implemented (TraceQL metrics, unindexed tag values)              |
+| 503         | No querier service available                                                 |
+| 504         | Query deadline exceeded                                                      |
 
 ## Tempo gRPC querier protocol
 
@@ -56,7 +65,7 @@ can use SignalDB as a querier backend:
   a trusted network for Tempo interop.
 - `SearchBlock` returns `Unimplemented` (SignalDB stores data in Iceberg
   tables, not Tempo blocks). Tag endpoints advertise the same static tag
-  set as the HTTP API; tag *value* enumeration is HTTP-only.
+  set as the HTTP API; tag _value_ enumeration is HTTP-only.
 
 ## Related
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "grafana:dev": "pnpm --filter signaldb-datasource dev",
     "grafana:build": "pnpm --filter signaldb-datasource build",
-    "grafana:test": "pnpm --filter signaldb-datasource test:ci"
+    "grafana:test": "pnpm --filter signaldb-datasource test:ci",
+    "ui:dev": "pnpm --filter signaldb-ui dev",
+    "ui:build": "pnpm --filter signaldb-ui build",
+    "ui:test": "pnpm --filter signaldb-ui test"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,10 +67,10 @@ importers:
         version: 0.2.39(@swc/core@1.15.46(@swc/helpers@0.5.23))
       '@testing-library/jest-dom':
         specifier: 7.0.0
-        version: 7.0.0(@testing-library/dom@9.3.4)
+        version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: 16.3.2
-        version: 16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -177,6 +177,70 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
 
+  src/ui:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.101.4(react@19.2.8)
+      '@tanstack/react-virtual':
+        specifier: ^3.11.0
+        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.8(react@19.2.8)
+      uplot:
+        specifier: ^1.6.31
+        version: 1.6.32
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.39.5
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.10.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.0.0
+        version: 3.2.7(vitest@3.2.7(@types/node@26.1.1)(jsdom@26.1.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))
+      eslint:
+        specifier: ^9.17.0
+        version: 9.39.5
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      typescript:
+        specifier: ~5.7.2
+        version: 5.7.3
+      typescript-eslint:
+        specifier: ^8.18.0
+        version: 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/node@26.1.1)(jsdom@26.1.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+
 packages:
 
   '@adobe/css-tools@4.5.0':
@@ -199,6 +263,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -358,6 +426,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -379,6 +459,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@braintree/sanitize-url@7.0.1':
     resolution: {integrity: sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==}
@@ -518,6 +602,162 @@ packages:
   '@es-joy/resolve.exports@1.2.0':
     resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
     engines: {node: '>=10'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -1246,6 +1486,134 @@ packages:
     resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    resolution: {integrity: sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.3':
+    resolution: {integrity: sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    resolution: {integrity: sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.3':
+    resolution: {integrity: sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    resolution: {integrity: sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    resolution: {integrity: sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    resolution: {integrity: sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    resolution: {integrity: sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    resolution: {integrity: sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    resolution: {integrity: sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==}
+    cpu: [x64]
+    os: [win32]
+
   '@sinclair/typebox@0.34.52':
     resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
@@ -1381,6 +1749,14 @@ packages:
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tanstack/react-virtual@3.14.8':
     resolution: {integrity: sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==}
     peerDependencies:
@@ -1390,9 +1766,16 @@ packages:
   '@tanstack/virtual-core@3.17.6':
     resolution: {integrity: sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==}
 
-  '@testing-library/dom@9.3.4':
-    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
-    engines: {node: '>=14'}
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.10.0':
+    resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
 
   '@testing-library/jest-dom@7.0.0':
     resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
@@ -1414,6 +1797,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -1445,11 +1834,17 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -1740,6 +2135,50 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1887,8 +2326,8 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
-  aria-query@5.1.3:
-    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1921,6 +2360,13 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2013,6 +2459,10 @@ packages:
   bytes@1.0.0:
     resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   calculate-size@1.1.1:
     resolution: {integrity: sha512-jJZ7pvbQVM/Ss3VO789qpsypN3xmnepg242cejOAslsmlZLYw2dnj7knnNowabQ0Kzabzx56KFTy2Pot/y6FmA==}
 
@@ -2043,6 +2493,10 @@ packages:
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2050,6 +2504,10 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2262,9 +2720,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deep-equal@2.2.3:
-    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
-    engines: {node: '>= 0.4'}
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2280,6 +2738,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2382,12 +2844,12 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
-
   es-iterator-helpers@1.4.0:
     resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -2407,6 +2869,11 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2514,6 +2981,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2532,6 +3002,10 @@ packages:
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
@@ -2898,10 +3372,6 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -3233,8 +3703,14 @@ packages:
   js-cookie@3.0.8:
     resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
@@ -3334,6 +3810,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3347,6 +3826,12 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3549,10 +4034,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -3669,6 +4150,13 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pbf@4.0.1:
     resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
@@ -3927,6 +4415,10 @@ packages:
       redux:
         optional: true
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-router-dom-v5-compat@6.30.4:
     resolution: {integrity: sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==}
     engines: {node: '>=14.0.0'}
@@ -4069,6 +4561,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rollup@4.62.3:
+    resolution: {integrity: sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -4201,6 +4698,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4296,6 +4796,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -4307,6 +4810,9 @@ packages:
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4379,6 +4885,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-loader@4.0.0:
     resolution: {integrity: sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==}
@@ -4479,6 +4988,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
@@ -4495,12 +5008,30 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -4600,6 +5131,18 @@ packages:
   typed-assert@1.0.9:
     resolution: {integrity: sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==}
 
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4669,6 +5212,79 @@ packages:
 
   value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
@@ -4803,6 +5419,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
@@ -4926,6 +5547,11 @@ snapshots:
       react-stately: 3.48.0(react@19.2.8)
       react-transition-group: 4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -5105,6 +5731,16 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
 
   '@babel/runtime@8.0.0': {}
@@ -5133,6 +5769,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@braintree/sanitize-url@7.0.1': {}
 
@@ -5346,6 +5984,84 @@ snapshots:
       jsdoc-type-pratt-parser: 7.3.0
 
   '@es-joy/resolve.exports@1.2.0': {}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
     dependencies:
@@ -6420,6 +7136,83 @@ snapshots:
 
   '@remix-run/router@1.23.3': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    optional: true
+
   '@sinclair/typebox@0.34.52': {}
 
   '@sindresorhus/base62@1.0.0': {}
@@ -6541,6 +7334,13 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.8
+
   '@tanstack/react-virtual@3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.6
@@ -6549,36 +7349,50 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.6': {}
 
-  '@testing-library/dom@9.3.4':
+  '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
-      aria-query: 5.1.3
-      chalk: 4.1.2
+      aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
+      picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@7.0.0(@testing-library/dom@9.3.4)':
+  '@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1)':
     dependencies:
       '@adobe/css-tools': 4.5.0
-      '@testing-library/dom': 9.3.4
+      '@testing-library/dom': 10.4.1
       aria-query: 5.3.2
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@9.3.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@testing-library/dom': 9.3.4
+      '@testing-library/dom': 10.4.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -6616,11 +7430,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -6705,6 +7526,22 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.7.3))(eslint@9.39.5)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 9.39.5
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -6721,6 +7558,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      eslint: 9.39.5
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
@@ -6730,6 +7579,15 @@ snapshots:
       debug: 4.4.3
       eslint: 9.39.5
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.65.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6747,9 +7605,25 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
+
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      debug: 4.4.3
+      eslint: 9.39.5
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
@@ -6765,6 +7639,21 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
@@ -6777,6 +7666,17 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@9.39.5)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.7.3)
+      eslint: 9.39.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6908,6 +7808,79 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@26.1.1)(jsdom@26.1.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@26.1.1)(jsdom@26.1.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -7069,9 +8042,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  aria-query@5.1.3:
+  aria-query@5.3.0:
     dependencies:
-      deep-equal: 2.2.3
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7131,6 +8104,14 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -7249,6 +8230,8 @@ snapshots:
 
   bytes@1.0.0: {}
 
+  cac@6.7.14: {}
+
   calculate-size@1.1.1: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -7276,12 +8259,22 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   char-regex@1.0.2: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -7480,26 +8473,7 @@ snapshots:
     optionalDependencies:
       babel-plugin-macros: 3.1.0
 
-  deep-equal@2.2.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.9
-      es-get-iterator: 1.1.3
-      get-intrinsic: 1.3.0
-      is-arguments: 1.2.0
-      is-array-buffer: 3.0.5
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.4
-      isarray: 2.0.5
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      regexp.prototype.flags: 1.5.4
-      side-channel: 1.1.1
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.22
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -7516,6 +8490,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2:
     optional: true
@@ -7665,18 +8641,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-get-iterator@1.1.3:
-    dependencies:
-      call-bind: 1.0.9
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      is-arguments: 1.2.0
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
-
   es-iterator-helpers@1.4.0:
     dependencies:
       call-bind: 1.0.9
@@ -7695,6 +8659,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -7721,6 +8687,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -7877,6 +8872,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
@@ -7896,6 +8895,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit-x@0.2.2: {}
+
+  expect-type@1.4.0: {}
 
   expect@30.4.1:
     dependencies:
@@ -8283,11 +9284,6 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
-
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -8813,7 +9809,11 @@ snapshots:
 
   js-cookie@3.0.8: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.15.0:
     dependencies:
@@ -8917,6 +9917,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
@@ -8926,6 +9928,16 @@ snapshots:
       yallist: 3.1.1
 
   lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
@@ -9064,11 +10076,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
@@ -9203,6 +10210,10 @@ snapshots:
       isarray: 0.0.1
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pbf@4.0.1:
     dependencies:
@@ -9447,6 +10458,8 @@ snapshots:
       '@types/react': 19.2.17
       redux: 5.0.1
 
+  react-refresh@0.17.0: {}
+
   react-router-dom-v5-compat@6.30.4(react-dom@19.2.8(react@19.2.8))(react-router-dom@5.3.4(react@19.2.8))(react@19.2.8):
     dependencies:
       '@remix-run/router': 1.23.3
@@ -9633,6 +10646,37 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rollup@4.62.3:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.3
+      '@rollup/rollup-android-arm64': 4.62.3
+      '@rollup/rollup-darwin-arm64': 4.62.3
+      '@rollup/rollup-darwin-x64': 4.62.3
+      '@rollup/rollup-freebsd-arm64': 4.62.3
+      '@rollup/rollup-freebsd-x64': 4.62.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.3
+      '@rollup/rollup-linux-arm64-gnu': 4.62.3
+      '@rollup/rollup-linux-arm64-musl': 4.62.3
+      '@rollup/rollup-linux-loong64-gnu': 4.62.3
+      '@rollup/rollup-linux-loong64-musl': 4.62.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.3
+      '@rollup/rollup-linux-ppc64-musl': 4.62.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.3
+      '@rollup/rollup-linux-riscv64-musl': 4.62.3
+      '@rollup/rollup-linux-s390x-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-musl': 4.62.3
+      '@rollup/rollup-openbsd-x64': 4.62.3
+      '@rollup/rollup-openharmony-arm64': 4.62.3
+      '@rollup/rollup-win32-arm64-msvc': 4.62.3
+      '@rollup/rollup-win32-ia32-msvc': 4.62.3
+      '@rollup/rollup-win32-x64-gnu': 4.62.3
+      '@rollup/rollup-win32-x64-msvc': 4.62.3
+      fsevents: 2.3.3
+
   rrweb-cssom@0.8.0: {}
 
   rtl-css-js@1.16.1:
@@ -9772,6 +10816,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9884,6 +10930,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-gps@3.1.2:
@@ -9898,6 +10946,8 @@ snapshots:
       stacktrace-gps: 3.1.2
 
   state-local@1.0.7: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9992,6 +11042,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-loader@4.0.0(webpack@5.109.0):
     dependencies:
       webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.23)(webpack-cli@7.2.1)
@@ -10052,6 +11106,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
+
   throttle-debounce@3.0.1: {}
 
   tiny-invariant@1.3.3: {}
@@ -10071,12 +11131,22 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -10114,6 +11184,10 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  ts-api-utils@2.5.0(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -10187,6 +11261,19 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typed-assert@1.0.9: {}
+
+  typescript-eslint@8.65.0(eslint@9.39.5)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.7.3))(eslint@9.39.5)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@5.7.3)
+      eslint: 9.39.5
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.7.3: {}
 
   typescript@5.9.3: {}
 
@@ -10267,6 +11354,84 @@ snapshots:
       convert-source-map: 2.0.0
 
   value-equal@1.0.1: {}
+
+  vite-node@3.2.4(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rollup: 4.62.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
+      fsevents: 2.3.3
+      sass: 1.101.3
+      terser: 5.49.0
+      yaml: 2.9.0
+
+  vitest@3.2.7(@types/node@26.1.1)(jsdom@26.1.0)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.1.1)(sass@1.101.3)(terser@5.49.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   void-elements@3.1.0: {}
 
@@ -10435,6 +11600,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wildcard@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'src/grafana-plugin'
+  - 'src/ui'

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -27,6 +27,7 @@ chrono.workspace = true
 
 log.workspace = true
 anyhow.workspace = true
+tower-http = { workspace = true, features = ["fs"] }
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -38,6 +39,7 @@ path = "src/main.rs"
 [dev-dependencies]
 tokio-test.workspace = true
 tower.workspace = true
+tempfile.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["tokio-test"]

--- a/src/router/src/endpoints/tempo.rs
+++ b/src/router/src/endpoints/tempo.rs
@@ -336,6 +336,21 @@ fn internal_trace_to_tempo(
                 span_id: span.span_id.clone(),
                 start_time_unix_nano: span.start_time_unix_nano.to_string(),
                 duration_nanos: span.duration_nano.to_string(),
+                name: Some(span.name.clone()),
+                parent_span_id: if span.parent_span_id.is_empty() {
+                    None
+                } else {
+                    Some(span.parent_span_id.clone())
+                },
+                service_name: Some(span.service_name.clone()),
+                status: Some(
+                    match span.status {
+                        common::model::span::SpanStatus::Ok => "ok",
+                        common::model::span::SpanStatus::Error => "error",
+                        common::model::span::SpanStatus::Unspecified => "unset",
+                    }
+                    .to_string(),
+                ),
                 attributes,
             }
         })

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 pub mod discovery;
 pub mod endpoints;
+pub mod ui;
 
 pub trait RouterState: std::fmt::Debug + Clone + Send + Sync + 'static {
     fn catalog(&self) -> &Catalog;
@@ -229,6 +230,8 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // Explore UI static assets (public, served from SIGNALDB_UI_DIR)
+        .nest_service("/ui", ui::service_from_env())
         // Admin routes with admin authentication
         .nest("/api/v1/admin", admin_router)
         .nest(

--- a/src/router/src/ui.rs
+++ b/src/router/src/ui.rs
@@ -1,0 +1,147 @@
+//! # Explore UI serving
+//!
+//! Serves the built SignalDB UI (a static SPA from `src/ui`) under `/ui`.
+//! The asset directory is provided at runtime via `SIGNALDB_UI_DIR` so cargo
+//! builds never depend on a Node toolchain; container images copy the built
+//! assets in and set the variable. An unset variable serves a short
+//! placeholder page; a set-but-invalid directory fails startup so a broken
+//! deployment cannot silently ship without its UI.
+
+use axum::Router;
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse};
+use std::path::{Path, PathBuf};
+use tower_http::services::{ServeDir, ServeFile};
+
+const UI_DIR_ENV: &str = "SIGNALDB_UI_DIR";
+
+/// Build the `/ui` service from the `SIGNALDB_UI_DIR` environment variable.
+///
+/// # Panics
+///
+/// Panics at startup when the variable is set but the directory does not
+/// contain a built UI (`index.html`). Misconfiguration must fail loudly
+/// instead of degrading to the placeholder page.
+pub fn service_from_env() -> Router {
+    let dir = std::env::var(UI_DIR_ENV).ok().map(PathBuf::from);
+    service_with_dir(dir).unwrap_or_else(|e| panic!("{e}"))
+}
+
+/// Build the `/ui` service for an explicit asset directory.
+///
+/// `None` serves the placeholder page (UI explicitly not bundled). A
+/// directory without an `index.html` is a configuration error.
+pub fn service_with_dir(dir: Option<PathBuf>) -> anyhow::Result<Router> {
+    match dir {
+        Some(dir) if has_ui_assets(&dir) => {
+            tracing::info!(dir = %dir.display(), "Serving explore UI");
+            let index = ServeFile::new(dir.join("index.html"));
+            // Unknown paths fall back to index.html so SPA deep links work.
+            Ok(Router::new().fallback_service(ServeDir::new(&dir).fallback(index)))
+        }
+        Some(dir) => anyhow::bail!(
+            "{UI_DIR_ENV} is set to {} but the directory contains no index.html; \
+             build the UI first (pnpm ui:build) or unset {UI_DIR_ENV}",
+            dir.display()
+        ),
+        None => Ok(Router::new().fallback(placeholder)),
+    }
+}
+
+async fn placeholder() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Html(
+            "<!doctype html><title>SignalDB UI</title>\
+             <body style=\"font-family:system-ui;max-width:38rem;margin:4rem auto\">\
+             <h1>UI not bundled</h1>\
+             <p>This SignalDB build has no explore UI assets. Build them with\
+             <code>pnpm ui:build</code> and point <code>SIGNALDB_UI_DIR</code>\
+             at <code>src/ui/dist</code>, or use the container image, which\
+             ships them preinstalled.</p></body>",
+        ),
+    )
+}
+
+/// True when `dir` looks like a built UI bundle (used by callers for logs).
+pub fn has_ui_assets(dir: &Path) -> bool {
+    dir.join("index.html").is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    async fn body_string(res: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        String::from_utf8_lossy(&bytes).to_string()
+    }
+
+    fn ui_fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("index.html"), "<html>ui-index</html>")
+            .expect("write index");
+        std::fs::create_dir(dir.path().join("assets")).expect("mkdir assets");
+        std::fs::write(dir.path().join("assets/app.js"), "console.log(1)").expect("write asset");
+        dir
+    }
+
+    async fn get(router: Router, path: &str) -> axum::response::Response {
+        router
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn serves_index_and_assets_from_dir() {
+        let dir = ui_fixture();
+        let router = service_with_dir(Some(dir.path().to_path_buf())).expect("valid dir");
+
+        let res = get(router.clone(), "/").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(body_string(res).await.contains("ui-index"));
+
+        let res = get(router, "/assets/app.js").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(body_string(res).await.contains("console.log"));
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_index_for_unknown_paths() {
+        let dir = ui_fixture();
+        let router = service_with_dir(Some(dir.path().to_path_buf())).expect("valid dir");
+        let res = get(router, "/some/deep/link").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(body_string(res).await.contains("ui-index"));
+    }
+
+    #[tokio::test]
+    async fn placeholder_without_assets() {
+        let router = service_with_dir(None).expect("no dir is valid");
+        let res = get(router, "/").await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        assert!(body_string(res).await.contains("UI not bundled"));
+    }
+
+    #[test]
+    fn configured_dir_without_index_is_an_error() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let err = service_with_dir(Some(empty.path().to_path_buf()))
+            .expect_err("missing index.html must fail");
+        assert!(err.to_string().contains("index.html"));
+    }
+
+    #[test]
+    fn has_ui_assets_checks_for_index() {
+        let dir = ui_fixture();
+        assert!(has_ui_assets(dir.path()));
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert!(!has_ui_assets(empty.path()));
+    }
+}

--- a/src/tempo-api/src/lib.rs
+++ b/src/tempo-api/src/lib.rs
@@ -197,6 +197,26 @@ pub struct Span {
     pub start_time_unix_nano: String,
     #[serde(rename = "durationNanos")]
     pub duration_nanos: String,
+    /// Span name intrinsic (Tempo exposes it as `name` on spanset spans).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Parent span id; empty/absent for root spans. Needed by clients that
+    /// reconstruct the span hierarchy (e.g. waterfall views).
+    #[serde(
+        rename = "parentSpanID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_span_id: Option<String>,
+    #[serde(
+        rename = "serviceName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_name: Option<String>,
+    /// Span status (`ok`, `error`, `unset`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     pub attributes: HashMap<String, Attribute>,
 }
 
@@ -278,6 +298,10 @@ mod tests {
                     span_id: "563d623c76514f8e".to_string(),
                     start_time_unix_nano: "1684778327735077898".to_string(),
                     duration_nanos: "446979497".to_string(),
+                    name: None,
+                    parent_span_id: None,
+                    service_name: None,
+                    status: None,
                     attributes: vec![Attribute {
                         key: "status".to_string(),
                         value: Value::StringValue("error".to_string()),
@@ -312,6 +336,10 @@ mod tests {
                     span_id: "563d623c76514f8e".to_string(),
                     start_time_unix_nano: "1684778327735077898".to_string(),
                     duration_nanos: "446979497".to_string(),
+                    name: None,
+                    parent_span_id: None,
+                    service_name: None,
+                    status: None,
                     attributes: vec![Attribute {
                         key: "status".to_string(),
                         value: Value::StringValue("error".to_string()),
@@ -340,6 +368,10 @@ mod tests {
                 span_id: "563d623c76514f8e".to_string(),
                 start_time_unix_nano: "1684778327735077898".to_string(),
                 duration_nanos: "446979497".to_string(),
+                name: None,
+                parent_span_id: None,
+                service_name: None,
+                status: None,
                 attributes: vec![Attribute {
                     key: "status".to_string(),
                     value: Value::StringValue("error".to_string()),
@@ -361,6 +393,10 @@ mod tests {
             span_id: "563d623c76514f8e".to_string(),
             start_time_unix_nano: "1684778327735077898".to_string(),
             duration_nanos: "446979497".to_string(),
+            name: None,
+            parent_span_id: None,
+            service_name: None,
+            status: None,
             attributes: vec![Attribute {
                 key: "status".to_string(),
                 value: Value::StringValue("error".to_string()),

--- a/src/ui/.env.example
+++ b/src/ui/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env.local (gitignored). The Vite dev server proxies /loki, /tempo,
+# /prometheus, and /api to SIGNALDB_TARGET and injects the auth headers below,
+# so you can point development at any live SignalDB instance without CORS
+# changes and without API keys reaching browser code.
+
+# Local: ./scripts/run-dev.sh (router on :3000). Or a remote instance.
+SIGNALDB_TARGET=http://localhost:3000
+SIGNALDB_API_KEY=
+SIGNALDB_TENANT=default
+# Optional; omit to use the tenant's default dataset.
+#SIGNALDB_DATASET=production

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,0 +1,29 @@
+# SignalDB UI
+
+Native explore UI for SignalDB: logs, traces, and metrics against the
+router's query APIs. Ships embedded in the router binary at `/ui/`.
+
+## Development
+
+```bash
+cp src/ui/.env.example src/ui/.env.local   # set target + credentials
+pnpm install
+pnpm ui:dev                                # http://localhost:5173/ui/
+```
+
+The dev server hot-reloads and proxies all API paths (`/loki`, `/tempo`,
+`/prometheus`, `/api`) to `SIGNALDB_TARGET` — a local `./scripts/run-dev.sh`
+instance or any live deployment. Auth headers are injected by the proxy from
+`.env.local`, so browser code is identical to the embedded production build
+and API keys never reach the client.
+
+## Commands
+
+```bash
+pnpm ui:dev        # dev server with HMR
+pnpm ui:build      # typecheck + production build to src/ui/dist
+pnpm ui:test       # vitest, single run
+pnpm --filter signaldb-ui test:watch
+pnpm --filter signaldb-ui test:coverage
+pnpm --filter signaldb-ui lint
+```

--- a/src/ui/eslint.config.js
+++ b/src/ui/eslint.config.js
@@ -1,0 +1,15 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+);

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
     <title>SignalDB</title>
   </head>
   <body>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>SignalDB</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "signaldb-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-virtual": "^3.11.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "uplot": "^1.6.31"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^3.0.0",
+    "eslint": "^9.17.0",
+    "jsdom": "^26.0.0",
+    "typescript": "~5.7.2",
+    "typescript-eslint": "^8.18.0",
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/src/ui/public/favicon.svg
+++ b/src/ui/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+  <rect width="18" height="18" rx="4" fill="#14181e"/>
+  <path d="M2 9 L5 9 L7 4 L10 14 L13 6 L14.5 9 L16 9" stroke="#f58a3c" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -35,12 +35,11 @@ describe("App", () => {
     stubFetchRoutes([
       { match: "query_range", body: emptyMatrix },
       { match: "/labels?", body: emptyLabels },
+      { match: "/tempo/api/search", body: { traces: [], metrics: {} } },
     ]);
     renderWithClient(<App />);
     screen.getByRole("tab", { name: "Traces" }).click();
-    expect(
-      await screen.findByText(/Trace view lands in phase 2/),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Trace ID")).toBeInTheDocument();
     expect(window.location.search).toContain("signal=traces");
   });
 });

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -1,10 +1,46 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
+import {
+  emptyLabels,
+  emptyMatrix,
+  emptyStreams,
+  renderWithClient,
+  stubFetchRoutes,
+} from "./test/render";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.replaceState(null, "", "/");
+});
 
 describe("App", () => {
-  it("renders the shell with the product mark", () => {
-    render(<App />);
+  it("renders the shell with the product mark and explore tabs", async () => {
+    stubFetchRoutes([
+      { match: "query_range", body: emptyStreams },
+      { match: "/labels?", body: emptyLabels },
+    ]);
+    renderWithClient(<App />);
     expect(screen.getByRole("banner")).toHaveTextContent(/signaldb/i);
+    expect(screen.getByRole("tab", { name: "Logs" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      await screen.findByText(/No log lines match this query/),
+    ).toBeInTheDocument();
+  });
+
+  it("switches signals via tabs", async () => {
+    stubFetchRoutes([
+      { match: "query_range", body: emptyMatrix },
+      { match: "/labels?", body: emptyLabels },
+    ]);
+    renderWithClient(<App />);
+    screen.getByRole("tab", { name: "Traces" }).click();
+    expect(
+      await screen.findByText(/Trace view lands in phase 2/),
+    ).toBeInTheDocument();
+    expect(window.location.search).toContain("signal=traces");
   });
 });

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { App } from "./App";
+
+describe("App", () => {
+  it("renders the shell with the product mark", () => {
+    render(<App />);
+    expect(screen.getByRole("banner")).toHaveTextContent(/signaldb/i);
+  });
+});

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -31,6 +31,28 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  it("changes the tenant context from the top bar", async () => {
+    stubFetchRoutes([
+      { match: "query_range", body: emptyStreams },
+      { match: "/labels?", body: emptyLabels },
+    ]);
+    renderWithClient(<App />);
+    const user = (await import("@testing-library/user-event")).default;
+    await user.click(
+      screen.getByTitle("Tenant / dataset context for all queries"),
+    );
+    await user.clear(screen.getByLabelText("Tenant"));
+    await user.type(screen.getByLabelText("Tenant"), "acme");
+    await user.clear(screen.getByLabelText("Dataset"));
+    await user.type(screen.getByLabelText("Dataset"), "prod");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+    expect(window.location.search).toContain("tenant=acme");
+    expect(window.location.search).toContain("dataset=prod");
+    expect(screen.getByRole("button", { name: /acme/ })).toHaveTextContent(
+      "acme·prod",
+    );
+  });
+
   it("switches signals via tabs", async () => {
     stubFetchRoutes([
       { match: "query_range", body: emptyMatrix },

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { ExploreView } from "./features/explore/ExploreView";
 import { TopBar } from "./features/shell/TopBar";
 
 export function App() {
@@ -5,9 +6,7 @@ export function App() {
     <div className="app-frame">
       <TopBar />
       <main className="app-main">
-        <p className="placeholder">
-          Explore is under construction — logs, traces, and metrics land here.
-        </p>
+        <ExploreView />
       </main>
     </div>
   );

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,12 +1,18 @@
+import { setTenantContext } from "./api/http";
 import { ExploreView } from "./features/explore/ExploreView";
 import { TopBar } from "./features/shell/TopBar";
+import { useExploreState } from "./lib/urlState";
 
 export function App() {
+  const [state, update] = useExploreState();
+  // Keep the API clients' tenant headers in sync with the URL state.
+  setTenantContext({ tenant: state.tenant, dataset: state.dataset });
+
   return (
     <div className="app-frame">
-      <TopBar />
+      <TopBar state={state} update={update} />
       <main className="app-main">
-        <ExploreView />
+        <ExploreView state={state} update={update} />
       </main>
     </div>
   );

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,0 +1,14 @@
+import { TopBar } from "./features/shell/TopBar";
+
+export function App() {
+  return (
+    <div className="app-frame">
+      <TopBar />
+      <main className="app-main">
+        <p className="placeholder">
+          Explore is under construction — logs, traces, and metrics land here.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/ui/src/api/http.test.ts
+++ b/src/ui/src/api/http.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setTenantContext, tenantHeaders } from "./http";
+
+afterEach(() => {
+  setTenantContext({ tenant: "", dataset: "" });
+});
+
+describe("tenantHeaders", () => {
+  it("sends no tenant headers for the ambient default context", () => {
+    expect(tenantHeaders()).toEqual({ Accept: "application/json" });
+  });
+
+  it("sends tenant and dataset headers when set", () => {
+    setTenantContext({ tenant: "acme", dataset: "production" });
+    expect(tenantHeaders()).toEqual({
+      Accept: "application/json",
+      "X-Tenant-ID": "acme",
+      "X-Dataset-ID": "production",
+    });
+  });
+
+  it("omits the dataset header when only the tenant is set", () => {
+    setTenantContext({ tenant: "acme", dataset: "" });
+    expect(tenantHeaders()).toEqual({
+      Accept: "application/json",
+      "X-Tenant-ID": "acme",
+    });
+  });
+});

--- a/src/ui/src/api/http.ts
+++ b/src/ui/src/api/http.ts
@@ -1,0 +1,35 @@
+// Request-scoped tenant context. The explore state (URL) is the source of
+// truth; views sync it here so the API clients can attach the headers. In
+// dev, the Vite proxy fills in env defaults for requests without them.
+
+export interface TenantContext {
+  tenant: string;
+  dataset: string;
+}
+
+let current: TenantContext = { tenant: "", dataset: "" };
+
+export function setTenantContext(ctx: TenantContext): void {
+  current = ctx;
+}
+
+export function getTenantContext(): TenantContext {
+  return current;
+}
+
+export function tenantHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (current.tenant) headers["X-Tenant-ID"] = current.tenant;
+  if (current.dataset) headers["X-Dataset-ID"] = current.dataset;
+  return headers;
+}
+
+/** Build-time defaults injected by Vite from SIGNALDB_TENANT/_DATASET. */
+export const DEFAULT_TENANT: string =
+  typeof __SIGNALDB_DEFAULT_TENANT__ !== "undefined"
+    ? __SIGNALDB_DEFAULT_TENANT__
+    : "";
+export const DEFAULT_DATASET: string =
+  typeof __SIGNALDB_DEFAULT_DATASET__ !== "undefined"
+    ? __SIGNALDB_DEFAULT_DATASET__
+    : "";

--- a/src/ui/src/api/loki.test.ts
+++ b/src/ui/src/api/loki.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  lokiLabels,
+  lokiLabelValues,
+  lokiQueryHistogram,
+  lokiQueryLogs,
+} from "./loki";
+
+const RANGE = { fromMs: 1_000_000, toMs: 2_000_000 };
+
+function mockFetchOnce(body: unknown, status = 200) {
+  const fn = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("lokiQueryLogs", () => {
+  it("flattens streams and sorts rows newest-first", async () => {
+    mockFetchOnce({
+      status: "success",
+      data: {
+        resultType: "streams",
+        result: [
+          {
+            stream: { service_name: "checkout", level: "info" },
+            values: [["1000000000", "older line"]],
+          },
+          {
+            stream: { service_name: "payments", level: "error" },
+            values: [["3000000000", "newest line"]],
+          },
+        ],
+      },
+    });
+    const rows = await lokiQueryLogs("{}", RANGE, 100);
+    expect(rows.map((r) => r.line)).toEqual(["newest line", "older line"]);
+    expect(rows[0]?.labels).toEqual({
+      service_name: "payments",
+      level: "error",
+    });
+    expect(rows[0]?.tsMs).toBe(3000);
+  });
+
+  it("sends nanosecond bounds and backward direction", async () => {
+    const fn = mockFetchOnce({
+      status: "success",
+      data: { resultType: "streams", result: [] },
+    });
+    await lokiQueryLogs('{x="y"}', RANGE, 250);
+    const url = String(fn.mock.calls[0]?.[0]);
+    expect(url).toContain("/loki/api/v1/query_range?");
+    expect(url).toContain("start=1000000000000");
+    expect(url).toContain("end=2000000000000");
+    expect(url).toContain("direction=backward");
+    expect(url).toContain("limit=250");
+  });
+
+  it("throws a readable error on HTTP failure", async () => {
+    mockFetchOnce({ error: "parse error in query" }, 400);
+    await expect(lokiQueryLogs("{", RANGE, 10)).rejects.toThrow(
+      /query_range failed \(400\)/,
+    );
+  });
+
+  it("rejects matrix responses for a log query", async () => {
+    mockFetchOnce({
+      status: "success",
+      data: { resultType: "matrix", result: [] },
+    });
+    await expect(lokiQueryLogs("{}", RANGE, 10)).rejects.toThrow(
+      /resultType=matrix/,
+    );
+  });
+});
+
+describe("lokiQueryHistogram", () => {
+  it("maps matrix results to per-level series in milliseconds", async () => {
+    mockFetchOnce({
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [
+          {
+            metric: { level: "error" },
+            values: [
+              [1700, "3"],
+              [1760, "5"],
+            ],
+          },
+          { metric: {}, values: [[1700, "10"]] },
+        ],
+      },
+    });
+    const series = await lokiQueryHistogram("q", RANGE, "1m");
+    expect(series).toEqual([
+      {
+        level: "error",
+        points: [
+          [1_700_000, 3],
+          [1_760_000, 5],
+        ],
+      },
+      { level: "unknown", points: [[1_700_000, 10]] },
+    ]);
+  });
+});
+
+describe("label endpoints", () => {
+  it("fetches labels within the range", async () => {
+    const fn = mockFetchOnce({
+      status: "success",
+      data: ["level", "service_name"],
+    });
+    const labels = await lokiLabels(RANGE);
+    expect(labels).toEqual(["level", "service_name"]);
+    expect(String(fn.mock.calls[0]?.[0])).toContain("/loki/api/v1/labels?");
+  });
+
+  it("URL-encodes label names for the values endpoint", async () => {
+    const fn = mockFetchOnce({ status: "success", data: ["a"] });
+    await lokiLabelValues("weird/label", RANGE);
+    expect(String(fn.mock.calls[0]?.[0])).toContain(
+      "/loki/api/v1/label/weird%2Flabel/values?",
+    );
+  });
+
+  it("tolerates a missing data field", async () => {
+    mockFetchOnce({ status: "success" });
+    expect(await lokiLabels(RANGE)).toEqual([]);
+  });
+});

--- a/src/ui/src/api/loki.test.ts
+++ b/src/ui/src/api/loki.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setTenantContext } from "./http";
 import {
   lokiLabels,
   lokiLabelValues,
@@ -48,6 +49,24 @@ describe("lokiQueryLogs", () => {
       level: "error",
     });
     expect(rows[0]?.tsMs).toBe(3000);
+  });
+
+  it("attaches tenant headers from the current context", async () => {
+    const fn = mockFetchOnce({
+      status: "success",
+      data: { resultType: "streams", result: [] },
+    });
+    setTenantContext({ tenant: "acme", dataset: "prod" });
+    try {
+      await lokiQueryLogs("{}", RANGE, 10);
+    } finally {
+      setTenantContext({ tenant: "", dataset: "" });
+    }
+    const init = fn.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      "X-Tenant-ID": "acme",
+      "X-Dataset-ID": "prod",
+    });
   });
 
   it("sends nanosecond bounds and backward direction", async () => {

--- a/src/ui/src/api/loki.ts
+++ b/src/ui/src/api/loki.ts
@@ -3,6 +3,7 @@
 // attributes appear as stream labels.
 
 import { msToNanos, nanosToMs, type ResolvedRange } from "../lib/time";
+import { tenantHeaders } from "./http";
 
 export interface LogRow {
   tsNs: string;
@@ -34,7 +35,7 @@ interface LokiResponse<T> {
 
 async function lokiFetch<T>(path: string, params: URLSearchParams): Promise<T> {
   const res = await fetch(`/loki/api/v1/${path}?${params}`, {
-    headers: { Accept: "application/json" },
+    headers: tenantHeaders(),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/src/ui/src/api/loki.ts
+++ b/src/ui/src/api/loki.ts
@@ -1,0 +1,131 @@
+// Client for the router's Loki-compatible API (/loki/api/v1). SignalDB
+// materializes `severity_text` as Loki's `level` label; other materialized
+// attributes appear as stream labels.
+
+import { msToNanos, nanosToMs, type ResolvedRange } from "../lib/time";
+
+export interface LogRow {
+  tsNs: string;
+  tsMs: number;
+  line: string;
+  labels: Record<string, string>;
+}
+
+export interface HistogramSeries {
+  level: string;
+  /** [timestampMs, count] pairs, ascending. */
+  points: [number, number][];
+}
+
+interface LokiStreamResult {
+  stream: Record<string, string>;
+  values: [string, string][];
+}
+
+interface LokiMatrixResult {
+  metric: Record<string, string>;
+  values: [number, string][];
+}
+
+interface LokiResponse<T> {
+  status: string;
+  data: { resultType: string; result: T[] };
+}
+
+async function lokiFetch<T>(path: string, params: URLSearchParams): Promise<T> {
+  const res = await fetch(`/loki/api/v1/${path}?${params}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Loki API ${path} failed (${res.status}): ${body.slice(0, 300)}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export async function lokiQueryLogs(
+  query: string,
+  range: ResolvedRange,
+  limit: number,
+): Promise<LogRow[]> {
+  const params = new URLSearchParams({
+    query,
+    start: msToNanos(range.fromMs),
+    end: msToNanos(range.toMs),
+    limit: String(limit),
+    direction: "backward",
+  });
+  const res = await lokiFetch<LokiResponse<LokiStreamResult>>(
+    "query_range",
+    params,
+  );
+  if (res.data.resultType !== "streams") {
+    throw new Error(
+      `Expected a log query but got resultType=${res.data.resultType}`,
+    );
+  }
+  const rows: LogRow[] = [];
+  for (const stream of res.data.result) {
+    for (const [tsNs, line] of stream.values) {
+      rows.push({ tsNs, tsMs: nanosToMs(tsNs), line, labels: stream.stream });
+    }
+  }
+  // Streams arrive independently ordered; merge to newest-first.
+  rows.sort((a, b) => (BigInt(a.tsNs) < BigInt(b.tsNs) ? 1 : -1));
+  return rows;
+}
+
+export async function lokiQueryHistogram(
+  query: string,
+  range: ResolvedRange,
+  step: string,
+): Promise<HistogramSeries[]> {
+  const params = new URLSearchParams({
+    query,
+    start: msToNanos(range.fromMs),
+    end: msToNanos(range.toMs),
+    step,
+  });
+  const res = await lokiFetch<LokiResponse<LokiMatrixResult>>(
+    "query_range",
+    params,
+  );
+  if (res.data.resultType !== "matrix") {
+    throw new Error(
+      `Expected a metric query but got resultType=${res.data.resultType}`,
+    );
+  }
+  return res.data.result.map((r) => ({
+    level: r.metric["level"] ?? "unknown",
+    points: r.values.map(([t, v]): [number, number] => [t * 1000, Number(v)]),
+  }));
+}
+
+export async function lokiLabels(range: ResolvedRange): Promise<string[]> {
+  const params = new URLSearchParams({
+    start: msToNanos(range.fromMs),
+    end: msToNanos(range.toMs),
+  });
+  const res = await lokiFetch<{ status: string; data: string[] }>(
+    "labels",
+    params,
+  );
+  return res.data ?? [];
+}
+
+export async function lokiLabelValues(
+  label: string,
+  range: ResolvedRange,
+): Promise<string[]> {
+  const params = new URLSearchParams({
+    start: msToNanos(range.fromMs),
+    end: msToNanos(range.toMs),
+  });
+  const res = await lokiFetch<{ status: string; data: string[] }>(
+    `label/${encodeURIComponent(label)}/values`,
+    params,
+  );
+  return res.data ?? [];
+}

--- a/src/ui/src/api/prom.test.ts
+++ b/src/ui/src/api/prom.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promQueryRange, seriesName } from "./prom";
+
+const RANGE = { fromMs: 1_000_000, toMs: 2_000_000 };
+
+function mockFetchOnce(body: unknown, status = 200) {
+  const fn = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("promQueryRange", () => {
+  it("maps matrix results to millisecond points", async () => {
+    const fn = mockFetchOnce({
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [
+          {
+            metric: { __name__: "up", service_name: "checkout" },
+            values: [
+              [1000, "1"],
+              [1060, "0.5"],
+            ],
+          },
+        ],
+      },
+    });
+    const series = await promQueryRange("up", RANGE, 60);
+    expect(series).toEqual([
+      {
+        labels: { __name__: "up", service_name: "checkout" },
+        points: [
+          [1_000_000, 1],
+          [1_060_000, 0.5],
+        ],
+      },
+    ]);
+    const url = String(fn.mock.calls[0]?.[0]);
+    expect(url).toContain("/prometheus/api/v1/query_range?");
+    expect(url).toContain("step=60");
+    expect(url).toContain("start=1000");
+    expect(url).toContain("end=2000");
+  });
+
+  it("throws the API error message on status=error", async () => {
+    mockFetchOnce({
+      status: "error",
+      error: "parse error at char 3",
+      data: { resultType: "matrix", result: [] },
+    });
+    await expect(promQueryRange("up{", RANGE, 60)).rejects.toThrow(
+      /parse error at char 3/,
+    );
+  });
+
+  it("throws on HTTP failure", async () => {
+    mockFetchOnce({ oops: true }, 500);
+    await expect(promQueryRange("up", RANGE, 60)).rejects.toThrow(/\(500\)/);
+  });
+
+  it("rejects non-matrix results", async () => {
+    mockFetchOnce({
+      status: "success",
+      data: { resultType: "vector", result: [] },
+    });
+    await expect(promQueryRange("up", RANGE, 60)).rejects.toThrow(/vector/);
+  });
+});
+
+describe("seriesName", () => {
+  it("formats name and sorted labels", () => {
+    expect(seriesName({ service_name: "b", __name__: "up", env: "a" })).toBe(
+      'up{env="a", service_name="b"}',
+    );
+  });
+
+  it("handles missing name and empty labels", () => {
+    expect(seriesName({ __name__: "up" })).toBe("up");
+    expect(seriesName({})).toBe("value");
+    expect(seriesName({ a: "1" })).toBe('{a="1"}');
+  });
+});

--- a/src/ui/src/api/prom.ts
+++ b/src/ui/src/api/prom.ts
@@ -1,0 +1,63 @@
+// Client for the router's Prometheus-compatible API (/prometheus/api/v1).
+
+import type { ResolvedRange } from "../lib/time";
+
+export interface PromSeries {
+  labels: Record<string, string>;
+  /** [timestampMs, value] pairs, ascending. */
+  points: [number, number][];
+}
+
+interface PromMatrixResult {
+  metric: Record<string, string>;
+  values: [number, string][];
+}
+
+interface PromResponse {
+  status: string;
+  data: { resultType: string; result: PromMatrixResult[] };
+  error?: string;
+}
+
+export async function promQueryRange(
+  promql: string,
+  range: ResolvedRange,
+  stepSeconds: number,
+): Promise<PromSeries[]> {
+  const params = new URLSearchParams({
+    query: promql,
+    start: String(range.fromMs / 1000),
+    end: String(range.toMs / 1000),
+    step: String(stepSeconds),
+  });
+  const res = await fetch(`/prometheus/api/v1/query_range?${params}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Prometheus query_range failed (${res.status}): ${body.slice(0, 300)}`,
+    );
+  }
+  const json = (await res.json()) as PromResponse;
+  if (json.status !== "success") {
+    throw new Error(`Prometheus query failed: ${json.error ?? json.status}`);
+  }
+  if (json.data.resultType !== "matrix") {
+    throw new Error(`Expected a matrix result but got ${json.data.resultType}`);
+  }
+  return json.data.result.map((r) => ({
+    labels: r.metric,
+    points: r.values.map(([t, v]): [number, number] => [t * 1000, Number(v)]),
+  }));
+}
+
+/** Prometheus-style series label: `name{k="v", …}`. */
+export function seriesName(labels: Record<string, string>): string {
+  const { __name__: name, ...rest } = labels;
+  const pairs = Object.entries(rest)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}="${v}"`);
+  if (pairs.length === 0) return name ?? "value";
+  return `${name ?? ""}{${pairs.join(", ")}}`;
+}

--- a/src/ui/src/api/prom.ts
+++ b/src/ui/src/api/prom.ts
@@ -1,6 +1,7 @@
 // Client for the router's Prometheus-compatible API (/prometheus/api/v1).
 
 import type { ResolvedRange } from "../lib/time";
+import { tenantHeaders } from "./http";
 
 export interface PromSeries {
   labels: Record<string, string>;
@@ -31,7 +32,7 @@ export async function promQueryRange(
     step: String(stepSeconds),
   });
   const res = await fetch(`/prometheus/api/v1/query_range?${params}`, {
-    headers: { Accept: "application/json" },
+    headers: tenantHeaders(),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/src/ui/src/api/tempo.test.ts
+++ b/src/ui/src/api/tempo.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { flattenAttrValue, tempoGetTrace, tempoSearch } from "./tempo";
+
+const RANGE = { fromMs: 1_000_000, toMs: 2_000_500 };
+
+function mockFetchOnce(body: unknown, status = 200) {
+  const fn = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("flattenAttrValue", () => {
+  it("unwraps every value variant", () => {
+    expect(flattenAttrValue({ stringValue: "x" })).toBe("x");
+    expect(flattenAttrValue({ intValue: 7 })).toBe(7);
+    expect(flattenAttrValue({ doubleValue: 1.5 })).toBe(1.5);
+    expect(flattenAttrValue({ boolValue: false })).toBe(false);
+    expect(flattenAttrValue({})).toBe("");
+  });
+});
+
+describe("tempoGetTrace", () => {
+  it("maps the wire format to flat spans", async () => {
+    const fn = mockFetchOnce({
+      traceID: "abc",
+      rootServiceName: "gateway",
+      rootTraceName: "POST /checkout",
+      startTimeUnixNano: "1000",
+      durationMs: 412,
+      spanSets: [
+        {
+          matched: 2,
+          spans: [
+            {
+              spanID: "s1",
+              startTimeUnixNano: "1000",
+              durationNanos: "2000",
+              name: "root-op",
+              serviceName: "gateway",
+              status: "ok",
+              attributes: {
+                "http.method": {
+                  key: "http.method",
+                  value: { stringValue: "POST" },
+                },
+                "http.status_code": {
+                  key: "http.status_code",
+                  value: { intValue: 200 },
+                },
+              },
+            },
+            {
+              spanID: "s2",
+              startTimeUnixNano: "1100",
+              durationNanos: "500",
+              parentSpanID: "s1",
+              status: "error",
+            },
+          ],
+        },
+      ],
+    });
+    const trace = await tempoGetTrace("abc", RANGE);
+    expect(String(fn.mock.calls[0]?.[0])).toContain(
+      "/tempo/api/traces/abc?start=1000&end=2001",
+    );
+    expect(trace.traceId).toBe("abc");
+    expect(trace.spans).toHaveLength(2);
+    expect(trace.spans[0]).toMatchObject({
+      spanId: "s1",
+      parentSpanId: null,
+      name: "root-op",
+      serviceName: "gateway",
+      attributes: { "http.method": "POST", "http.status_code": 200 },
+    });
+    expect(trace.spans[1]).toMatchObject({
+      spanId: "s2",
+      parentSpanId: "s1",
+      status: "error",
+    });
+  });
+
+  it("throws a readable error on failure", async () => {
+    mockFetchOnce({ error: "trace not found" }, 404);
+    await expect(tempoGetTrace("missing")).rejects.toThrow(
+      /traces\/missing failed \(404\)/,
+    );
+  });
+});
+
+describe("tempoSearch", () => {
+  it("maps summaries and passes unix-second bounds", async () => {
+    const fn = mockFetchOnce({
+      traces: [
+        {
+          traceID: "t1",
+          rootServiceName: "checkout",
+          rootTraceName: "GET /cart",
+          startTimeUnixNano: "5000",
+          durationMs: 88,
+        },
+      ],
+      metrics: {},
+    });
+    const out = await tempoSearch(RANGE, 25);
+    const url = String(fn.mock.calls[0]?.[0]);
+    expect(url).toContain("/tempo/api/search?");
+    expect(url).toContain("start=1000");
+    expect(url).toContain("end=2001");
+    expect(url).toContain("limit=25");
+    expect(out).toEqual([
+      {
+        traceId: "t1",
+        rootServiceName: "checkout",
+        rootTraceName: "GET /cart",
+        startNs: "5000",
+        durationMs: 88,
+      },
+    ]);
+  });
+
+  it("tolerates an empty result", async () => {
+    mockFetchOnce({ metrics: {} });
+    expect(await tempoSearch(RANGE, 10)).toEqual([]);
+  });
+});

--- a/src/ui/src/api/tempo.ts
+++ b/src/ui/src/api/tempo.ts
@@ -1,0 +1,140 @@
+// Client for the router's Tempo-compatible API (/tempo/api).
+
+import type { ResolvedRange } from "../lib/time";
+
+export type AttrValue = string | number | boolean;
+
+export interface TempoSpan {
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  serviceName: string;
+  /** "ok" | "error" | "unset" */
+  status: string;
+  startNs: string;
+  durNs: string;
+  attributes: Record<string, AttrValue>;
+}
+
+export interface TraceSummary {
+  traceId: string;
+  rootServiceName: string;
+  rootTraceName: string;
+  startNs: string;
+  durationMs: number;
+}
+
+export interface TempoTrace extends TraceSummary {
+  spans: TempoSpan[];
+}
+
+interface WireValue {
+  stringValue?: string;
+  intValue?: number;
+  boolValue?: boolean;
+  doubleValue?: number;
+}
+
+interface WireSpan {
+  spanID: string;
+  startTimeUnixNano: string;
+  durationNanos: string;
+  name?: string;
+  parentSpanID?: string;
+  serviceName?: string;
+  status?: string;
+  attributes?: Record<string, { key: string; value: WireValue }>;
+}
+
+interface WireTrace {
+  traceID: string;
+  rootServiceName: string;
+  rootTraceName: string;
+  startTimeUnixNano: string;
+  durationMs: number;
+  spanSets?: { spans: WireSpan[]; matched: number }[];
+}
+
+export function flattenAttrValue(v: WireValue): AttrValue {
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.intValue !== undefined) return v.intValue;
+  if (v.doubleValue !== undefined) return v.doubleValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+  return "";
+}
+
+function toSpan(w: WireSpan): TempoSpan {
+  const attributes: Record<string, AttrValue> = {};
+  for (const [key, attr] of Object.entries(w.attributes ?? {})) {
+    attributes[key] = flattenAttrValue(attr.value);
+  }
+  return {
+    spanId: w.spanID,
+    parentSpanId: w.parentSpanID || null,
+    name: w.name ?? "",
+    serviceName: w.serviceName ?? "",
+    status: w.status ?? "unset",
+    startNs: w.startTimeUnixNano,
+    durNs: w.durationNanos,
+    attributes,
+  };
+}
+
+async function tempoFetch<T>(
+  path: string,
+  params: URLSearchParams,
+): Promise<T> {
+  const query = params.size > 0 ? `?${params}` : "";
+  const res = await fetch(`/tempo/api/${path}${query}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Tempo API ${path} failed (${res.status}): ${body.slice(0, 300)}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export async function tempoGetTrace(
+  traceId: string,
+  range?: ResolvedRange,
+): Promise<TempoTrace> {
+  const params = new URLSearchParams();
+  if (range) {
+    params.set("start", String(Math.floor(range.fromMs / 1000)));
+    params.set("end", String(Math.ceil(range.toMs / 1000)));
+  }
+  const wire = await tempoFetch<WireTrace>(
+    `traces/${encodeURIComponent(traceId)}`,
+    params,
+  );
+  return {
+    traceId: wire.traceID,
+    rootServiceName: wire.rootServiceName,
+    rootTraceName: wire.rootTraceName,
+    startNs: wire.startTimeUnixNano,
+    durationMs: wire.durationMs,
+    spans: (wire.spanSets ?? []).flatMap((s) => s.spans.map(toSpan)),
+  };
+}
+
+export async function tempoSearch(
+  range: ResolvedRange,
+  limit: number,
+): Promise<TraceSummary[]> {
+  const params = new URLSearchParams({
+    start: String(Math.floor(range.fromMs / 1000)),
+    end: String(Math.ceil(range.toMs / 1000)),
+    limit: String(limit),
+  });
+  const wire = await tempoFetch<{ traces?: WireTrace[] }>("search", params);
+  return (wire.traces ?? []).map((t) => ({
+    traceId: t.traceID,
+    rootServiceName: t.rootServiceName,
+    rootTraceName: t.rootTraceName,
+    startNs: t.startTimeUnixNano,
+    durationMs: t.durationMs,
+  }));
+}

--- a/src/ui/src/api/tempo.ts
+++ b/src/ui/src/api/tempo.ts
@@ -1,6 +1,7 @@
 // Client for the router's Tempo-compatible API (/tempo/api).
 
 import type { ResolvedRange } from "../lib/time";
+import { tenantHeaders } from "./http";
 
 export type AttrValue = string | number | boolean;
 
@@ -86,7 +87,7 @@ async function tempoFetch<T>(
 ): Promise<T> {
   const query = params.size > 0 ? `?${params}` : "";
   const res = await fetch(`/tempo/api/${path}${query}`, {
-    headers: { Accept: "application/json" },
+    headers: tenantHeaders(),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/src/ui/src/features/explore/ExploreView.tsx
+++ b/src/ui/src/features/explore/ExploreView.tsx
@@ -2,7 +2,7 @@ import { TimeRangePicker } from "../shell/TimeRangePicker";
 import { LogsView } from "../logs/LogsView";
 import { MetricsView } from "../metrics/MetricsView";
 import { TracesView } from "../traces/TracesView";
-import { useExploreState, type Signal } from "../../lib/urlState";
+import type { ExploreState, Signal } from "../../lib/urlState";
 import "./explore.css";
 
 const SIGNAL_TABS: { id: Signal; label: string }[] = [
@@ -11,9 +11,12 @@ const SIGNAL_TABS: { id: Signal; label: string }[] = [
   { id: "metrics", label: "Metrics" },
 ];
 
-export function ExploreView() {
-  const [state, update] = useExploreState();
+interface Props {
+  state: ExploreState;
+  update: (patch: Partial<ExploreState>) => void;
+}
 
+export function ExploreView({ state, update }: Props) {
   return (
     <div className="explore">
       <div className="explore-controls">

--- a/src/ui/src/features/explore/ExploreView.tsx
+++ b/src/ui/src/features/explore/ExploreView.tsx
@@ -1,0 +1,58 @@
+import { TimeRangePicker } from "../shell/TimeRangePicker";
+import { LogsView } from "../logs/LogsView";
+import { useExploreState, type Signal } from "../../lib/urlState";
+import "./explore.css";
+
+const SIGNAL_TABS: { id: Signal; label: string }[] = [
+  { id: "logs", label: "Logs" },
+  { id: "traces", label: "Traces" },
+  { id: "metrics", label: "Metrics" },
+];
+
+export function ExploreView() {
+  const [state, update] = useExploreState();
+
+  return (
+    <div className="explore">
+      <div className="explore-controls">
+        <div className="signal-tabs" role="tablist" aria-label="Signal">
+          {SIGNAL_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              className="sigtab"
+              aria-selected={state.signal === tab.id}
+              onClick={() => update({ signal: tab.id })}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="explore-controls-right">
+          <TimeRangePicker
+            range={state.range}
+            onChange={(range) => update({ range })}
+          />
+          <button
+            className="livebtn"
+            aria-pressed={state.live}
+            onClick={() => update({ live: !state.live })}
+          >
+            <span className="live-pip" /> Live
+          </button>
+        </div>
+      </div>
+
+      {state.signal === "logs" && <LogsView state={state} update={update} />}
+      {state.signal === "traces" && (
+        <div className="view-placeholder">
+          Trace view lands in phase 2.
+          {state.trace && <code> trace={state.trace}</code>}
+        </div>
+      )}
+      {state.signal === "metrics" && (
+        <div className="view-placeholder">Metrics view lands in phase 3.</div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/features/explore/ExploreView.tsx
+++ b/src/ui/src/features/explore/ExploreView.tsx
@@ -1,5 +1,6 @@
 import { TimeRangePicker } from "../shell/TimeRangePicker";
 import { LogsView } from "../logs/LogsView";
+import { TracesView } from "../traces/TracesView";
 import { useExploreState, type Signal } from "../../lib/urlState";
 import "./explore.css";
 
@@ -45,10 +46,7 @@ export function ExploreView() {
 
       {state.signal === "logs" && <LogsView state={state} update={update} />}
       {state.signal === "traces" && (
-        <div className="view-placeholder">
-          Trace view lands in phase 2.
-          {state.trace && <code> trace={state.trace}</code>}
-        </div>
+        <TracesView state={state} update={update} />
       )}
       {state.signal === "metrics" && (
         <div className="view-placeholder">Metrics view lands in phase 3.</div>

--- a/src/ui/src/features/explore/ExploreView.tsx
+++ b/src/ui/src/features/explore/ExploreView.tsx
@@ -1,5 +1,6 @@
 import { TimeRangePicker } from "../shell/TimeRangePicker";
 import { LogsView } from "../logs/LogsView";
+import { MetricsView } from "../metrics/MetricsView";
 import { TracesView } from "../traces/TracesView";
 import { useExploreState, type Signal } from "../../lib/urlState";
 import "./explore.css";
@@ -49,7 +50,7 @@ export function ExploreView() {
         <TracesView state={state} update={update} />
       )}
       {state.signal === "metrics" && (
-        <div className="view-placeholder">Metrics view lands in phase 3.</div>
+        <MetricsView state={state} update={update} />
       )}
     </div>
   );

--- a/src/ui/src/features/explore/explore.css
+++ b/src/ui/src/features/explore/explore.css
@@ -1,0 +1,587 @@
+.explore {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.explore-controls {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border);
+  gap: 10px;
+}
+
+.signal-tabs {
+  display: flex;
+  gap: 2px;
+  flex: 1;
+}
+
+.sigtab {
+  padding: 9px 13px 7px;
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--dim);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.sigtab[aria-selected="true"] {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+.explore-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.time-picker select,
+.livebtn {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.livebtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.live-pip {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+.livebtn[aria-pressed="true"] {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.livebtn[aria-pressed="true"] .live-pip {
+  background: var(--accent);
+  animation: live-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes live-pulse {
+  50% {
+    opacity: 0.25;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .livebtn .live-pip {
+    animation: none !important;
+  }
+}
+
+.view-placeholder {
+  color: var(--dim);
+  padding: 24px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+/* ---------- query bar ---------- */
+
+.logsview {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.querybar {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--surface2);
+}
+
+.chip-k {
+  padding: 4px 5px 4px 9px;
+  color: var(--dim);
+}
+
+.chip-op {
+  padding: 4px 4px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chip-v {
+  padding: 4px 5px;
+}
+
+.chip-x {
+  padding: 4px 8px 4px 5px;
+  color: var(--faint);
+}
+
+.chip-x:hover {
+  color: var(--err);
+}
+
+.add-filter {
+  color: var(--dim);
+  font-size: 12px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  padding: 4px 11px;
+}
+
+.add-filter:hover {
+  color: var(--text);
+  border-color: var(--dim);
+}
+
+.chip-form {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.chip-form input,
+.chip-form select {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 5px;
+  padding: 3px 7px;
+  font-size: 12px;
+  font-family: var(--mono);
+  max-width: 160px;
+}
+
+.chip-form button {
+  font-size: 12px;
+  color: var(--dim);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 9px;
+}
+
+.search-form {
+  flex: 1;
+  min-width: 160px;
+}
+
+.search-input {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.qlmode {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--faint);
+  padding: 6px 4px;
+}
+
+.qlmode:hover {
+  color: var(--dim);
+}
+
+.raw-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.raw-form textarea {
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 7px 10px;
+  resize: vertical;
+}
+
+.raw-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.raw-actions button {
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 11px;
+  color: var(--dim);
+}
+
+/* ---------- layout ---------- */
+
+.logs-body {
+  display: grid;
+  grid-template-columns: 248px 1fr;
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 900px) {
+  .logs-body {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+}
+
+.logs-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* ---------- sidebar ---------- */
+
+.sidebar {
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.sidebar-head {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--faint);
+  font-weight: 650;
+  padding: 11px 12px 6px;
+}
+
+.sidebar-search {
+  margin: 0 12px 8px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 5px 9px;
+  font-size: 12px;
+}
+
+.fieldlist {
+  overflow-y: auto;
+  flex: 1;
+  padding-bottom: 10px;
+}
+
+.fieldlist-empty,
+.fieldvals-note {
+  color: var(--faint);
+  font-size: 11.5px;
+  padding: 4px 12px;
+}
+
+.field {
+  width: 100%;
+  text-align: left;
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  display: block;
+}
+
+.field:hover,
+.field.open {
+  background: var(--surface2);
+}
+
+.fieldvals {
+  padding: 2px 12px 8px;
+  background: var(--surface2);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.fieldval {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 3px 0 3px 10px;
+  border-left: 2px solid var(--border);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fieldval:hover {
+  border-left-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ---------- histogram ---------- */
+
+.histo-wrap {
+  padding: 10px 16px 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.histo-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.histo-total {
+  font-size: 12.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.histo-note {
+  font-size: 11px;
+  color: var(--faint);
+}
+
+.histo {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.histo-empty {
+  color: var(--faint);
+  font-size: 11.5px;
+  align-items: center;
+}
+
+.histo-bar {
+  flex: 1;
+  display: flex;
+  flex-direction: column-reverse;
+  border-radius: 2px 2px 0 0;
+  overflow: hidden;
+  min-width: 2px;
+}
+
+.histo-bar i {
+  display: block;
+  width: 100%;
+}
+
+.histo-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--mono);
+  padding: 3px 0 4px;
+}
+
+/* ---------- log list ---------- */
+
+.loglist {
+  flex: 1;
+  overflow-y: auto;
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.loglist-empty {
+  color: var(--faint);
+  padding: 18px 16px;
+}
+
+.query-error {
+  color: var(--err);
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 12px 16px;
+}
+
+.logrow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 4px 16px 4px 12px;
+  border-left: 3px solid transparent;
+  width: 100%;
+  text-align: left;
+}
+
+.logrow:hover {
+  background: var(--surface2);
+}
+
+.logrow.level-error {
+  border-left-color: var(--err-bar);
+}
+
+.logrow.level-warn {
+  border-left-color: var(--warn-bar);
+}
+
+.logrow-ts {
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
+}
+
+.logrow-level {
+  flex: 0 0 48px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+span.level-error {
+  color: var(--err);
+}
+
+span.level-warn {
+  color: var(--warn);
+}
+
+span.level-info {
+  color: var(--info);
+}
+
+span.level-debug {
+  color: var(--debug);
+}
+
+.logrow-svc {
+  flex: 0 0 auto;
+  color: var(--dim);
+}
+
+.logrow-msg {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.logrow-trace {
+  color: var(--faint);
+  font-size: 10px;
+}
+
+.logdetail {
+  background: var(--surface2);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px 12px 40px;
+  font-family: var(--ui);
+}
+
+.logdetail-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.act {
+  font-size: 11.5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  background: var(--surface);
+}
+
+.act-primary {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 550;
+}
+
+.attr-grid {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 720px;
+}
+
+.attr-row {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr max-content;
+  gap: 0 14px;
+  font-size: 11.5px;
+}
+
+.attr-row dt {
+  font-family: var(--mono);
+  color: var(--dim);
+}
+
+.attr-row dd {
+  font-family: var(--mono);
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.attr-actions {
+  visibility: hidden;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.attr-row:hover .attr-actions {
+  visibility: visible;
+}
+
+.attr-actions button {
+  font-size: 10px;
+  color: var(--faint);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
+.attr-actions button:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}

--- a/src/ui/src/features/logs/FieldSidebar.test.tsx
+++ b/src/ui/src/features/logs/FieldSidebar.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { FieldSidebar } from "./FieldSidebar";
+
+const RANGE = { fromMs: 0, toMs: 1000 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("FieldSidebar", () => {
+  it("lists labels and filters them by search text", async () => {
+    renderWithClient(
+      <FieldSidebar
+        labels={["service_name", "level", "http_method"]}
+        range={RANGE}
+        rangeKey="1h"
+        onAddFilter={() => {}}
+      />,
+    );
+    expect(screen.getByText("service_name")).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("Filter fields"), "lev");
+    expect(screen.queryByText("service_name")).not.toBeInTheDocument();
+    expect(screen.getByText("level")).toBeInTheDocument();
+  });
+
+  it("loads values on expand and adds a filter on click", async () => {
+    stubFetchRoutes([
+      {
+        match: "/loki/api/v1/label/level/values",
+        body: { status: "success", data: ["error", "info"] },
+      },
+    ]);
+    const onAddFilter = vi.fn();
+    renderWithClient(
+      <FieldSidebar
+        labels={["level"]}
+        range={RANGE}
+        rangeKey="1h"
+        onAddFilter={onAddFilter}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "level" }));
+    await userEvent.click(await screen.findByRole("button", { name: "error" }));
+    expect(onAddFilter).toHaveBeenCalledWith({
+      label: "level",
+      op: "=",
+      value: "error",
+    });
+  });
+
+  it("shows a failure note when values cannot load", async () => {
+    stubFetchRoutes([
+      { match: "/values", body: { error: "boom" }, status: 500 },
+    ]);
+    renderWithClient(
+      <FieldSidebar
+        labels={["level"]}
+        range={RANGE}
+        rangeKey="1h"
+        onAddFilter={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "level" }));
+    expect(
+      await screen.findByText("Failed to load values"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/features/logs/FieldSidebar.tsx
+++ b/src/ui/src/features/logs/FieldSidebar.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { lokiLabelValues } from "../../api/loki";
+import type { LabelFilter } from "../../lib/filters";
+import type { ResolvedRange } from "../../lib/time";
+
+interface Props {
+  labels: string[];
+  range: ResolvedRange;
+  rangeKey: string;
+  onAddFilter: (filter: LabelFilter) => void;
+}
+
+/**
+ * Fields panel v1: label names from the Loki labels endpoint, values on
+ * expand. Presence/cardinality stats arrive with the native fields API.
+ */
+export function FieldSidebar({ labels, range, rangeKey, onAddFilter }: Props) {
+  const [open, setOpen] = useState<string | null>(null);
+  const [filterText, setFilterText] = useState("");
+
+  const visible = labels.filter((l) =>
+    l.toLowerCase().includes(filterText.toLowerCase()),
+  );
+
+  return (
+    <aside className="sidebar" aria-label="Fields">
+      <div className="sidebar-head">Fields</div>
+      <input
+        type="search"
+        className="sidebar-search"
+        placeholder="Filter fields…"
+        aria-label="Filter fields"
+        value={filterText}
+        onChange={(e) => setFilterText(e.target.value)}
+      />
+      <div className="fieldlist">
+        {visible.length === 0 && (
+          <div className="fieldlist-empty">No fields</div>
+        )}
+        {visible.map((label) => (
+          <div key={label}>
+            <button
+              className={`field ${open === label ? "open" : ""}`}
+              aria-expanded={open === label}
+              onClick={() => setOpen(open === label ? null : label)}
+            >
+              {label}
+            </button>
+            {open === label && (
+              <FieldValues
+                label={label}
+                range={range}
+                rangeKey={rangeKey}
+                onAddFilter={onAddFilter}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function FieldValues({
+  label,
+  range,
+  rangeKey,
+  onAddFilter,
+}: {
+  label: string;
+  range: ResolvedRange;
+  rangeKey: string;
+  onAddFilter: (filter: LabelFilter) => void;
+}) {
+  const { data, isPending, isError } = useQuery({
+    queryKey: ["loki-label-values", label, rangeKey],
+    queryFn: () => lokiLabelValues(label, range),
+    staleTime: 30_000,
+  });
+
+  if (isPending) return <div className="fieldvals-note">Loading…</div>;
+  if (isError)
+    return <div className="fieldvals-note">Failed to load values</div>;
+  if (!data || data.length === 0)
+    return <div className="fieldvals-note">No values in range</div>;
+
+  return (
+    <div className="fieldvals">
+      {data.map((value) => (
+        <button
+          key={value}
+          className="fieldval"
+          title={`Add filter ${label} = ${value}`}
+          onClick={() => onAddFilter({ label, op: "=", value })}
+        >
+          {value}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/src/features/logs/FilterChips.test.tsx
+++ b/src/ui/src/features/logs/FilterChips.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { LabelFilter } from "../../lib/filters";
+import { FilterChips } from "./FilterChips";
+
+const filters: LabelFilter[] = [
+  { label: "service_name", op: "=", value: "checkout" },
+  { label: "level", op: "!=", value: "debug" },
+];
+
+describe("FilterChips", () => {
+  it("renders one chip per filter", () => {
+    render(<FilterChips filters={filters} labels={[]} onChange={() => {}} />);
+    expect(screen.getByText("service_name")).toBeInTheDocument();
+    expect(screen.getByText("checkout")).toBeInTheDocument();
+    expect(screen.getByText("level")).toBeInTheDocument();
+  });
+
+  it("removes a chip", async () => {
+    const onChange = vi.fn();
+    render(<FilterChips filters={filters} labels={[]} onChange={onChange} />);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Remove filter service_name = checkout",
+      }),
+    );
+    expect(onChange).toHaveBeenCalledWith([filters[1]]);
+  });
+
+  it("adds a filter through the inline form", async () => {
+    const onChange = vi.fn();
+    render(<FilterChips filters={[]} labels={["level"]} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: "+ filter" }));
+    await userEvent.type(screen.getByLabelText("Filter label"), "level");
+    await userEvent.selectOptions(
+      screen.getByLabelText("Filter operator"),
+      "=~",
+    );
+    await userEvent.type(screen.getByLabelText("Filter value"), "err.*");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(onChange).toHaveBeenCalledWith([
+      { label: "level", op: "=~", value: "err.*" },
+    ]);
+  });
+
+  it("refuses to add a filter with an invalid label name", async () => {
+    const onChange = vi.fn();
+    render(<FilterChips filters={[]} labels={[]} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: "+ filter" }));
+    await userEvent.type(screen.getByLabelText("Filter label"), "bad label!");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/features/logs/FilterChips.tsx
+++ b/src/ui/src/features/logs/FilterChips.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import {
+  FILTER_OPS,
+  isValidLabelName,
+  type FilterOp,
+  type LabelFilter,
+} from "../../lib/filters";
+
+interface Props {
+  filters: LabelFilter[];
+  /** Known label names for the add-filter form; free text is also allowed. */
+  labels: string[];
+  onChange: (filters: LabelFilter[]) => void;
+}
+
+export function FilterChips({ filters, labels, onChange }: Props) {
+  const [adding, setAdding] = useState(false);
+  const [label, setLabel] = useState("");
+  const [op, setOp] = useState<FilterOp>("=");
+  const [value, setValue] = useState("");
+
+  const submit = () => {
+    if (!isValidLabelName(label)) return;
+    onChange([...filters, { label, op, value }]);
+    setLabel("");
+    setOp("=");
+    setValue("");
+    setAdding(false);
+  };
+
+  return (
+    <div className="chips" role="group" aria-label="Filters">
+      {filters.map((f, i) => (
+        <span className="chip" key={`${f.label}-${f.op}-${f.value}-${i}`}>
+          <span className="chip-k">{f.label}</span>
+          <span className="chip-op">{f.op}</span>
+          <span className="chip-v">{f.value}</span>
+          <button
+            className="chip-x"
+            aria-label={`Remove filter ${f.label} ${f.op} ${f.value}`}
+            onClick={() => onChange(filters.filter((_, idx) => idx !== i))}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      {adding ? (
+        <form
+          className="chip-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          <input
+            list="known-labels"
+            aria-label="Filter label"
+            placeholder="label"
+            value={label}
+            autoFocus
+            onChange={(e) => setLabel(e.target.value)}
+          />
+          <datalist id="known-labels">
+            {labels.map((l) => (
+              <option key={l} value={l} />
+            ))}
+          </datalist>
+          <select
+            aria-label="Filter operator"
+            value={op}
+            onChange={(e) => setOp(e.target.value as FilterOp)}
+          >
+            {FILTER_OPS.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+          <input
+            aria-label="Filter value"
+            placeholder="value"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <button type="submit">Add</button>
+          <button type="button" onClick={() => setAdding(false)}>
+            Cancel
+          </button>
+        </form>
+      ) : (
+        <button className="add-filter" onClick={() => setAdding(true)}>
+          + filter
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/features/logs/Histogram.test.tsx
+++ b/src/ui/src/features/logs/Histogram.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { bucketize, Histogram, normalizeLevel } from "./Histogram";
+import { bucketize, Histogram, normalizeLevel, padBuckets } from "./Histogram";
 
 describe("normalizeLevel", () => {
   it("maps synonyms onto canonical levels", () => {
@@ -38,6 +38,33 @@ describe("bucketize", () => {
       { level: "warning", points: [[1000, 5]] },
     ]);
     expect(buckets[0]?.counts).toEqual({ warn: 7 });
+  });
+});
+
+describe("padBuckets", () => {
+  it("fills the selected range with empty buckets on the step grid", () => {
+    const data = bucketize([{ level: "info", points: [[2000, 5]] }]);
+    const padded = padBuckets(data, 0, 4000, 1000);
+    expect(padded.map((b) => b.tMs)).toEqual([0, 1000, 2000, 3000, 4000]);
+    expect(padded.map((b) => b.total)).toEqual([0, 0, 5, 0, 0]);
+  });
+
+  it("keeps off-grid buckets and ignores degenerate steps", () => {
+    const data = bucketize([{ level: "info", points: [[1500, 2]] }]);
+    const padded = padBuckets(data, 1000, 3000, 1000);
+    expect(padded.map((b) => b.tMs)).toEqual([1000, 1500, 2000, 3000]);
+    expect(padBuckets(data, 1000, 3000, 0)).toEqual(data);
+  });
+
+  it("pads via the component when range and step are provided", () => {
+    render(
+      <Histogram
+        series={[{ level: "info", points: [[2000, 5]] }]}
+        rangeMs={{ fromMs: 0, toMs: 4000 }}
+        stepMs={1000}
+      />,
+    );
+    expect(screen.getAllByTestId("histo-bar")).toHaveLength(5);
   });
 });
 

--- a/src/ui/src/features/logs/Histogram.test.tsx
+++ b/src/ui/src/features/logs/Histogram.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { bucketize, Histogram, normalizeLevel } from "./Histogram";
+
+describe("normalizeLevel", () => {
+  it("maps synonyms onto canonical levels", () => {
+    expect(normalizeLevel("ERROR")).toBe("error");
+    expect(normalizeLevel("err")).toBe("error");
+    expect(normalizeLevel("fatal")).toBe("error");
+    expect(normalizeLevel("WARNING")).toBe("warn");
+    expect(normalizeLevel("Information")).toBe("info");
+    expect(normalizeLevel("trace")).toBe("debug");
+    expect(normalizeLevel("weird")).toBe("other");
+  });
+});
+
+describe("bucketize", () => {
+  it("merges series into time-sorted buckets with totals", () => {
+    const buckets = bucketize([
+      {
+        level: "error",
+        points: [
+          [2000, 3],
+          [1000, 1],
+        ],
+      },
+      { level: "INFO", points: [[1000, 10]] },
+    ]);
+    expect(buckets).toEqual([
+      { tMs: 1000, counts: { error: 1, info: 10 }, total: 11 },
+      { tMs: 2000, counts: { error: 3 }, total: 3 },
+    ]);
+  });
+
+  it("collapses same-normalized levels into one count", () => {
+    const buckets = bucketize([
+      { level: "warn", points: [[1000, 2]] },
+      { level: "warning", points: [[1000, 5]] },
+    ]);
+    expect(buckets[0]?.counts).toEqual({ warn: 7 });
+  });
+});
+
+describe("Histogram", () => {
+  it("renders one bar per bucket with level segments", () => {
+    render(
+      <Histogram
+        series={[
+          {
+            level: "error",
+            points: [
+              [1000, 2],
+              [2000, 4],
+            ],
+          },
+          { level: "info", points: [[1000, 6]] },
+        ]}
+      />,
+    );
+    const bars = screen.getAllByTestId("histo-bar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]?.querySelector('[data-level="info"]')).toBeTruthy();
+    expect(bars[0]?.querySelector('[data-level="error"]')).toBeTruthy();
+    expect(bars[1]?.querySelector('[data-level="info"]')).toBeNull();
+  });
+
+  it("shows an empty state without data", () => {
+    render(<Histogram series={[]} />);
+    expect(screen.getByText(/No log volume/)).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/features/logs/Histogram.tsx
+++ b/src/ui/src/features/logs/Histogram.tsx
@@ -46,13 +46,44 @@ export function bucketize(series: HistogramSeries[]): HistogramBucket[] {
     }));
 }
 
+/**
+ * Fill the selected range with empty buckets so sparse data doesn't stretch
+ * across the full width. Bucket alignment follows the backend's epoch-aligned
+ * date_bin grid.
+ */
+export function padBuckets(
+  buckets: HistogramBucket[],
+  fromMs: number,
+  toMs: number,
+  stepMs: number,
+): HistogramBucket[] {
+  if (stepMs <= 0 || toMs <= fromMs) return buckets;
+  const byTime = new Map(buckets.map((b) => [b.tMs, b]));
+  const start = Math.floor(fromMs / stepMs) * stepMs;
+  const out: HistogramBucket[] = [];
+  for (let t = start; t <= toMs; t += stepMs) {
+    out.push(byTime.get(t) ?? { tMs: t, counts: {}, total: 0 });
+  }
+  // Keep any buckets that fall outside the aligned grid (defensive).
+  for (const b of buckets) {
+    if (!out.some((o) => o.tMs === b.tMs)) out.push(b);
+  }
+  return out.sort((a, b) => a.tMs - b.tMs);
+}
+
 interface Props {
   series: HistogramSeries[];
   height?: number;
+  /** Selected time range; when given, empty buckets pad the full range. */
+  rangeMs?: { fromMs: number; toMs: number };
+  stepMs?: number;
 }
 
-export function Histogram({ series, height = 72 }: Props) {
-  const buckets = bucketize(series);
+export function Histogram({ series, height = 72, rangeMs, stepMs }: Props) {
+  let buckets = bucketize(series);
+  if (rangeMs && stepMs && buckets.length > 0) {
+    buckets = padBuckets(buckets, rangeMs.fromMs, rangeMs.toMs, stepMs);
+  }
   const max = Math.max(1, ...buckets.map((b) => b.total));
   const levels = [...LEVEL_ORDER, "other"];
 

--- a/src/ui/src/features/logs/Histogram.tsx
+++ b/src/ui/src/features/logs/Histogram.tsx
@@ -1,0 +1,101 @@
+import { formatTimestamp } from "../../lib/time";
+import type { HistogramSeries } from "../../api/loki";
+
+/** Stacking order bottom-to-top; anything else lands in "other". */
+const LEVEL_ORDER = ["debug", "info", "warn", "error"] as const;
+
+const LEVEL_VAR: Record<string, string> = {
+  debug: "var(--debug-bar)",
+  info: "var(--info-bar)",
+  warn: "var(--warn-bar)",
+  error: "var(--err-bar)",
+  other: "var(--faint)",
+};
+
+export function normalizeLevel(level: string): string {
+  const l = level.toLowerCase();
+  if (l.startsWith("err") || l === "fatal" || l === "critical") return "error";
+  if (l.startsWith("warn")) return "warn";
+  if (l === "info" || l === "information") return "info";
+  if (l === "debug" || l === "trace") return "debug";
+  return "other";
+}
+
+export interface HistogramBucket {
+  tMs: number;
+  counts: Record<string, number>;
+  total: number;
+}
+
+export function bucketize(series: HistogramSeries[]): HistogramBucket[] {
+  const byTime = new Map<number, Record<string, number>>();
+  for (const s of series) {
+    const level = normalizeLevel(s.level);
+    for (const [tMs, count] of s.points) {
+      const bucket = byTime.get(tMs) ?? {};
+      bucket[level] = (bucket[level] ?? 0) + count;
+      byTime.set(tMs, bucket);
+    }
+  }
+  return [...byTime.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([tMs, counts]) => ({
+      tMs,
+      counts,
+      total: Object.values(counts).reduce((a, b) => a + b, 0),
+    }));
+}
+
+interface Props {
+  series: HistogramSeries[];
+  height?: number;
+}
+
+export function Histogram({ series, height = 72 }: Props) {
+  const buckets = bucketize(series);
+  const max = Math.max(1, ...buckets.map((b) => b.total));
+  const levels = [...LEVEL_ORDER, "other"];
+
+  if (buckets.length === 0) {
+    return <div className="histo histo-empty">No log volume in range</div>;
+  }
+
+  return (
+    <div>
+      <div
+        className="histo"
+        style={{ height }}
+        role="img"
+        aria-label="Log volume over time by level"
+      >
+        {buckets.map((b) => (
+          <div
+            className="histo-bar"
+            key={b.tMs}
+            data-testid="histo-bar"
+            title={`${formatTimestamp(b.tMs)} — ${b.total} lines`}
+          >
+            {levels.map((level) => {
+              const count = b.counts[level] ?? 0;
+              if (count === 0) return null;
+              return (
+                <i
+                  key={level}
+                  data-level={level}
+                  style={{
+                    height: `${Math.max(1, (count / max) * (height - 4))}px`,
+                    background: LEVEL_VAR[level],
+                  }}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="histo-axis">
+        <span>{formatTimestamp(buckets[0]!.tMs)}</span>
+        <span>{formatTimestamp(buckets[buckets.length - 1]!.tMs)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/features/logs/LogList.test.tsx
+++ b/src/ui/src/features/logs/LogList.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { LogRow } from "../../api/loki";
+import { LogList, traceIdOf } from "./LogList";
+
+const row = (over: Partial<LogRow>): LogRow => ({
+  tsNs: "1000000000",
+  tsMs: 1000,
+  line: "hello",
+  labels: {},
+  ...over,
+});
+
+describe("traceIdOf", () => {
+  it("finds trace ids under common label spellings", () => {
+    expect(traceIdOf(row({ labels: { trace_id: "abc" } }))).toBe("abc");
+    expect(traceIdOf(row({ labels: { traceID: "def" } }))).toBe("def");
+    expect(traceIdOf(row({ labels: {} }))).toBeNull();
+  });
+});
+
+describe("LogList", () => {
+  const rows: LogRow[] = [
+    row({
+      tsNs: "3000000000",
+      tsMs: 3000,
+      line: "payment failed",
+      labels: {
+        level: "error",
+        service_name: "payments",
+        trace_id: "cafe1234beef",
+      },
+    }),
+    row({
+      tsNs: "2000000000",
+      tsMs: 2000,
+      line: "request handled",
+      labels: { level: "info", service_name: "gateway" },
+    }),
+  ];
+
+  it("renders virtualized rows with level and service", () => {
+    render(
+      <LogList rows={rows} onAddFilter={() => {}} onOpenTrace={() => {}} />,
+    );
+    expect(screen.getByText("payment failed")).toBeInTheDocument();
+    expect(screen.getByText("request handled")).toBeInTheDocument();
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    expect(screen.getByText("gateway")).toBeInTheDocument();
+  });
+
+  it("expands a row to show attributes and filter actions", async () => {
+    const onAddFilter = vi.fn();
+    render(
+      <LogList rows={rows} onAddFilter={onAddFilter} onOpenTrace={() => {}} />,
+    );
+    await userEvent.click(screen.getByText("payment failed"));
+    expect(screen.getByText("trace_id")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Filter for service_name = payments",
+      }),
+    );
+    expect(onAddFilter).toHaveBeenCalledWith({
+      label: "service_name",
+      op: "=",
+      value: "payments",
+    });
+  });
+
+  it("supports exclude filters from the detail view", async () => {
+    const onAddFilter = vi.fn();
+    render(
+      <LogList rows={rows} onAddFilter={onAddFilter} onOpenTrace={() => {}} />,
+    );
+    await userEvent.click(screen.getByText("payment failed"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Filter out level = error" }),
+    );
+    expect(onAddFilter).toHaveBeenCalledWith({
+      label: "level",
+      op: "!=",
+      value: "error",
+    });
+  });
+
+  it("pivots to the trace from a row with a trace id", async () => {
+    const onOpenTrace = vi.fn();
+    render(
+      <LogList rows={rows} onAddFilter={() => {}} onOpenTrace={onOpenTrace} />,
+    );
+    await userEvent.click(screen.getByText("payment failed"));
+    await userEvent.click(
+      screen.getByRole("button", { name: /View trace cafe1234/ }),
+    );
+    expect(onOpenTrace).toHaveBeenCalledWith("cafe1234beef");
+  });
+
+  it("shows an empty state", () => {
+    render(<LogList rows={[]} onAddFilter={() => {}} onOpenTrace={() => {}} />);
+    expect(screen.getByText(/No log lines/)).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/features/logs/LogList.tsx
+++ b/src/ui/src/features/logs/LogList.tsx
@@ -1,0 +1,138 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useRef, useState } from "react";
+import type { LogRow } from "../../api/loki";
+import type { LabelFilter } from "../../lib/filters";
+import { formatTimestamp } from "../../lib/time";
+import { normalizeLevel } from "./Histogram";
+
+interface Props {
+  rows: LogRow[];
+  onAddFilter: (filter: LabelFilter) => void;
+  onOpenTrace: (traceId: string) => void;
+}
+
+/** Labels that identify a linked trace when present on a log row. */
+const TRACE_LABELS = ["trace_id", "traceID", "traceId"];
+
+export function traceIdOf(row: LogRow): string | null {
+  for (const key of TRACE_LABELS) {
+    const v = row.labels[key];
+    if (v) return v;
+  }
+  return null;
+}
+
+export function LogList({ rows, onAddFilter, onOpenTrace }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 26,
+    overscan: 20,
+  });
+
+  if (rows.length === 0) {
+    return <div className="loglist-empty">No log lines match this query.</div>;
+  }
+
+  return (
+    <div className="loglist" ref={scrollRef}>
+      <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+        {virtualizer.getVirtualItems().map((item) => {
+          const row = rows[item.index]!;
+          const key = `${row.tsNs}-${item.index}`;
+          const level = normalizeLevel(row.labels["level"] ?? "");
+          const isOpen = expanded === key;
+          const traceId = traceIdOf(row);
+          return (
+            <div
+              key={key}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
+              className="logrow-wrap"
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${item.start}px)`,
+              }}
+            >
+              <button
+                className={`logrow level-${level}`}
+                aria-expanded={isOpen}
+                onClick={() => setExpanded(isOpen ? null : key)}
+              >
+                <span className="logrow-ts">{formatTimestamp(row.tsMs)}</span>
+                <span className={`logrow-level level-${level}`}>
+                  {(row.labels["level"] ?? "-").toUpperCase()}
+                </span>
+                <span className="logrow-svc">
+                  {row.labels["service_name"] ?? ""}
+                </span>
+                <span className="logrow-msg">{row.line}</span>
+                {traceId !== null && <span className="logrow-trace">⛓</span>}
+              </button>
+              {isOpen && (
+                <div className="logdetail">
+                  <div className="logdetail-actions">
+                    {traceId !== null && (
+                      <button
+                        className="act act-primary"
+                        onClick={() => onOpenTrace(traceId)}
+                      >
+                        View trace {traceId.slice(0, 8)}…
+                      </button>
+                    )}
+                    <button
+                      className="act"
+                      onClick={() =>
+                        navigator.clipboard?.writeText(
+                          JSON.stringify(
+                            { ...row.labels, line: row.line },
+                            null,
+                            2,
+                          ),
+                        )
+                      }
+                    >
+                      Copy JSON
+                    </button>
+                  </div>
+                  <dl className="attr-grid">
+                    {Object.entries(row.labels).map(([k, v]) => (
+                      <div className="attr-row" key={k}>
+                        <dt>{k}</dt>
+                        <dd>{v}</dd>
+                        <span className="attr-actions">
+                          <button
+                            aria-label={`Filter for ${k} = ${v}`}
+                            onClick={() =>
+                              onAddFilter({ label: k, op: "=", value: v })
+                            }
+                          >
+                            + filter
+                          </button>
+                          <button
+                            aria-label={`Filter out ${k} = ${v}`}
+                            onClick={() =>
+                              onAddFilter({ label: k, op: "!=", value: v })
+                            }
+                          >
+                            − exclude
+                          </button>
+                        </span>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/features/logs/LogsView.test.tsx
+++ b/src/ui/src/features/logs/LogsView.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_STATE, type ExploreState } from "../../lib/urlState";
+import {
+  emptyLabels,
+  emptyMatrix,
+  logsResponse,
+  renderWithClient,
+  stubFetchRoutes,
+} from "../../test/render";
+import { LogsView } from "./LogsView";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function routes() {
+  return stubFetchRoutes([
+    // Histogram queries carry a step param; log queries a direction param.
+    {
+      match: /query_range.*direction=backward/,
+      body: logsResponse([
+        {
+          tsNs: "2000000000",
+          line: "charge failed: card_declined",
+          labels: { level: "error", service_name: "payments" },
+        },
+        {
+          tsNs: "1000000000",
+          line: "checkout started",
+          labels: { level: "info", service_name: "checkout" },
+        },
+      ]),
+    },
+    { match: /query_range.*step=/, body: emptyMatrix },
+    {
+      match: "/loki/api/v1/labels",
+      body: { status: "success", data: ["level", "service_name"] },
+    },
+  ]);
+}
+
+function renderView(state: Partial<ExploreState> = {}) {
+  const update = vi.fn();
+  const view = renderWithClient(
+    <LogsView state={{ ...DEFAULT_STATE, ...state }} update={update} />,
+  );
+  return { update, view };
+}
+
+describe("LogsView", () => {
+  it("renders fetched log rows and the row count", async () => {
+    routes();
+    renderView();
+    expect(
+      await screen.findByText("charge failed: card_declined"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("checkout started")).toBeInTheDocument();
+    expect(screen.getByText("2 rows")).toBeInTheDocument();
+  });
+
+  it("issues a histogram query grouped by level", async () => {
+    const fetchFn = routes();
+    renderView();
+    await waitFor(() => {
+      // URLSearchParams encodes spaces as "+".
+      const urls = fetchFn.mock.calls.map((c) =>
+        decodeURIComponent(String(c[0])).replace(/\+/g, " "),
+      );
+      expect(
+        urls.some((u) => u.includes("sum by (level) (count_over_time(")),
+      ).toBe(true);
+    });
+  });
+
+  it("adding a filter from a row updates state and clears raw mode", async () => {
+    routes();
+    const { update } = renderView();
+    await userEvent.click(
+      await screen.findByText("charge failed: card_declined"),
+    );
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Filter for service_name = payments",
+      }),
+    );
+    expect(update).toHaveBeenCalledWith({
+      filters: [{ label: "service_name", op: "=", value: "payments" }],
+      raw: "",
+    });
+  });
+
+  it("switches to raw LogQL editing prefilled with the compiled query", async () => {
+    routes();
+    const { update } = renderView({
+      filters: [{ label: "level", op: "=", value: "error" }],
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: "{ } edit as text" }),
+    );
+    const textarea = screen.getByLabelText("LogQL query");
+    expect(textarea).toHaveValue('{level="error"}');
+    // fireEvent instead of userEvent.type: "{" is a userEvent escape char.
+    fireEvent.change(textarea, {
+      target: { value: '{service_name="api"}' },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(update).toHaveBeenCalledWith({ raw: '{service_name="api"}' });
+  });
+
+  it("skips the histogram for raw queries", async () => {
+    const fetchFn = routes();
+    renderView({ raw: '{service_name="api"}' });
+    await screen.findByText("charge failed: card_declined");
+    const urls = fetchFn.mock.calls.map((c) =>
+      decodeURIComponent(String(c[0])),
+    );
+    expect(urls.some((u) => u.includes("count_over_time"))).toBe(false);
+  });
+
+  it("surfaces query errors", async () => {
+    stubFetchRoutes([
+      {
+        match: /query_range/,
+        body: { error: "parse error: unexpected token" },
+        status: 400,
+      },
+      { match: "/loki/api/v1/labels", body: emptyLabels },
+    ]);
+    renderView();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Query failed:.*400/,
+    );
+  });
+
+  it("pivots to the trace view from a log row", async () => {
+    stubFetchRoutes([
+      {
+        match: /query_range.*direction=backward/,
+        body: logsResponse([
+          {
+            tsNs: "2000000000",
+            line: "traced line",
+            labels: { level: "info", trace_id: "abcd1234" },
+          },
+        ]),
+      },
+      { match: /query_range.*step=/, body: emptyMatrix },
+      { match: "/loki/api/v1/labels", body: emptyLabels },
+    ]);
+    const { update } = renderView();
+    await userEvent.click(await screen.findByText("traced line"));
+    await userEvent.click(
+      screen.getByRole("button", { name: /View trace abcd1234/ }),
+    );
+    expect(update).toHaveBeenCalledWith({
+      signal: "traces",
+      trace: "abcd1234",
+    });
+  });
+});

--- a/src/ui/src/features/logs/LogsView.tsx
+++ b/src/ui/src/features/logs/LogsView.tsx
@@ -32,7 +32,9 @@ export function LogsView({ state, update }: Props) {
     raw: state.raw || undefined,
   };
   const logql = compileLogQL(model);
-  const rangeKey = rangeToParam(state.range);
+  // Cache scope: time range plus tenant context, so switching tenants
+  // refetches instead of serving another tenant's cached results.
+  const rangeKey = `${rangeToParam(state.range)}|${state.tenant}|${state.dataset}`;
   // Relative ranges resolve "now" per fetch so live mode slides forward.
   const range = () => resolveRange(state.range, Date.now());
   const refetchInterval = state.live ? LIVE_INTERVAL_MS : false;

--- a/src/ui/src/features/logs/LogsView.tsx
+++ b/src/ui/src/features/logs/LogsView.tsx
@@ -1,0 +1,185 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { lokiLabels, lokiQueryHistogram, lokiQueryLogs } from "../../api/loki";
+import {
+  compileHistogramQL,
+  compileLogQL,
+  upsertFilter,
+  type LabelFilter,
+} from "../../lib/filters";
+import { rangeToParam, resolveRange, stepForRange } from "../../lib/time";
+import type { ExploreState } from "../../lib/urlState";
+import { FieldSidebar } from "./FieldSidebar";
+import { FilterChips } from "./FilterChips";
+import { Histogram } from "./Histogram";
+import { LogList } from "./LogList";
+
+const LIVE_INTERVAL_MS = 2000;
+
+interface Props {
+  state: ExploreState;
+  update: (patch: Partial<ExploreState>) => void;
+}
+
+export function LogsView({ state, update }: Props) {
+  const [editingRaw, setEditingRaw] = useState(false);
+  const [rawDraft, setRawDraft] = useState("");
+  const [searchDraft, setSearchDraft] = useState(state.search);
+
+  const model = {
+    filters: state.filters,
+    search: state.search,
+    raw: state.raw || undefined,
+  };
+  const logql = compileLogQL(model);
+  const rangeKey = rangeToParam(state.range);
+  // Relative ranges resolve "now" per fetch so live mode slides forward.
+  const range = () => resolveRange(state.range, Date.now());
+  const refetchInterval = state.live ? LIVE_INTERVAL_MS : false;
+
+  const logs = useQuery({
+    queryKey: ["loki-logs", logql, rangeKey, state.limit],
+    queryFn: () => lokiQueryLogs(logql, range(), state.limit),
+    refetchInterval,
+  });
+
+  const resolvedForStep = resolveRange(state.range, Date.now());
+  const step = stepForRange(resolvedForStep);
+  const histogramQL = compileHistogramQL(model, step);
+  const histogram = useQuery({
+    queryKey: ["loki-histogram", histogramQL, rangeKey],
+    queryFn: () => lokiQueryHistogram(histogramQL!, range(), step),
+    enabled: histogramQL !== null,
+    refetchInterval,
+  });
+
+  const labels = useQuery({
+    queryKey: ["loki-labels", rangeKey],
+    queryFn: () => lokiLabels(range()),
+    staleTime: 60_000,
+  });
+
+  const addFilter = (f: LabelFilter) =>
+    update({ filters: upsertFilter(state.filters, f), raw: "" });
+
+  const openTrace = (traceId: string) =>
+    update({ signal: "traces", trace: traceId });
+
+  return (
+    <div className="logsview">
+      <div className="querybar">
+        {state.raw === "" && !editingRaw && (
+          <>
+            <FilterChips
+              filters={state.filters}
+              labels={labels.data ?? []}
+              onChange={(filters) => update({ filters })}
+            />
+            <form
+              className="search-form"
+              onSubmit={(e) => {
+                e.preventDefault();
+                update({ search: searchDraft });
+              }}
+            >
+              <input
+                type="search"
+                className="search-input"
+                placeholder="Search in log lines…"
+                aria-label="Search in log lines"
+                value={searchDraft}
+                onChange={(e) => setSearchDraft(e.target.value)}
+              />
+            </form>
+          </>
+        )}
+        {(state.raw !== "" || editingRaw) && (
+          <form
+            className="raw-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              update({ raw: rawDraft });
+              setEditingRaw(false);
+            }}
+          >
+            <textarea
+              aria-label="LogQL query"
+              value={editingRaw ? rawDraft : state.raw}
+              rows={2}
+              onChange={(e) => {
+                setEditingRaw(true);
+                setRawDraft(e.target.value);
+              }}
+            />
+            <div className="raw-actions">
+              <button type="submit">Run</button>
+              <button
+                type="button"
+                onClick={() => {
+                  update({ raw: "" });
+                  setEditingRaw(false);
+                }}
+              >
+                Back to builder
+              </button>
+            </div>
+          </form>
+        )}
+        {state.raw === "" && !editingRaw && (
+          <button
+            className="qlmode"
+            title="Edit the compiled LogQL directly"
+            onClick={() => {
+              setRawDraft(logql);
+              setEditingRaw(true);
+            }}
+          >
+            {"{ } edit as text"}
+          </button>
+        )}
+      </div>
+
+      <div className="logs-body">
+        <FieldSidebar
+          labels={labels.data ?? []}
+          range={resolvedForStep}
+          rangeKey={rangeKey}
+          onAddFilter={addFilter}
+        />
+        <div className="logs-main">
+          {histogramQL !== null && (
+            <div className="histo-wrap">
+              <div className="histo-head">
+                <span className="histo-total">
+                  {logs.data ? `${logs.data.length} rows` : "…"}
+                  {logs.data && logs.data.length === state.limit
+                    ? ` (limit ${state.limit})`
+                    : ""}
+                </span>
+                {logs.isFetching && (
+                  <span className="histo-note">updating…</span>
+                )}
+              </div>
+              {histogram.data && <Histogram series={histogram.data} />}
+            </div>
+          )}
+          {logs.isError && (
+            <div className="query-error" role="alert">
+              Query failed: {(logs.error as Error).message}
+            </div>
+          )}
+          {logs.isPending && !logs.isError && (
+            <div className="loglist-empty">Loading…</div>
+          )}
+          {logs.data && (
+            <LogList
+              rows={logs.data}
+              onAddFilter={addFilter}
+              onOpenTrace={openTrace}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/features/logs/LogsView.tsx
+++ b/src/ui/src/features/logs/LogsView.tsx
@@ -7,7 +7,12 @@ import {
   upsertFilter,
   type LabelFilter,
 } from "../../lib/filters";
-import { rangeToParam, resolveRange, stepForRange } from "../../lib/time";
+import {
+  durationToSeconds,
+  rangeToParam,
+  resolveRange,
+  stepForRange,
+} from "../../lib/time";
 import type { ExploreState } from "../../lib/urlState";
 import { FieldSidebar } from "./FieldSidebar";
 import { FilterChips } from "./FilterChips";
@@ -162,7 +167,13 @@ export function LogsView({ state, update }: Props) {
                   <span className="histo-note">updating…</span>
                 )}
               </div>
-              {histogram.data && <Histogram series={histogram.data} />}
+              {histogram.data && (
+                <Histogram
+                  series={histogram.data}
+                  rangeMs={resolvedForStep}
+                  stepMs={(durationToSeconds(step) ?? 60) * 1000}
+                />
+              )}
             </div>
           )}
           {logs.isError && (

--- a/src/ui/src/features/metrics/MetricsChart.tsx
+++ b/src/ui/src/features/metrics/MetricsChart.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+import { seriesName, type PromSeries } from "../../api/prom";
+import { alignSeries, seriesColorVar } from "../../lib/promSeries";
+
+interface Props {
+  series: PromSeries[];
+  height?: number;
+}
+
+function cssColor(varExpr: string, el: HTMLElement): string {
+  const name = /var\((--[a-z0-9-]+)\)/i.exec(varExpr)?.[1];
+  if (!name) return varExpr;
+  return getComputedStyle(el).getPropertyValue(name).trim() || "#888";
+}
+
+export function MetricsChart({ series, height = 260 }: Props) {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || series.length === 0) return;
+
+    const data = alignSeries(series) as uPlot.AlignedData;
+    const make = () =>
+      new uPlot(
+        {
+          width: host.clientWidth || 800,
+          height,
+          // Timestamps are already in ms.
+          ms: 1,
+          series: [
+            {},
+            ...series.map((s, i) => ({
+              label: seriesName(s.labels),
+              stroke: cssColor(seriesColorVar(i), host),
+              width: 1.5,
+              points: { show: false },
+            })),
+          ],
+          axes: [
+            { stroke: cssColor("var(--dim)", host) },
+            { stroke: cssColor("var(--dim)", host) },
+          ],
+          legend: { show: false },
+        },
+        data,
+        host,
+      );
+
+    let plot = make();
+    const onResize = () => {
+      plot.destroy();
+      plot = make();
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      plot.destroy();
+    };
+  }, [series, height]);
+
+  return <div ref={hostRef} data-testid="metrics-chart" />;
+}

--- a/src/ui/src/features/metrics/MetricsView.test.tsx
+++ b/src/ui/src/features/metrics/MetricsView.test.tsx
@@ -1,0 +1,100 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_STATE, type ExploreState } from "../../lib/urlState";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { MetricsView } from "./MetricsView";
+
+// uPlot needs a real canvas; the chart wrapper is exercised as a stub and
+// the data pipeline is covered by prom/promSeries unit tests.
+vi.mock("./MetricsChart", () => ({
+  MetricsChart: ({ series }: { series: unknown[] }) => (
+    <div data-testid="metrics-chart">chart:{series.length}</div>
+  ),
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const MATRIX = {
+  status: "success",
+  data: {
+    resultType: "matrix",
+    result: [
+      {
+        metric: { __name__: "up", service_name: "checkout" },
+        values: [[1000, "1"]],
+      },
+      {
+        metric: { __name__: "up", service_name: "payments" },
+        values: [[1000, "0"]],
+      },
+    ],
+  },
+};
+
+function renderView(state: Partial<ExploreState> = {}) {
+  const update = vi.fn();
+  renderWithClient(
+    <MetricsView
+      state={{ ...DEFAULT_STATE, signal: "metrics", ...state }}
+      update={update}
+    />,
+  );
+  return update;
+}
+
+describe("MetricsView", () => {
+  it("prompts for a query when none is set", () => {
+    renderView();
+    expect(screen.getByText(/Enter a PromQL expression/)).toBeInTheDocument();
+  });
+
+  it("submits the drafted query via update", async () => {
+    stubFetchRoutes([{ match: "query_range", body: MATRIX }]);
+    const update = renderView();
+    await userEvent.type(screen.getByLabelText("PromQL query"), "up ");
+    await userEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(update).toHaveBeenCalledWith({ promql: "up" });
+  });
+
+  it("renders the chart and a legend entry per series", async () => {
+    stubFetchRoutes([{ match: "query_range", body: MATRIX }]);
+    renderView({ promql: "up" });
+    expect(await screen.findByTestId("metrics-chart")).toHaveTextContent(
+      "chart:2",
+    );
+    const legend = screen.getByRole("list", { name: "Series" });
+    expect(legend).toHaveTextContent('up{service_name="checkout"}');
+    expect(legend).toHaveTextContent('up{service_name="payments"}');
+  });
+
+  it("shows an empty state for zero series", async () => {
+    stubFetchRoutes([
+      {
+        match: "query_range",
+        body: { status: "success", data: { resultType: "matrix", result: [] } },
+      },
+    ]);
+    renderView({ promql: "up" });
+    expect(await screen.findByText("No series returned.")).toBeInTheDocument();
+  });
+
+  it("surfaces query errors", async () => {
+    stubFetchRoutes([
+      {
+        match: "query_range",
+        body: {
+          status: "error",
+          error: "unknown function foo",
+          data: { resultType: "matrix", result: [] },
+        },
+      },
+    ]);
+    renderView({ promql: "foo(up)" });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /unknown function foo/,
+    );
+  });
+});

--- a/src/ui/src/features/metrics/MetricsView.tsx
+++ b/src/ui/src/features/metrics/MetricsView.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 export function MetricsView({ state, update }: Props) {
   const [draft, setDraft] = useState(state.promql);
-  const rangeKey = rangeToParam(state.range);
+  const rangeKey = `${rangeToParam(state.range)}|${state.tenant}|${state.dataset}`;
   const promql = state.promql;
 
   const query = useQuery({

--- a/src/ui/src/features/metrics/MetricsView.tsx
+++ b/src/ui/src/features/metrics/MetricsView.tsx
@@ -1,0 +1,88 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { promQueryRange, seriesName } from "../../api/prom";
+import {
+  durationToSeconds,
+  rangeToParam,
+  resolveRange,
+  stepForRange,
+} from "../../lib/time";
+import type { ExploreState } from "../../lib/urlState";
+import { seriesColorVar } from "../../lib/promSeries";
+import { MetricsChart } from "./MetricsChart";
+import "./metrics.css";
+
+interface Props {
+  state: ExploreState;
+  update: (patch: Partial<ExploreState>) => void;
+}
+
+export function MetricsView({ state, update }: Props) {
+  const [draft, setDraft] = useState(state.promql);
+  const rangeKey = rangeToParam(state.range);
+  const promql = state.promql;
+
+  const query = useQuery({
+    queryKey: ["prom-range", promql, rangeKey],
+    queryFn: () => {
+      const range = resolveRange(state.range, Date.now());
+      const step = durationToSeconds(stepForRange(range, 120)) ?? 60;
+      return promQueryRange(promql, range, step);
+    },
+    enabled: promql.trim() !== "",
+    refetchInterval: state.live ? 15_000 : false,
+  });
+
+  return (
+    <div className="metricsview">
+      <form
+        className="promql-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          update({ promql: draft.trim() });
+        }}
+      >
+        <input
+          aria-label="PromQL query"
+          className="promql-input"
+          placeholder="PromQL, e.g. rate(http_server_duration_count[5m])"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button type="submit">Run</button>
+      </form>
+
+      {promql === "" && (
+        <div className="metrics-note">
+          Enter a PromQL expression to chart metrics.
+        </div>
+      )}
+      {query.isError && (
+        <div className="query-error" role="alert">
+          Query failed: {(query.error as Error).message}
+        </div>
+      )}
+      {query.isFetching && !query.data && (
+        <div className="metrics-note">Loading…</div>
+      )}
+      {query.data && query.data.length === 0 && (
+        <div className="metrics-note">No series returned.</div>
+      )}
+      {query.data && query.data.length > 0 && (
+        <>
+          <div className="mchart-wrap">
+            <MetricsChart series={query.data} />
+          </div>
+          <ul className="mlegend" aria-label="Series">
+            {query.data.map((s, i) => (
+              <li key={seriesName(s.labels)}>
+                <i style={{ background: seriesColorVar(i) }} />
+                {seriesName(s.labels)}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/features/metrics/metrics.css
+++ b/src/ui/src/features/metrics/metrics.css
@@ -1,0 +1,67 @@
+.metricsview {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.promql-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.promql-input {
+  flex: 1;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.promql-form button {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.metrics-note {
+  color: var(--faint);
+  padding: 14px 16px;
+  font-size: 12px;
+}
+
+.mchart-wrap {
+  padding: 14px 18px 4px;
+}
+
+.mlegend {
+  list-style: none;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  padding: 8px 18px 14px;
+  font-size: 11.5px;
+  color: var(--dim);
+  font-family: var(--mono);
+}
+
+.mlegend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mlegend i {
+  width: 14px;
+  height: 3px;
+  border-radius: 2px;
+  display: inline-block;
+}

--- a/src/ui/src/features/shell/TimeRangePicker.tsx
+++ b/src/ui/src/features/shell/TimeRangePicker.tsx
@@ -1,0 +1,37 @@
+import {
+  RANGE_PRESETS,
+  formatRangeLabel,
+  type TimeRange,
+} from "../../lib/time";
+
+interface Props {
+  range: TimeRange;
+  onChange: (range: TimeRange) => void;
+}
+
+export function TimeRangePicker({ range, onChange }: Props) {
+  const currentSeconds = range.type === "relative" ? range.seconds : null;
+  return (
+    <label className="time-picker">
+      <span className="visually-hidden">Time range</span>
+      <select
+        value={currentSeconds ?? "absolute"}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v !== "absolute") {
+            onChange({ type: "relative", seconds: Number(v) });
+          }
+        }}
+      >
+        {range.type === "absolute" && (
+          <option value="absolute">{formatRangeLabel(range)}</option>
+        )}
+        {RANGE_PRESETS.map((p) => (
+          <option key={p.seconds} value={p.seconds}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/ui/src/features/shell/TopBar.css
+++ b/src/ui/src/features/shell/TopBar.css
@@ -26,6 +26,57 @@
   font-weight: 600;
 }
 
+.topbar-sep {
+  color: var(--faint);
+}
+
+.tenant-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.tenant-chip:hover {
+  border-color: var(--dim);
+}
+
+.tenant-sep {
+  color: var(--faint);
+}
+
+.tenant-caret {
+  color: var(--faint);
+  font-size: 10px;
+}
+
+.tenant-form {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.tenant-form input {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 5px;
+  padding: 3px 8px;
+  font-size: 12px;
+  width: 130px;
+}
+
+.tenant-form button {
+  font-size: 12px;
+  color: var(--dim);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 9px;
+}
+
 .app-frame {
   display: flex;
   flex-direction: column;

--- a/src/ui/src/features/shell/TopBar.css
+++ b/src/ui/src/features/shell/TopBar.css
@@ -1,0 +1,46 @@
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.topbar-mark {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.topbar-mark svg {
+  display: block;
+}
+
+.topbar-mark b {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.app-frame {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--surface);
+}
+
+.app-main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.placeholder {
+  color: var(--dim);
+  padding: 24px;
+}

--- a/src/ui/src/features/shell/TopBar.tsx
+++ b/src/ui/src/features/shell/TopBar.tsx
@@ -1,0 +1,20 @@
+import "./TopBar.css";
+
+export function TopBar() {
+  return (
+    <header className="topbar">
+      <span className="topbar-mark">
+        <svg width="18" height="14" viewBox="0 0 18 14" fill="none" aria-hidden="true">
+          <path
+            d="M1 7 L4 7 L6 2 L9 12 L12 4 L13.5 7 L17 7"
+            stroke="var(--accent)"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        signal<b>db</b>
+      </span>
+    </header>
+  );
+}

--- a/src/ui/src/features/shell/TopBar.tsx
+++ b/src/ui/src/features/shell/TopBar.tsx
@@ -1,10 +1,24 @@
+import { useState } from "react";
+import { DEFAULT_DATASET, DEFAULT_TENANT } from "../../api/http";
+import type { ExploreState } from "../../lib/urlState";
 import "./TopBar.css";
 
-export function TopBar() {
+interface Props {
+  state: ExploreState;
+  update: (patch: Partial<ExploreState>) => void;
+}
+
+export function TopBar({ state, update }: Props) {
   return (
     <header className="topbar">
       <span className="topbar-mark">
-        <svg width="18" height="14" viewBox="0 0 18 14" fill="none" aria-hidden="true">
+        <svg
+          width="18"
+          height="14"
+          viewBox="0 0 18 14"
+          fill="none"
+          aria-hidden="true"
+        >
           <path
             d="M1 7 L4 7 L6 2 L9 12 L12 4 L13.5 7 L17 7"
             stroke="var(--accent)"
@@ -15,6 +29,62 @@ export function TopBar() {
         </svg>
         signal<b>db</b>
       </span>
+      <span className="topbar-sep">/</span>
+      <TenantSelector state={state} update={update} />
     </header>
+  );
+}
+
+function TenantSelector({ state, update }: Props) {
+  const [editing, setEditing] = useState(false);
+  const effectiveTenant = state.tenant || DEFAULT_TENANT;
+  const effectiveDataset = state.dataset || DEFAULT_DATASET;
+
+  if (!editing) {
+    return (
+      <button
+        className="tenant-chip"
+        title="Tenant / dataset context for all queries"
+        onClick={() => setEditing(true)}
+      >
+        {effectiveTenant || "tenant"}
+        <span className="tenant-sep">·</span>
+        {effectiveDataset || "default"}
+        <span className="tenant-caret">▾</span>
+      </button>
+    );
+  }
+
+  return (
+    <form
+      className="tenant-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const data = new FormData(e.currentTarget);
+        update({
+          tenant: String(data.get("tenant") ?? "").trim(),
+          dataset: String(data.get("dataset") ?? "").trim(),
+        });
+        setEditing(false);
+      }}
+    >
+      <input
+        name="tenant"
+        aria-label="Tenant"
+        placeholder="tenant"
+        defaultValue={state.tenant || DEFAULT_TENANT}
+        autoFocus
+      />
+      <input
+        name="dataset"
+        aria-label="Dataset"
+        placeholder="default dataset"
+        defaultValue={state.dataset || DEFAULT_DATASET}
+      />
+      <button type="submit">Apply</button>
+      <button type="button" onClick={() => setEditing(false)}>
+        Cancel
+      </button>
+    </form>
   );
 }

--- a/src/ui/src/features/traces/TracesView.test.tsx
+++ b/src/ui/src/features/traces/TracesView.test.tsx
@@ -1,0 +1,159 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_STATE, type ExploreState } from "../../lib/urlState";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { TracesView } from "./TracesView";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const SEARCH_BODY = {
+  traces: [
+    {
+      traceID: "t1cafe",
+      rootServiceName: "gateway",
+      rootTraceName: "POST /api/checkout",
+      startTimeUnixNano: "1700000000000000000",
+      durationMs: 412,
+    },
+  ],
+  metrics: {},
+};
+
+const TRACE_BODY = {
+  traceID: "t1cafe",
+  rootServiceName: "gateway",
+  rootTraceName: "POST /api/checkout",
+  startTimeUnixNano: "1000",
+  durationMs: 412,
+  spanSets: [
+    {
+      matched: 3,
+      spans: [
+        {
+          spanID: "root",
+          startTimeUnixNano: "1000000000",
+          durationNanos: "412000000",
+          name: "POST /api/checkout",
+          serviceName: "gateway",
+          status: "ok",
+          attributes: {},
+        },
+        {
+          spanID: "charge",
+          parentSpanID: "root",
+          startTimeUnixNano: "1040000000",
+          durationNanos: "258000000",
+          name: "charge",
+          serviceName: "payments",
+          status: "error",
+          attributes: {
+            "payment.provider": {
+              key: "payment.provider",
+              value: { stringValue: "stripe" },
+            },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+function renderView(state: Partial<ExploreState> = {}) {
+  const update = vi.fn();
+  renderWithClient(
+    <TracesView
+      state={{ ...DEFAULT_STATE, signal: "traces", ...state }}
+      update={update}
+    />,
+  );
+  return update;
+}
+
+describe("TracesView search", () => {
+  it("lists traces and opens one on click", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "POST /api/checkout" }),
+    );
+    expect(update).toHaveBeenCalledWith({ trace: "t1cafe" });
+  });
+
+  it("opens a trace by pasted id", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: { metrics: {} } }]);
+    const update = renderView();
+    await userEvent.type(screen.getByLabelText("Trace ID"), "  deadbeef  ");
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(update).toHaveBeenCalledWith({ trace: "deadbeef" });
+  });
+
+  it("surfaces search errors", async () => {
+    stubFetchRoutes([
+      { match: "/tempo/api/search", body: { error: "boom" }, status: 500 },
+    ]);
+    renderView();
+    expect(await screen.findByRole("alert")).toHaveTextContent(/500/);
+  });
+});
+
+describe("TracesView detail", () => {
+  it("renders the waterfall with the error span preselected", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/traces/t1cafe", body: TRACE_BODY }]);
+    renderView({ trace: "t1cafe" });
+    const spans = await screen.findAllByRole("listitem");
+    expect(spans).toHaveLength(2);
+    // Error span is preselected, so its attributes show in the detail panel.
+    expect(screen.getByText("payment.provider")).toBeInTheDocument();
+    expect(screen.getByText("stripe")).toBeInTheDocument();
+    expect(screen.getByText(/1 error/)).toBeInTheDocument();
+  });
+
+  it("selects a span on click and shows its details", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/traces/t1cafe", body: TRACE_BODY }]);
+    renderView({ trace: "t1cafe" });
+    const rows = await screen.findAllByRole("listitem");
+    await userEvent.click(rows[0]!);
+    expect(rows[0]).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByRole("heading", { name: "POST /api/checkout", level: 4 }),
+    ).toBeInTheDocument();
+  });
+
+  it("pivots to logs filtered by trace_id", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/traces/t1cafe", body: TRACE_BODY }]);
+    const update = renderView({ trace: "t1cafe" });
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Logs for this trace →" }),
+    );
+    expect(update).toHaveBeenCalledWith({
+      signal: "logs",
+      trace: "",
+      raw: "",
+      filters: [{ label: "trace_id", op: "=", value: "t1cafe" }],
+    });
+  });
+
+  it("navigates back to the search list", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/traces/t1cafe", body: TRACE_BODY }]);
+    const update = renderView({ trace: "t1cafe" });
+    await userEvent.click(
+      await screen.findByRole("button", { name: "← traces" }),
+    );
+    expect(update).toHaveBeenCalledWith({ trace: "" });
+  });
+
+  it("surfaces trace lookup failures", async () => {
+    stubFetchRoutes([
+      {
+        match: "/tempo/api/traces/missing",
+        body: { error: "not found" },
+        status: 404,
+      },
+    ]);
+    renderView({ trace: "missing" });
+    expect(await screen.findByRole("alert")).toHaveTextContent(/404/);
+  });
+});

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -1,0 +1,221 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { tempoGetTrace, tempoSearch, type TempoSpan } from "../../api/tempo";
+import {
+  formatTimestamp,
+  nanosToMs,
+  rangeToParam,
+  resolveRange,
+} from "../../lib/time";
+import type { ExploreState } from "../../lib/urlState";
+import { buildWaterfall, formatDurationMs } from "../../lib/waterfall";
+import "./traces.css";
+
+interface Props {
+  state: ExploreState;
+  update: (patch: Partial<ExploreState>) => void;
+}
+
+export function TracesView({ state, update }: Props) {
+  if (state.trace !== "") {
+    return <TraceDetail state={state} update={update} />;
+  }
+  return <TraceSearch state={state} update={update} />;
+}
+
+function TraceSearch({ state, update }: Props) {
+  const rangeKey = rangeToParam(state.range);
+  const search = useQuery({
+    queryKey: ["tempo-search", rangeKey, state.limit],
+    queryFn: () =>
+      tempoSearch(resolveRange(state.range, Date.now()), state.limit),
+  });
+
+  return (
+    <div className="traces-search">
+      <form
+        className="trace-id-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const id = new FormData(e.currentTarget).get("traceId");
+          if (typeof id === "string" && id.trim() !== "") {
+            update({ trace: id.trim() });
+          }
+        }}
+      >
+        <input
+          name="traceId"
+          aria-label="Trace ID"
+          placeholder="Open trace by ID…"
+        />
+        <button type="submit">Open</button>
+      </form>
+
+      {search.isError && (
+        <div className="query-error" role="alert">
+          Search failed: {(search.error as Error).message}
+        </div>
+      )}
+      {search.isPending && <div className="traces-note">Loading…</div>}
+      {search.data && search.data.length === 0 && (
+        <div className="traces-note">No traces in this time range.</div>
+      )}
+      {search.data && search.data.length > 0 && (
+        <table className="trace-table">
+          <thead>
+            <tr>
+              <th>Root</th>
+              <th>Service</th>
+              <th>Time</th>
+              <th className="num">Duration</th>
+              <th>Trace ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {search.data.map((t) => (
+              <tr key={t.traceId} onClick={() => update({ trace: t.traceId })}>
+                <td>
+                  <button className="trace-open">{t.rootTraceName}</button>
+                </td>
+                <td>{t.rootServiceName}</td>
+                <td>{formatTimestamp(nanosToMs(t.startNs))}</td>
+                <td className="num">{formatDurationMs(t.durationMs)}</td>
+                <td className="trace-id">{t.traceId}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function TraceDetail({ state, update }: Props) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const trace = useQuery({
+    queryKey: ["tempo-trace", state.trace],
+    queryFn: () => tempoGetTrace(state.trace),
+  });
+
+  if (trace.isError) {
+    return (
+      <div className="query-error" role="alert">
+        Trace lookup failed: {(trace.error as Error).message}
+      </div>
+    );
+  }
+  if (trace.isPending) return <div className="traces-note">Loading…</div>;
+
+  const waterfall = buildWaterfall(trace.data.spans);
+  const selectedRow =
+    waterfall.rows.find((r) => r.span.spanId === selected) ??
+    waterfall.rows.find((r) => r.span.status === "error") ??
+    waterfall.rows[0];
+
+  return (
+    <div className="traceview">
+      <div className="trace-head">
+        <button className="backbtn" onClick={() => update({ trace: "" })}>
+          ← traces
+        </button>
+        <h3>{trace.data.rootTraceName}</h3>
+        <span className="tmeta">
+          {formatDurationMs(trace.data.durationMs)} · {waterfall.rows.length}{" "}
+          spans · {waterfall.services.length} services
+          {waterfall.errorCount > 0 && (
+            <em className="tmeta-err"> · {waterfall.errorCount} error(s)</em>
+          )}
+        </span>
+        <span className="trace-id">{trace.data.traceId}</span>
+      </div>
+      <div className="trace-body">
+        <div className="waterfall" role="list" aria-label="Spans">
+          {waterfall.rows.map((row) => (
+            <button
+              key={row.span.spanId}
+              role="listitem"
+              className="span-row"
+              aria-selected={selectedRow?.span.spanId === row.span.spanId}
+              onClick={() => setSelected(row.span.spanId)}
+            >
+              <span
+                className="span-label"
+                style={{ paddingLeft: row.depth * 16 }}
+              >
+                <span className="span-svc">{row.span.serviceName}</span>
+                <span className="span-name">{row.span.name}</span>
+              </span>
+              <span className="span-track">
+                <span
+                  className={`span-bar${row.span.status === "error" ? " error" : ""}`}
+                  style={{
+                    left: `${row.leftPct}%`,
+                    width: `${row.widthPct}%`,
+                  }}
+                />
+              </span>
+              <span
+                className={`span-dur${row.span.status === "error" ? " error" : ""}`}
+              >
+                {formatDurationMs(row.durationMs)}
+              </span>
+            </button>
+          ))}
+        </div>
+        {selectedRow && (
+          <SpanDetail
+            span={selectedRow.span}
+            traceId={trace.data.traceId}
+            update={update}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SpanDetail({
+  span,
+  traceId,
+  update,
+}: {
+  span: TempoSpan;
+  traceId: string;
+  update: (patch: Partial<ExploreState>) => void;
+}) {
+  const attrs = Object.entries(span.attributes);
+  return (
+    <aside className="span-detail" aria-label="Span details">
+      <h4>{span.name}</h4>
+      <div className="span-detail-sub">
+        {span.serviceName}
+        {span.status === "error" && <em className="tmeta-err"> · error</em>}
+      </div>
+      <button
+        className="act act-primary"
+        onClick={() =>
+          update({
+            signal: "logs",
+            trace: "",
+            raw: "",
+            filters: [{ label: "trace_id", op: "=", value: traceId }],
+          })
+        }
+      >
+        Logs for this trace →
+      </button>
+      <div className="span-detail-sec">Attributes</div>
+      {attrs.length === 0 && (
+        <div className="traces-note">No attributes recorded.</div>
+      )}
+      <dl className="span-attrs">
+        {attrs.map(([k, v]) => (
+          <div key={k}>
+            <dt>{k}</dt>
+            <dd>{String(v)}</dd>
+          </div>
+        ))}
+      </dl>
+    </aside>
+  );
+}

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -16,6 +16,10 @@ interface Props {
   update: (patch: Partial<ExploreState>) => void;
 }
 
+function plural(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
 export function TracesView({ state, update }: Props) {
   if (state.trace !== "") {
     return <TraceDetail state={state} update={update} />;
@@ -120,10 +124,19 @@ function TraceDetail({ state, update }: Props) {
         </button>
         <h3>{trace.data.rootTraceName}</h3>
         <span className="tmeta">
-          {formatDurationMs(trace.data.durationMs)} · {waterfall.rows.length}{" "}
-          spans · {waterfall.services.length} services
+          {formatDurationMs(
+            // The search API truncates durationMs; span extents are exact.
+            trace.data.durationMs > 0
+              ? trace.data.durationMs
+              : Number(waterfall.traceDurationNs) / 1e6,
+          )}{" "}
+          · {plural(waterfall.rows.length, "span")} ·{" "}
+          {plural(waterfall.services.length, "service")}
           {waterfall.errorCount > 0 && (
-            <em className="tmeta-err"> · {waterfall.errorCount} error(s)</em>
+            <em className="tmeta-err">
+              {" "}
+              · {plural(waterfall.errorCount, "error")}
+            </em>
           )}
         </span>
         <span className="trace-id">{trace.data.traceId}</span>

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -24,7 +24,7 @@ export function TracesView({ state, update }: Props) {
 }
 
 function TraceSearch({ state, update }: Props) {
-  const rangeKey = rangeToParam(state.range);
+  const rangeKey = `${rangeToParam(state.range)}|${state.tenant}|${state.dataset}`;
   const search = useQuery({
     queryKey: ["tempo-search", rangeKey, state.limit],
     queryFn: () =>
@@ -93,7 +93,7 @@ function TraceSearch({ state, update }: Props) {
 function TraceDetail({ state, update }: Props) {
   const [selected, setSelected] = useState<string | null>(null);
   const trace = useQuery({
-    queryKey: ["tempo-trace", state.trace],
+    queryKey: ["tempo-trace", state.trace, state.tenant, state.dataset],
     queryFn: () => tempoGetTrace(state.trace),
   });
 

--- a/src/ui/src/features/traces/traces.css
+++ b/src/ui/src/features/traces/traces.css
@@ -1,0 +1,272 @@
+.traces-search {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+}
+
+.trace-id-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-id-form input {
+  flex: 0 1 340px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.trace-id-form button {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.traces-note {
+  color: var(--faint);
+  padding: 14px 16px;
+  font-size: 12px;
+}
+
+.trace-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 12px;
+}
+
+.trace-table th {
+  text-align: left;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--faint);
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 650;
+}
+
+.trace-table th.num,
+.trace-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.trace-table td {
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-table tbody tr {
+  cursor: pointer;
+}
+
+.trace-table tbody tr:hover {
+  background: var(--surface2);
+}
+
+.trace-open {
+  font-weight: 550;
+  color: var(--accent);
+}
+
+.trace-id {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--faint);
+}
+
+/* ---------- waterfall ---------- */
+
+.traceview {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.trace-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.trace-head h3 {
+  margin: 0;
+  font-size: 13.5px;
+  font-weight: 650;
+  font-family: var(--mono);
+}
+
+.backbtn {
+  color: var(--dim);
+  font-size: 12px;
+}
+
+.backbtn:hover {
+  color: var(--text);
+}
+
+.tmeta {
+  font-size: 11.5px;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.tmeta-err {
+  color: var(--err);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.trace-body {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 900px) {
+  .trace-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.waterfall {
+  border-right: 1px solid var(--border);
+  overflow: auto;
+  padding: 6px 0 10px;
+}
+
+.span-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  padding: 3px 16px 3px 12px;
+}
+
+.span-row:hover,
+.span-row[aria-selected="true"] {
+  background: var(--surface2);
+}
+
+.span-label {
+  flex: 0 0 300px;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 11px;
+  overflow: hidden;
+}
+
+.span-svc {
+  color: var(--faint);
+  flex: 0 0 auto;
+}
+
+.span-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.span-track {
+  flex: 1;
+  position: relative;
+  height: 15px;
+}
+
+.span-bar {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  border-radius: 3px;
+  background: var(--info-bar);
+  min-width: 3px;
+  opacity: 0.9;
+}
+
+.span-bar.error {
+  background: var(--err-bar);
+  outline: 1.5px solid var(--err);
+  outline-offset: 1px;
+}
+
+.span-dur {
+  flex: 0 0 64px;
+  text-align: right;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.span-dur.error {
+  color: var(--err);
+}
+
+/* ---------- span detail ---------- */
+
+.span-detail {
+  padding: 12px 14px;
+  overflow-y: auto;
+  font-size: 12px;
+}
+
+.span-detail h4 {
+  margin: 0 0 2px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.span-detail-sub {
+  color: var(--faint);
+  font-size: 11px;
+  margin-bottom: 10px;
+}
+
+.span-detail-sec {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--faint);
+  font-weight: 650;
+  margin: 14px 0 6px;
+}
+
+.span-attrs {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.span-attrs > div {
+  display: grid;
+  grid-template-columns: minmax(110px, max-content) 1fr;
+  gap: 0 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.span-attrs dt {
+  color: var(--dim);
+}
+
+.span-attrs dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}

--- a/src/ui/src/lib/filters.test.ts
+++ b/src/ui/src/lib/filters.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileHistogramQL,
+  compileLogQL,
+  compileSelector,
+  filterFromParam,
+  filterToParam,
+  MATCH_ALL_SELECTOR,
+  upsertFilter,
+  type LabelFilter,
+} from "./filters";
+
+const f = (
+  label: string,
+  op: LabelFilter["op"],
+  value: string,
+): LabelFilter => ({
+  label,
+  op,
+  value,
+});
+
+describe("compileSelector", () => {
+  it("compiles a match-all selector for no filters", () => {
+    expect(compileSelector([])).toBe(MATCH_ALL_SELECTOR);
+  });
+
+  it("compiles multiple matchers", () => {
+    expect(
+      compileSelector([
+        f("service_name", "=", "checkout"),
+        f("level", "!=", "debug"),
+      ]),
+    ).toBe('{service_name="checkout", level!="debug"}');
+  });
+
+  it("drops filters with invalid label names instead of emitting broken LogQL", () => {
+    expect(compileSelector([f("bad-label!", "=", "x")])).toBe(
+      MATCH_ALL_SELECTOR,
+    );
+  });
+
+  it("escapes quotes and backslashes in values", () => {
+    expect(compileSelector([f("path", "=", 'a"b\\c')])).toBe(
+      '{path="a\\"b\\\\c"}',
+    );
+  });
+});
+
+describe("compileLogQL", () => {
+  it("appends a line filter for search text", () => {
+    expect(
+      compileLogQL({ filters: [f("level", "=", "error")], search: "timeout" }),
+    ).toBe('{level="error"} |= "timeout"');
+  });
+
+  it("prefers the raw override verbatim", () => {
+    expect(
+      compileLogQL({
+        filters: [f("level", "=", "error")],
+        search: "x",
+        raw: '{service_name="api"} | json',
+      }),
+    ).toBe('{service_name="api"} | json');
+  });
+
+  it("ignores a whitespace-only raw override", () => {
+    expect(compileLogQL({ filters: [], search: "", raw: "  " })).toBe(
+      MATCH_ALL_SELECTOR,
+    );
+  });
+});
+
+describe("compileHistogramQL", () => {
+  it("wraps the log query in count_over_time grouped by level", () => {
+    expect(compileHistogramQL({ filters: [], search: "" }, "2m")).toBe(
+      `sum by (level) (count_over_time(${MATCH_ALL_SELECTOR} [2m]))`,
+    );
+  });
+
+  it("returns null for raw queries (may already be a metric query)", () => {
+    expect(
+      compileHistogramQL(
+        { filters: [], search: "", raw: "count_over_time(...)" },
+        "2m",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("filter URL params", () => {
+  it("round-trips every operator", () => {
+    for (const op of ["=", "!=", "=~", "!~"] as const) {
+      const filter = f("service_name", op, "check|out");
+      expect(filterFromParam(filterToParam(filter))).toEqual(filter);
+    }
+  });
+
+  it("rejects malformed params", () => {
+    expect(filterFromParam("no-separators")).toBeNull();
+    expect(filterFromParam("label|~|value")).toBeNull();
+    expect(filterFromParam("bad name|=|x")).toBeNull();
+  });
+
+  it("preserves empty values", () => {
+    expect(filterFromParam("l|=|")).toEqual(f("l", "=", ""));
+  });
+});
+
+describe("upsertFilter", () => {
+  it("replaces an existing filter with the same label and op", () => {
+    const out = upsertFilter(
+      [f("level", "=", "info")],
+      f("level", "=", "error"),
+    );
+    expect(out).toEqual([f("level", "=", "error")]);
+  });
+
+  it("appends when label or op differ", () => {
+    const out = upsertFilter(
+      [f("level", "=", "info")],
+      f("level", "!=", "debug"),
+    );
+    expect(out).toHaveLength(2);
+  });
+});

--- a/src/ui/src/lib/filters.ts
+++ b/src/ui/src/lib/filters.ts
@@ -1,0 +1,95 @@
+// Structured filter model and its LogQL compilation. Chips are the primary
+// input; "edit as text" switches the query to a raw LogQL string that takes
+// precedence until cleared.
+
+export type FilterOp = "=" | "!=" | "=~" | "!~";
+
+export interface LabelFilter {
+  label: string;
+  op: FilterOp;
+  value: string;
+}
+
+export interface LogQueryModel {
+  filters: LabelFilter[];
+  /** Case-sensitive line-contains match, compiled to `|= "…"`. */
+  search: string;
+  /** Raw LogQL override; when set it wins over filters + search. */
+  raw?: string;
+}
+
+export const FILTER_OPS: FilterOp[] = ["=", "!=", "=~", "!~"];
+
+const LABEL_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export function isValidLabelName(name: string): boolean {
+  return LABEL_RE.test(name);
+}
+
+export function escapeLogQLString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * LogQL requires at least one matcher in a selector; match everything via a
+ * non-empty regex on service_name (always present in SignalDB log streams).
+ */
+export const MATCH_ALL_SELECTOR = '{service_name=~".+"}';
+
+export function compileSelector(filters: LabelFilter[]): string {
+  const valid = filters.filter((f) => isValidLabelName(f.label));
+  if (valid.length === 0) return MATCH_ALL_SELECTOR;
+  const matchers = valid.map(
+    (f) => `${f.label}${f.op}"${escapeLogQLString(f.value)}"`,
+  );
+  return `{${matchers.join(", ")}}`;
+}
+
+export function compileLogQL(model: LogQueryModel): string {
+  if (model.raw && model.raw.trim() !== "") return model.raw.trim();
+  let q = compileSelector(model.filters);
+  if (model.search.trim() !== "") {
+    q += ` |= "${escapeLogQLString(model.search.trim())}"`;
+  }
+  return q;
+}
+
+/**
+ * Histogram companion query: log volume grouped by level. Only derivable for
+ * structured queries — a raw LogQL override may already be a metric query, so
+ * callers skip the histogram when `raw` is set.
+ */
+export function compileHistogramQL(
+  model: LogQueryModel,
+  step: string,
+): string | null {
+  if (model.raw && model.raw.trim() !== "") return null;
+  return `sum by (level) (count_over_time(${compileLogQL(model)} [${step}]))`;
+}
+
+/** URL serialization: one `f` param per filter, "label|op|value". */
+export function filterToParam(f: LabelFilter): string {
+  return `${f.label}|${f.op}|${f.value}`;
+}
+
+export function filterFromParam(param: string): LabelFilter | null {
+  const m = /^([^|]+)\|(=|!=|=~|!~)\|(.*)$/.exec(param);
+  if (!m) return null;
+  const label = m[1] ?? "";
+  if (!isValidLabelName(label)) return null;
+  return { label, op: m[2] as FilterOp, value: m[3] ?? "" };
+}
+
+/** Add or replace: an `=` filter on a label replaces an existing `=` filter. */
+export function upsertFilter(
+  filters: LabelFilter[],
+  next: LabelFilter,
+): LabelFilter[] {
+  const idx = filters.findIndex(
+    (f) => f.label === next.label && f.op === next.op,
+  );
+  if (idx === -1) return [...filters, next];
+  const copy = [...filters];
+  copy[idx] = next;
+  return copy;
+}

--- a/src/ui/src/lib/promSeries.test.ts
+++ b/src/ui/src/lib/promSeries.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { alignSeries, seriesColorVar } from "./promSeries";
+
+describe("alignSeries", () => {
+  it("aligns series onto a shared sorted time axis with null gaps", () => {
+    const data = alignSeries([
+      {
+        labels: {},
+        points: [
+          [1000, 1],
+          [3000, 3],
+        ],
+      },
+      {
+        labels: {},
+        points: [
+          [2000, 2],
+          [3000, 30],
+        ],
+      },
+    ]);
+    expect(data).toEqual([
+      [1000, 2000, 3000],
+      [1, null, 3],
+      [null, 2, 30],
+    ]);
+  });
+
+  it("returns just the axis for no series", () => {
+    expect(alignSeries([])).toEqual([[]]);
+  });
+});
+
+describe("seriesColorVar", () => {
+  it("cycles the palette", () => {
+    expect(seriesColorVar(0)).toBe("var(--accent)");
+    expect(seriesColorVar(6)).toBe("var(--accent)");
+    expect(seriesColorVar(1)).not.toBe(seriesColorVar(2));
+  });
+});

--- a/src/ui/src/lib/promSeries.ts
+++ b/src/ui/src/lib/promSeries.ts
@@ -1,0 +1,31 @@
+// Align Prometheus series onto a shared time axis for uPlot, which wants
+// columnar data: [timestamps, series1, series2, …] with null gaps.
+
+import type { PromSeries } from "../api/prom";
+
+export type AlignedData = [number[], ...(number | null)[][]];
+
+export function alignSeries(series: PromSeries[]): AlignedData {
+  const timestamps = [
+    ...new Set(series.flatMap((s) => s.points.map(([t]) => t))),
+  ].sort((a, b) => a - b);
+  const columns = series.map((s) => {
+    const byTime = new Map(s.points);
+    return timestamps.map((t) => byTime.get(t) ?? null);
+  });
+  return [timestamps, ...columns];
+}
+
+/** Cycle through the theme's categorical series colors. */
+export const SERIES_COLOR_VARS = [
+  "--accent",
+  "--info",
+  "--svc-b",
+  "--svc-c",
+  "--svc-e",
+  "--svc-d",
+] as const;
+
+export function seriesColorVar(index: number): string {
+  return `var(${SERIES_COLOR_VARS[index % SERIES_COLOR_VARS.length]})`;
+}

--- a/src/ui/src/lib/time.test.ts
+++ b/src/ui/src/lib/time.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RANGE,
+  durationToSeconds,
+  formatRangeLabel,
+  msToNanos,
+  nanosToMs,
+  parseRangeParam,
+  rangeToParam,
+  resolveRange,
+  secondsToDuration,
+  stepForRange,
+} from "./time";
+
+describe("resolveRange", () => {
+  it("resolves a relative range against now", () => {
+    const now = 1_000_000_000;
+    expect(resolveRange({ type: "relative", seconds: 60 }, now)).toEqual({
+      fromMs: now - 60_000,
+      toMs: now,
+    });
+  });
+
+  it("passes an absolute range through unchanged", () => {
+    const r = { type: "absolute", fromMs: 100, toMs: 200 } as const;
+    expect(resolveRange(r, 999)).toEqual({ fromMs: 100, toMs: 200 });
+  });
+});
+
+describe("nanosecond conversion", () => {
+  it("round-trips milliseconds through nanos", () => {
+    expect(msToNanos(1234)).toBe("1234000000");
+    expect(nanosToMs("1234000000")).toBe(1234);
+  });
+
+  it("handles realistic epoch timestamps without precision loss", () => {
+    const ms = 1_753_776_000_123;
+    expect(nanosToMs(msToNanos(ms))).toBe(ms);
+  });
+});
+
+describe("range URL params", () => {
+  it("round-trips relative ranges", () => {
+    const r = { type: "relative", seconds: 900 } as const;
+    expect(rangeToParam(r)).toBe("15m");
+    expect(parseRangeParam("15m")).toEqual(r);
+  });
+
+  it("round-trips absolute ranges", () => {
+    const r = { type: "absolute", fromMs: 1000, toMs: 2000 } as const;
+    expect(parseRangeParam(rangeToParam(r))).toEqual(r);
+  });
+
+  it("falls back to the default for garbage input", () => {
+    expect(parseRangeParam(null)).toEqual(DEFAULT_RANGE);
+    expect(parseRangeParam("banana")).toEqual(DEFAULT_RANGE);
+    expect(parseRangeParam("2000-1000")).toEqual(DEFAULT_RANGE);
+    expect(parseRangeParam("0m")).toEqual(DEFAULT_RANGE);
+  });
+});
+
+describe("durations", () => {
+  it("formats seconds to the largest clean unit", () => {
+    expect(secondsToDuration(45)).toBe("45s");
+    expect(secondsToDuration(300)).toBe("5m");
+    expect(secondsToDuration(7200)).toBe("2h");
+    expect(secondsToDuration(172800)).toBe("2d");
+  });
+
+  it("parses duration strings and rejects invalid ones", () => {
+    expect(durationToSeconds("90s")).toBe(90);
+    expect(durationToSeconds("3h")).toBe(10800);
+    expect(durationToSeconds("x")).toBeNull();
+    expect(durationToSeconds("1.5h")).toBeNull();
+  });
+});
+
+describe("stepForRange", () => {
+  it("targets roughly the requested bucket count", () => {
+    const step = stepForRange({ fromMs: 0, toMs: 3600_000 }, 45);
+    // 3600s / 45 = 80s → snaps up to 120s.
+    expect(step).toBe("2m");
+  });
+
+  it("never goes below one second", () => {
+    expect(stepForRange({ fromMs: 0, toMs: 1000 }, 45)).toBe("1s");
+  });
+});
+
+describe("formatRangeLabel", () => {
+  it("uses preset labels when available", () => {
+    expect(formatRangeLabel({ type: "relative", seconds: 3600 })).toBe(
+      "Last 1 h",
+    );
+  });
+
+  it("falls back to a duration for non-preset ranges", () => {
+    expect(formatRangeLabel({ type: "relative", seconds: 120 })).toBe(
+      "Last 2m",
+    );
+  });
+});

--- a/src/ui/src/lib/time.ts
+++ b/src/ui/src/lib/time.ts
@@ -1,0 +1,122 @@
+// Time-range model shared by every explore view. Relative ranges re-resolve
+// "now" on each query so live refreshes slide the window forward.
+
+export type TimeRange =
+  | { type: "relative"; seconds: number }
+  | { type: "absolute"; fromMs: number; toMs: number };
+
+export interface ResolvedRange {
+  fromMs: number;
+  toMs: number;
+}
+
+export const DEFAULT_RANGE: TimeRange = { type: "relative", seconds: 3600 };
+
+export const RANGE_PRESETS: { label: string; seconds: number }[] = [
+  { label: "Last 5 min", seconds: 300 },
+  { label: "Last 15 min", seconds: 900 },
+  { label: "Last 1 h", seconds: 3600 },
+  { label: "Last 6 h", seconds: 21600 },
+  { label: "Last 24 h", seconds: 86400 },
+  { label: "Last 7 d", seconds: 604800 },
+];
+
+export function resolveRange(range: TimeRange, nowMs: number): ResolvedRange {
+  if (range.type === "absolute") {
+    return { fromMs: range.fromMs, toMs: range.toMs };
+  }
+  return { fromMs: nowMs - range.seconds * 1000, toMs: nowMs };
+}
+
+/** Loki expects nanosecond timestamps as strings. */
+export function msToNanos(ms: number): string {
+  return (BigInt(Math.round(ms)) * 1_000_000n).toString();
+}
+
+export function nanosToMs(ns: string): number {
+  return Number(BigInt(ns) / 1_000_000n);
+}
+
+/**
+ * URL encoding for ranges: relative as a duration ("15m", "1h"), absolute as
+ * "fromMs-toMs". Round-trips through parseRangeParam.
+ */
+export function rangeToParam(range: TimeRange): string {
+  if (range.type === "absolute") {
+    return `${range.fromMs}-${range.toMs}`;
+  }
+  return secondsToDuration(range.seconds);
+}
+
+export function parseRangeParam(param: string | null): TimeRange {
+  if (!param) return DEFAULT_RANGE;
+  const abs = /^(\d+)-(\d+)$/.exec(param);
+  if (abs) {
+    const fromMs = Number(abs[1]);
+    const toMs = Number(abs[2]);
+    if (fromMs < toMs) return { type: "absolute", fromMs, toMs };
+    return DEFAULT_RANGE;
+  }
+  const seconds = durationToSeconds(param);
+  if (seconds !== null && seconds > 0) return { type: "relative", seconds };
+  return DEFAULT_RANGE;
+}
+
+export function secondsToDuration(seconds: number): string {
+  if (seconds % 86400 === 0) return `${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+export function durationToSeconds(value: string): number | null {
+  const m = /^(\d+)(s|m|h|d)$/.exec(value.trim());
+  if (!m) return null;
+  const n = Number(m[1]);
+  switch (m[2]) {
+    case "s":
+      return n;
+    case "m":
+      return n * 60;
+    case "h":
+      return n * 3600;
+    case "d":
+      return n * 86400;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Pick a histogram step that yields roughly `buckets` buckets, snapped to a
+ * human-friendly duration.
+ */
+export function stepForRange(range: ResolvedRange, buckets = 45): string {
+  const spanSeconds = Math.max(1, (range.toMs - range.fromMs) / 1000);
+  const raw = spanSeconds / buckets;
+  const steps = [
+    1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 21600,
+    43200, 86400,
+  ];
+  const step = steps.find((s) => s >= raw) ?? 86400;
+  return secondsToDuration(step);
+}
+
+export function formatTimestamp(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
+}
+
+export function formatRangeLabel(range: TimeRange): string {
+  if (range.type === "relative") {
+    const preset = RANGE_PRESETS.find((p) => p.seconds === range.seconds);
+    return preset ? preset.label : `Last ${secondsToDuration(range.seconds)}`;
+  }
+  const fmt = (ms: number) => {
+    const d = new Date(ms);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+  return `${fmt(range.fromMs)} → ${fmt(range.toMs)}`;
+}

--- a/src/ui/src/lib/urlState.test.ts
+++ b/src/ui/src/lib/urlState.test.ts
@@ -54,7 +54,18 @@ describe("buildSearch", () => {
       live: true,
       trace: "deadbeef",
       promql: "rate(x[5m])",
+      tenant: "acme",
+      dataset: "production",
     };
     expect(parseExploreState(buildSearch(state))).toEqual(state);
+  });
+
+  it("omits tenant params for the ambient default context", () => {
+    expect(buildSearch({ ...DEFAULT_STATE, signal: "traces" })).not.toContain(
+      "tenant",
+    );
+    const state = parseExploreState("?tenant=acme&dataset=prod");
+    expect(state.tenant).toBe("acme");
+    expect(state.dataset).toBe("prod");
   });
 });

--- a/src/ui/src/lib/urlState.test.ts
+++ b/src/ui/src/lib/urlState.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildSearch, DEFAULT_STATE, parseExploreState } from "./urlState";
+
+describe("parseExploreState", () => {
+  it("returns defaults for an empty search string", () => {
+    expect(parseExploreState("")).toEqual(DEFAULT_STATE);
+  });
+
+  it("parses a fully-populated URL", () => {
+    const state = parseExploreState(
+      "?signal=traces&range=15m&f=level%7C%3D%7Cerror&q=timeout&limit=100&live=1&trace=abc123&promql=up",
+    );
+    expect(state.signal).toBe("traces");
+    expect(state.range).toEqual({ type: "relative", seconds: 900 });
+    expect(state.filters).toEqual([
+      { label: "level", op: "=", value: "error" },
+    ]);
+    expect(state.search).toBe("timeout");
+    expect(state.limit).toBe(100);
+    expect(state.live).toBe(true);
+    expect(state.trace).toBe("abc123");
+    expect(state.promql).toBe("up");
+  });
+
+  it("ignores invalid signals, limits, and filters", () => {
+    const state = parseExploreState("?signal=bogus&limit=-5&f=not-a-filter");
+    expect(state.signal).toBe("logs");
+    expect(state.limit).toBe(500);
+    expect(state.filters).toEqual([]);
+  });
+
+  it("caps absurd limits", () => {
+    expect(parseExploreState("?limit=999999").limit).toBe(5000);
+  });
+});
+
+describe("buildSearch", () => {
+  it("emits nothing for the default state", () => {
+    expect(buildSearch(DEFAULT_STATE)).toBe("");
+  });
+
+  it("round-trips through parseExploreState", () => {
+    const state = {
+      ...DEFAULT_STATE,
+      signal: "metrics" as const,
+      range: { type: "absolute" as const, fromMs: 1000, toMs: 2000 },
+      filters: [
+        { label: "service_name", op: "=" as const, value: "checkout" },
+        { label: "level", op: "!=" as const, value: "debug" },
+      ],
+      search: "a b",
+      raw: '{x="y"}',
+      limit: 1000,
+      live: true,
+      trace: "deadbeef",
+      promql: "rate(x[5m])",
+    };
+    expect(parseExploreState(buildSearch(state))).toEqual(state);
+  });
+});

--- a/src/ui/src/lib/urlState.ts
+++ b/src/ui/src/lib/urlState.ts
@@ -24,6 +24,12 @@ export interface ExploreState {
   trace: string;
   /** PromQL expression for the metrics view. */
   promql: string;
+  /**
+   * Explicit tenant/dataset context. Empty means "ambient default": the dev
+   * proxy (or a future session) supplies it and no header is sent.
+   */
+  tenant: string;
+  dataset: string;
 }
 
 export const DEFAULT_STATE: ExploreState = {
@@ -36,6 +42,8 @@ export const DEFAULT_STATE: ExploreState = {
   live: false,
   trace: "",
   promql: "",
+  tenant: "",
+  dataset: "",
 };
 
 const SIGNALS: Signal[] = ["logs", "traces", "metrics"];
@@ -60,6 +68,8 @@ export function parseExploreState(search: string): ExploreState {
     live: p.get("live") === "1",
     trace: p.get("trace") ?? "",
     promql: p.get("promql") ?? "",
+    tenant: p.get("tenant") ?? "",
+    dataset: p.get("dataset") ?? "",
   };
 }
 
@@ -75,6 +85,8 @@ export function buildSearch(state: ExploreState): string {
   if (state.live) p.set("live", "1");
   if (state.trace) p.set("trace", state.trace);
   if (state.promql) p.set("promql", state.promql);
+  if (state.tenant) p.set("tenant", state.tenant);
+  if (state.dataset) p.set("dataset", state.dataset);
   const s = p.toString();
   return s === "" ? "" : `?${s}`;
 }

--- a/src/ui/src/lib/urlState.ts
+++ b/src/ui/src/lib/urlState.ts
@@ -1,0 +1,112 @@
+// Every explore view is a URL: signal, time range, filters, and options all
+// live in search params so views are deep-linkable and shareable.
+
+import { useCallback, useEffect, useState } from "react";
+import { filterFromParam, filterToParam, type LabelFilter } from "./filters";
+import {
+  DEFAULT_RANGE,
+  parseRangeParam,
+  rangeToParam,
+  type TimeRange,
+} from "./time";
+
+export type Signal = "logs" | "traces" | "metrics";
+
+export interface ExploreState {
+  signal: Signal;
+  range: TimeRange;
+  filters: LabelFilter[];
+  search: string;
+  raw: string;
+  limit: number;
+  live: boolean;
+  /** Selected trace id — opens the trace view. */
+  trace: string;
+  /** PromQL expression for the metrics view. */
+  promql: string;
+}
+
+export const DEFAULT_STATE: ExploreState = {
+  signal: "logs",
+  range: DEFAULT_RANGE,
+  filters: [],
+  search: "",
+  raw: "",
+  limit: 500,
+  live: false,
+  trace: "",
+  promql: "",
+};
+
+const SIGNALS: Signal[] = ["logs", "traces", "metrics"];
+
+export function parseExploreState(search: string): ExploreState {
+  const p = new URLSearchParams(search);
+  const signalParam = p.get("signal");
+  const signal = SIGNALS.includes(signalParam as Signal)
+    ? (signalParam as Signal)
+    : "logs";
+  const limit = Number(p.get("limit"));
+  return {
+    signal,
+    range: parseRangeParam(p.get("range")),
+    filters: p
+      .getAll("f")
+      .map(filterFromParam)
+      .filter((f): f is LabelFilter => f !== null),
+    search: p.get("q") ?? "",
+    raw: p.get("raw") ?? "",
+    limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 5000) : 500,
+    live: p.get("live") === "1",
+    trace: p.get("trace") ?? "",
+    promql: p.get("promql") ?? "",
+  };
+}
+
+export function buildSearch(state: ExploreState): string {
+  const p = new URLSearchParams();
+  if (state.signal !== "logs") p.set("signal", state.signal);
+  const rangeParam = rangeToParam(state.range);
+  if (rangeParam !== rangeToParam(DEFAULT_RANGE)) p.set("range", rangeParam);
+  for (const f of state.filters) p.append("f", filterToParam(f));
+  if (state.search) p.set("q", state.search);
+  if (state.raw) p.set("raw", state.raw);
+  if (state.limit !== 500) p.set("limit", String(state.limit));
+  if (state.live) p.set("live", "1");
+  if (state.trace) p.set("trace", state.trace);
+  if (state.promql) p.set("promql", state.promql);
+  const s = p.toString();
+  return s === "" ? "" : `?${s}`;
+}
+
+/**
+ * URL-backed state. Updates use replaceState (queries as you refine are one
+ * history entry); browser back/forward still works across externally
+ * navigated URLs via popstate.
+ */
+export function useExploreState(): [
+  ExploreState,
+  (patch: Partial<ExploreState>) => void,
+] {
+  const [state, setState] = useState<ExploreState>(() =>
+    parseExploreState(window.location.search),
+  );
+
+  useEffect(() => {
+    const onPop = () => setState(parseExploreState(window.location.search));
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const update = useCallback((patch: Partial<ExploreState>) => {
+    setState((prev) => {
+      const next = { ...prev, ...patch };
+      const search = buildSearch(next);
+      const url = `${window.location.pathname}${search}`;
+      window.history.replaceState(null, "", url);
+      return next;
+    });
+  }, []);
+
+  return [state, update];
+}

--- a/src/ui/src/lib/waterfall.test.ts
+++ b/src/ui/src/lib/waterfall.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { TempoSpan } from "../api/tempo";
+import { buildWaterfall, formatDurationMs } from "./waterfall";
+
+const span = (over: Partial<TempoSpan>): TempoSpan => ({
+  spanId: "s",
+  parentSpanId: null,
+  name: "op",
+  serviceName: "svc",
+  status: "ok",
+  startNs: "0",
+  durNs: "1000000",
+  attributes: {},
+  ...over,
+});
+
+describe("buildWaterfall", () => {
+  it("orders rows depth-first with children under parents", () => {
+    const rows = buildWaterfall([
+      span({ spanId: "child-late", parentSpanId: "root", startNs: "500" }),
+      span({ spanId: "root", startNs: "0", durNs: "1000" }),
+      span({ spanId: "child-early", parentSpanId: "root", startNs: "100" }),
+      span({
+        spanId: "grandchild",
+        parentSpanId: "child-early",
+        startNs: "150",
+      }),
+    ]).rows;
+    expect(rows.map((r) => r.span.spanId)).toEqual([
+      "root",
+      "child-early",
+      "grandchild",
+      "child-late",
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 2, 1]);
+  });
+
+  it("treats spans with missing parents as roots", () => {
+    const rows = buildWaterfall([
+      span({ spanId: "orphan", parentSpanId: "not-in-payload" }),
+      span({ spanId: "root" }),
+    ]).rows;
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.depth === 0)).toBe(true);
+  });
+
+  it("computes bar geometry as fractions of the trace duration", () => {
+    const { rows } = buildWaterfall([
+      span({ spanId: "root", startNs: "1000000000", durNs: "1000000000" }),
+      span({
+        spanId: "half",
+        parentSpanId: "root",
+        startNs: "1500000000",
+        durNs: "250000000",
+      }),
+    ]);
+    const half = rows.find((r) => r.span.spanId === "half")!;
+    expect(half.leftPct).toBeCloseTo(50, 1);
+    expect(half.widthPct).toBeCloseTo(25, 1);
+    expect(half.startOffsetMs).toBeCloseTo(500);
+    expect(half.durationMs).toBeCloseTo(250);
+  });
+
+  it("handles nanosecond timestamps beyond float precision", () => {
+    const base = 1_753_776_000_123_456_789n;
+    const { rows, traceDurationNs } = buildWaterfall([
+      span({ spanId: "a", startNs: String(base), durNs: "2000000" }),
+      span({
+        spanId: "b",
+        parentSpanId: "a",
+        startNs: String(base + 1_000_000n),
+        durNs: "1000000",
+      }),
+    ]);
+    expect(traceDurationNs).toBe(2_000_000n);
+    expect(rows.find((r) => r.span.spanId === "b")!.leftPct).toBeCloseTo(50, 1);
+  });
+
+  it("counts errors and collects services", () => {
+    const wf = buildWaterfall([
+      span({ spanId: "a", serviceName: "gateway" }),
+      span({ spanId: "b", serviceName: "payments", status: "error" }),
+      span({ spanId: "c", serviceName: "payments" }),
+    ]);
+    expect(wf.errorCount).toBe(1);
+    expect(wf.services.sort()).toEqual(["gateway", "payments"]);
+  });
+
+  it("returns an empty waterfall for no spans", () => {
+    expect(buildWaterfall([]).rows).toEqual([]);
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("chooses sensible units", () => {
+    expect(formatDurationMs(2500)).toBe("2.50 s");
+    expect(formatDurationMs(412)).toBe("412 ms");
+    expect(formatDurationMs(4.2)).toBe("4.2 ms");
+    expect(formatDurationMs(0.25)).toBe("250 µs");
+  });
+});

--- a/src/ui/src/lib/waterfall.ts
+++ b/src/ui/src/lib/waterfall.ts
@@ -1,0 +1,98 @@
+// Pure waterfall geometry: order spans depth-first by start time and compute
+// per-span offsets as fractions of the trace duration.
+
+import type { TempoSpan } from "../api/tempo";
+
+export interface WaterfallRow {
+  span: TempoSpan;
+  depth: number;
+  /** Bar offset/size as percentages of the trace duration. */
+  leftPct: number;
+  widthPct: number;
+  startOffsetMs: number;
+  durationMs: number;
+}
+
+export interface Waterfall {
+  rows: WaterfallRow[];
+  traceStartNs: bigint;
+  traceDurationNs: bigint;
+  errorCount: number;
+  services: string[];
+}
+
+export function buildWaterfall(spans: TempoSpan[]): Waterfall {
+  if (spans.length === 0) {
+    return {
+      rows: [],
+      traceStartNs: 0n,
+      traceDurationNs: 0n,
+      errorCount: 0,
+      services: [],
+    };
+  }
+
+  const byId = new Map(spans.map((s) => [s.spanId, s]));
+  const children = new Map<string, TempoSpan[]>();
+  const roots: TempoSpan[] = [];
+  for (const span of spans) {
+    // Spans whose parent is missing from the payload render as roots so a
+    // partial trace still produces a usable waterfall.
+    const parent = span.parentSpanId;
+    if (parent !== null && byId.has(parent)) {
+      const list = children.get(parent) ?? [];
+      list.push(span);
+      children.set(parent, list);
+    } else {
+      roots.push(span);
+    }
+  }
+
+  const byStart = (a: TempoSpan, b: TempoSpan) =>
+    BigInt(a.startNs) < BigInt(b.startNs) ? -1 : 1;
+
+  let start = BigInt(spans[0]!.startNs);
+  let end = start;
+  for (const s of spans) {
+    const sStart = BigInt(s.startNs);
+    const sEnd = sStart + BigInt(s.durNs);
+    if (sStart < start) start = sStart;
+    if (sEnd > end) end = sEnd;
+  }
+  const total = end - start > 0n ? end - start : 1n;
+
+  const rows: WaterfallRow[] = [];
+  const visit = (span: TempoSpan, depth: number) => {
+    const offset = BigInt(span.startNs) - start;
+    const dur = BigInt(span.durNs);
+    // Per-mille precision is plenty for bar geometry.
+    const leftPct = Number((offset * 1000n) / total) / 10;
+    const widthPct = Math.max(0.3, Number((dur * 1000n) / total) / 10);
+    rows.push({
+      span,
+      depth,
+      leftPct,
+      widthPct,
+      startOffsetMs: Number(offset / 1000n) / 1000,
+      durationMs: Number(dur / 1000n) / 1000,
+    });
+    for (const child of (children.get(span.spanId) ?? []).sort(byStart)) {
+      visit(child, depth + 1);
+    }
+  };
+  for (const root of roots.sort(byStart)) visit(root, 0);
+
+  return {
+    rows,
+    traceStartNs: start,
+    traceDurationNs: total,
+    errorCount: spans.filter((s) => s.status === "error").length,
+    services: [...new Set(spans.map((s) => s.serviceName))],
+  };
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)} s`;
+  if (ms >= 1) return `${ms.toFixed(ms < 10 ? 1 : 0)} ms`;
+  return `${(ms * 1000).toFixed(0)} µs`;
+}

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -1,0 +1,24 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles/global.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Observability queries are time-window scoped; refetching on focus
+      // would silently shift results under the user.
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/src/ui/src/styles/global.css
+++ b/src/ui/src/styles/global.css
@@ -1,0 +1,158 @@
+/* SignalDB UI design tokens. Light is the base; dark overrides arrive via
+   prefers-color-scheme and can be forced either way with data-theme. */
+:root {
+  --bg: #f2f3f6;
+  --surface: #ffffff;
+  --surface2: #e9ecf1;
+  --surface3: #dfe3ea;
+  --border: #d3d8e0;
+  --text: #1c222b;
+  --dim: #5d6675;
+  --faint: #8b93a2;
+  --accent: #c25a0a;
+  --accent-soft: rgba(194, 90, 10, 0.12);
+  --err: #c43a42;
+  --warn: #96760c;
+  --info: #2f66c9;
+  --debug: #7a8494;
+  --err-bar: #d8555c;
+  --warn-bar: #d9b83e;
+  --info-bar: #6f95dd;
+  --debug-bar: #aab2bf;
+  --ok: #2c9070;
+  --svc-a: #2f66c9;
+  --svc-b: #2c9070;
+  --svc-c: #8a56c9;
+  --svc-d: #b08a10;
+  --svc-e: #c04f8a;
+  --mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+    monospace;
+  --ui: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1014;
+    --surface: #14181e;
+    --surface2: #1a202a;
+    --surface3: #222a36;
+    --border: #29303c;
+    --text: #e4e8ef;
+    --dim: #8b94a3;
+    --faint: #626b7a;
+    --accent: #f58a3c;
+    --accent-soft: rgba(245, 138, 60, 0.14);
+    --err: #f2555a;
+    --warn: #e4c452;
+    --info: #6f9cf0;
+    --debug: #78818f;
+    --err-bar: #d84a50;
+    --warn-bar: #cfa93a;
+    --info-bar: #4a72c2;
+    --debug-bar: #414b5a;
+    --ok: #46b58a;
+    --svc-a: #6f9cf0;
+    --svc-b: #46b58a;
+    --svc-c: #b183e6;
+    --svc-d: #e4c452;
+    --svc-e: #e070a8;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #0d1014;
+  --surface: #14181e;
+  --surface2: #1a202a;
+  --surface3: #222a36;
+  --border: #29303c;
+  --text: #e4e8ef;
+  --dim: #8b94a3;
+  --faint: #626b7a;
+  --accent: #f58a3c;
+  --accent-soft: rgba(245, 138, 60, 0.14);
+  --err: #f2555a;
+  --warn: #e4c452;
+  --info: #6f9cf0;
+  --debug: #78818f;
+  --err-bar: #d84a50;
+  --warn-bar: #cfa93a;
+  --info-bar: #4a72c2;
+  --debug-bar: #414b5a;
+  --ok: #46b58a;
+  --svc-a: #6f9cf0;
+  --svc-b: #46b58a;
+  --svc-c: #b183e6;
+  --svc-d: #e4c452;
+  --svc-e: #e070a8;
+}
+
+:root[data-theme="light"] {
+  --bg: #f2f3f6;
+  --surface: #ffffff;
+  --surface2: #e9ecf1;
+  --surface3: #dfe3ea;
+  --border: #d3d8e0;
+  --text: #1c222b;
+  --dim: #5d6675;
+  --faint: #8b93a2;
+  --accent: #c25a0a;
+  --accent-soft: rgba(194, 90, 10, 0.12);
+  --err: #c43a42;
+  --warn: #96760c;
+  --info: #2f66c9;
+  --debug: #7a8494;
+  --err-bar: #d8555c;
+  --warn-bar: #d9b83e;
+  --info-bar: #6f95dd;
+  --debug-bar: #aab2bf;
+  --ok: #2c9070;
+  --svc-a: #2f66c9;
+  --svc-b: #2c9070;
+  --svc-c: #8a56c9;
+  --svc-d: #b08a10;
+  --svc-e: #c04f8a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--ui);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+input,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 3px;
+}

--- a/src/ui/src/test/render.tsx
+++ b/src/ui/src/test/render.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { vi } from "vitest";
+
+export function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+type JsonRoute = { match: string | RegExp; body: unknown; status?: number };
+
+/**
+ * Stub global fetch with URL-matched JSON routes. Later routes win when
+ * multiple match; unmatched URLs 404 so tests fail loudly on unexpected
+ * requests.
+ */
+export function stubFetchRoutes(routes: JsonRoute[]) {
+  const fn = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input);
+    const route = [...routes]
+      .reverse()
+      .find((r) =>
+        typeof r.match === "string" ? url.includes(r.match) : r.match.test(url),
+      );
+    if (!route) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: `no stub for ${url}` }), {
+          status: 404,
+        }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(route.body), {
+        status: route.status ?? 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+export const emptyStreams = {
+  status: "success",
+  data: { resultType: "streams", result: [] },
+};
+
+export const emptyMatrix = {
+  status: "success",
+  data: { resultType: "matrix", result: [] },
+};
+
+export const emptyLabels = { status: "success", data: [] };
+
+export function logsResponse(
+  rows: {
+    tsNs: string;
+    line: string;
+    labels: Record<string, string>;
+  }[],
+) {
+  return {
+    status: "success",
+    data: {
+      resultType: "streams",
+      result: rows.map((r) => ({
+        stream: r.labels,
+        values: [[r.tsNs, r.line]],
+      })),
+    },
+  };
+}

--- a/src/ui/src/test/setup.ts
+++ b/src/ui/src/test/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/ui/src/test/setup.ts
+++ b/src/ui/src/test/setup.ts
@@ -68,3 +68,19 @@ class ResizeObserverStub implements ResizeObserver {
 }
 
 globalThis.ResizeObserver = globalThis.ResizeObserver ?? ResizeObserverStub;
+
+// jsdom has no matchMedia; uPlot queries it at module load for pixel-ratio
+// tracking.
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}

--- a/src/ui/src/test/setup.ts
+++ b/src/ui/src/test/setup.ts
@@ -5,3 +5,66 @@ import { afterEach } from "vitest";
 afterEach(() => {
   cleanup();
 });
+
+// jsdom reports zero layout sizes, which makes @tanstack/react-virtual render
+// an empty window. Give scroll containers a plausible size so virtualized
+// lists materialize rows in component tests.
+Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+  configurable: true,
+  get() {
+    return 800;
+  },
+});
+Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+  configurable: true,
+  get() {
+    return 1200;
+  },
+});
+Element.prototype.getBoundingClientRect = function () {
+  return {
+    width: 1200,
+    height: 800,
+    top: 0,
+    left: 0,
+    bottom: 800,
+    right: 1200,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+};
+
+// jsdom has no ResizeObserver; @tanstack/react-virtual needs one to learn the
+// scroll container's size. Report the stubbed rect once on observe.
+class ResizeObserverStub implements ResizeObserver {
+  private readonly cb: ResizeObserverCallback;
+
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+
+  observe(target: Element) {
+    const rect = target.getBoundingClientRect();
+    this.cb(
+      [
+        {
+          target,
+          contentRect: rect,
+          borderBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+          contentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+          devicePixelContentBoxSize: [
+            { inlineSize: rect.width, blockSize: rect.height },
+          ],
+        } as ResizeObserverEntry,
+      ],
+      this,
+    );
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? ResizeObserverStub;

--- a/src/ui/src/vite-env.d.ts
+++ b/src/ui/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+// Injected via `define` in vite.config.ts from SIGNALDB_TENANT/_DATASET.
+declare const __SIGNALDB_DEFAULT_TENANT__: string | undefined;
+declare const __SIGNALDB_DEFAULT_DATASET__: string | undefined;

--- a/src/ui/tsconfig.json
+++ b/src/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -1,0 +1,51 @@
+/// <reference types="vitest/config" />
+import react from "@vitejs/plugin-react";
+import { defineConfig, loadEnv, type ProxyOptions } from "vite";
+
+// Paths the SignalDB router serves; the dev server forwards them to a live
+// instance so the browser only ever sees same-origin requests, exactly as in
+// the embedded production build.
+const PROXIED_PATHS = ["/loki", "/tempo", "/prometheus", "/api"];
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, __dirname, "SIGNALDB_");
+  const target = env.SIGNALDB_TARGET || "http://localhost:3000";
+
+  // Auth is injected by the proxy from .env.local so API keys never reach
+  // browser code during development.
+  const headers: Record<string, string> = {};
+  if (env.SIGNALDB_API_KEY)
+    headers["Authorization"] = `Bearer ${env.SIGNALDB_API_KEY}`;
+  if (env.SIGNALDB_TENANT) headers["X-Tenant-ID"] = env.SIGNALDB_TENANT;
+  if (env.SIGNALDB_DATASET) headers["X-Dataset-ID"] = env.SIGNALDB_DATASET;
+
+  const proxy = Object.fromEntries(
+    PROXIED_PATHS.map((path): [string, ProxyOptions] => [
+      path,
+      {
+        target,
+        changeOrigin: true,
+        // Dev-only proxy: accept self-signed certs on homelab targets.
+        secure: false,
+        headers,
+      },
+    ]),
+  );
+
+  return {
+    plugins: [react()],
+    // Served by the router under /ui/ in production.
+    base: "/ui/",
+    server: { port: 5173, proxy },
+    test: {
+      environment: "jsdom",
+      setupFiles: "./src/test/setup.ts",
+      css: false,
+      coverage: {
+        provider: "v8",
+        include: ["src/**/*.{ts,tsx}"],
+        exclude: ["src/main.tsx", "src/test/**", "src/**/*.d.ts"],
+      },
+    },
+  };
+});

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -11,14 +11,6 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "SIGNALDB_");
   const target = env.SIGNALDB_TARGET || "http://localhost:3000";
 
-  // Auth is injected by the proxy from .env.local so API keys never reach
-  // browser code during development.
-  const headers: Record<string, string> = {};
-  if (env.SIGNALDB_API_KEY)
-    headers["Authorization"] = `Bearer ${env.SIGNALDB_API_KEY}`;
-  if (env.SIGNALDB_TENANT) headers["X-Tenant-ID"] = env.SIGNALDB_TENANT;
-  if (env.SIGNALDB_DATASET) headers["X-Dataset-ID"] = env.SIGNALDB_DATASET;
-
   const proxy = Object.fromEntries(
     PROXIED_PATHS.map((path): [string, ProxyOptions] => [
       path,
@@ -27,7 +19,25 @@ export default defineConfig(({ mode }) => {
         changeOrigin: true,
         // Dev-only proxy: accept self-signed certs on homelab targets.
         secure: false,
-        headers,
+        configure(proxyServer) {
+          proxyServer.on("proxyReq", (proxyReq, req) => {
+            // The API key never reaches browser code; always injected here.
+            if (env.SIGNALDB_API_KEY) {
+              proxyReq.setHeader(
+                "Authorization",
+                `Bearer ${env.SIGNALDB_API_KEY}`,
+              );
+            }
+            // Tenant context: the UI's selector sends its own headers; the
+            // env values are only defaults for requests without them.
+            if (!req.headers["x-tenant-id"] && env.SIGNALDB_TENANT) {
+              proxyReq.setHeader("X-Tenant-ID", env.SIGNALDB_TENANT);
+            }
+            if (!req.headers["x-dataset-id"] && env.SIGNALDB_DATASET) {
+              proxyReq.setHeader("X-Dataset-ID", env.SIGNALDB_DATASET);
+            }
+          });
+        },
       },
     ]),
   );
@@ -36,6 +46,11 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     // Served by the router under /ui/ in production.
     base: "/ui/",
+    // Surface the dev defaults so the tenant selector can display them.
+    define: {
+      __SIGNALDB_DEFAULT_TENANT__: JSON.stringify(env.SIGNALDB_TENANT ?? ""),
+      __SIGNALDB_DEFAULT_DATASET__: JSON.stringify(env.SIGNALDB_DATASET ?? ""),
+    },
     server: { port: 5173, proxy },
     test: {
       environment: "jsdom",


### PR DESCRIPTION
## Summary

Adds a native explore UI (`src/ui`, Vite + React + TS) served by the router at `/ui`, consuming the existing Loki/Tempo/Prometheus compat APIs — so the UI doubles as a daily-driven test of the compat surface, and anything it shows is equally reachable from Grafana.

**Views**
- **Logs**: filter chips compiled to LogQL (raw-text escape hatch), per-level volume histogram, virtualized log list with per-attribute filter/exclude, fields sidebar on the labels endpoints, 2s-poll live tail
- **Traces**: recent-trace search + open-by-ID, waterfall with span detail panel and error highlighting
- **Metrics**: PromQL box charting `query_range` via uPlot
- **Correlation**: log rows with `trace_id` pivot to the waterfall; span panel pivots back to logs filtered by trace
- Every view is a URL (time range, filters, selection in query params)

**Backend changes**
- Router serves `SIGNALDB_UI_DIR` at `/ui` with SPA fallback; unset → placeholder page, set-but-invalid → startup failure (fail-hard by design)
- Docker: `ui-builder` node stage; router + monolithic images ship the UI preinstalled, and a failed UI build fails the image build
- tempo-api: spanset spans gain optional `name`/`parentSpanID`/`serviceName`/`status` intrinsics (skip-if-none; needed to reconstruct the hierarchy client-side)

**Dev loop**
- `pnpm ui:dev`: Vite HMR with a proxy that forwards `/loki` `/tempo` `/prometheus` `/api` to `SIGNALDB_TARGET` and injects tenant auth headers from `.env.local` — develop against run-dev.sh or any live instance without CORS changes; API keys never reach browser code
- Pre-commit hook now gates per staged toolchain (UI-only commits skip the clippy pass; UI commits get typecheck+lint)
- CI: `UI` job wired into the `changes` filter skipped-not-filtered; UI-only PRs skip Rust jobs

## Testing

- 102 vitest tests (16 files): unit coverage for the time-range model, LogQL compilation, URL state, waterfall geometry (hierarchy, orphans, bigint timestamps), series alignment, and all three API clients incl. error paths; component tests for chips, histogram, log list, sidebar, and all three views
- 5 router tests for `/ui` serving semantics (index, assets, SPA fallback, invalid-dir error)
- Verified end-to-end: monolithic binary with `SIGNALDB_UI_DIR` serves index/assets/deep links at `:3000/ui/`

## Docs

New `docs/users/explore-ui.md`; updates to the Tempo API reference, dokku guide, architecture overview, and tempo-api/architecture skills.