### PR TITLE
fix(router): empty query results and error bodies on the query surfaces

### DIFF
--- a/docs/users/logql-reference.md
+++ b/docs/users/logql-reference.md
@@ -33,15 +33,15 @@ APIs (see [Authentication](authentication.md)):
 
 ## Endpoints
 
-| Endpoint | Status |
-|----------|--------|
-| `GET /loki/api/v1/query_range` | Range query. Returns a **streams** result for log queries, a **matrix** for metric queries |
-| `GET /loki/api/v1/query` | Instant query. Returns the most recent lines over a one-hour window ending at `time` (log queries only) |
-| `GET /loki/api/v1/labels` | Label names available in the window |
-| `GET /loki/api/v1/label/{name}/values` | Distinct values of one label |
-| `GET /loki/api/v1/series` | Series (label sets) matching a selector |
-| `GET /loki/api/v1/detected_fields` | Discover attribute fields in a window: name, inferred type, approximate cardinality (samples the data; no declaration or indexing needed) |
-| `GET /loki/api/v1/tail` | Not implemented — live tail is tracked separately |
+| Endpoint                               | Status                                                                                                                                    |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /loki/api/v1/query_range`         | Range query. Returns a **streams** result for log queries, a **matrix** for metric queries                                                |
+| `GET /loki/api/v1/query`               | Instant query. Returns the most recent lines over a one-hour window ending at `time` (log queries only)                                   |
+| `GET /loki/api/v1/labels`              | Label names available in the window                                                                                                       |
+| `GET /loki/api/v1/label/{name}/values` | Distinct values of one label                                                                                                              |
+| `GET /loki/api/v1/series`              | Series (label sets) matching a selector                                                                                                   |
+| `GET /loki/api/v1/detected_fields`     | Discover attribute fields in a window: name, inferred type, approximate cardinality (samples the data; no declaration or indexing needed) |
+| `GET /loki/api/v1/tail`                | Not implemented — live tail is tracked separately                                                                                         |
 
 Common query parameters: `query` (the LogQL string), `start`/`end`
 (unix nanoseconds, unix seconds, or RFC3339), `limit`, `direction`
@@ -53,13 +53,13 @@ Common query parameters: `query` (the LogQL string), `start`/`end`
 SignalDB stores logs in columnar form, not as free-form label sets. LogQL
 labels resolve as follows:
 
-| LogQL label | Resolves to |
-|-------------|-------------|
-| `service_name`, `service`, `job` | the `service_name` column |
-| `level`, `severity`, `detected_level` | the `severity_text` column |
-| `trace_id`, `span_id` | the matching columns |
-| a **materialized** label (see below) | its dedicated `label_<key>` column |
-| any other label | the `log_attributes` / `resource_attributes` maps |
+| LogQL label                           | Resolves to                                       |
+| ------------------------------------- | ------------------------------------------------- |
+| `service_name`, `service`, `job`      | the `service_name` column                         |
+| `level`, `severity`, `detected_level` | the `severity_text` column                        |
+| `trace_id`, `span_id`                 | the matching columns                              |
+| a **materialized** label (see below)  | its dedicated `label_<key>` column                |
+| any other label                       | the `log_attributes` / `resource_attributes` maps |
 
 Labels backed by a column are exact. On tables created since attributes
 became typed maps, **any other label is also exact**: the value is looked
@@ -204,7 +204,7 @@ sum by (level) (rate({service_name="api"}[5m]))
 
 ### Time bucketing — the key approximation
 
-Loki evaluates a range aggregation over a *sliding* `[range]` window at
+Loki evaluates a range aggregation over a _sliding_ `[range]` window at
 each step. SignalDB instead buckets into **fixed, step-aligned windows**
 with `date_bin(step, timestamp)`. This is **exact when `step` equals the
 range** (Grafana's default for `count_over_time` panels) and an
@@ -242,10 +242,27 @@ curl -G 'http://localhost:3000/loki/api/v1/query_range' \
   --data-urlencode 'step=5m'
 ```
 
+## Errors
+
+Failures return a JSON body in the Prometheus/Loki error shape:
+
+```json
+{
+  "status": "error",
+  "errorType": "bad_data",
+  "error": "expected matcher operator, found end of input at line 1, column 10"
+}
+```
+
+`errorType` is `bad_data` (400), `not_found` (404), `rate_limited` (429),
+`timeout` (504), `unavailable` (503, no querier), `not_implemented` (501),
+or `internal` (500). A query that matches nothing is not an error — it
+returns `200` with an empty `result` array.
+
 ## Query-demand statistics
 
 Attribute labels used in filters (any label that is not a dedicated
-column) are counted as *query demand* and flushed to the catalog's
+column) are counted as _query demand_ and flushed to the catalog's
 advisory `attribute_stats` table, where they inform which attributes are
 worth materializing (see the storage layout docs on materialized labels).
 

--- a/docs/users/profiles.md
+++ b/docs/users/profiles.md
@@ -79,13 +79,13 @@ profiles_enabled = false
 
 The router serves a Pyroscope-compatible surface under `/pyroscope`:
 
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /pyroscope/render` | Flamegraph for a query and time range |
-| `GET /pyroscope/render-diff` | Differential flamegraph between two ranges |
-| `GET /pyroscope/profile-types` | Available profile types |
-| `GET /pyroscope/label-names` | Label discovery (reads JSON-string or map-typed attribute tables) |
-| `GET /pyroscope/label-values?label=…` | Values for one label |
+| Endpoint                              | Purpose                                                           |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| `GET /pyroscope/render`               | Flamegraph for a query and time range                             |
+| `GET /pyroscope/render-diff`          | Differential flamegraph between two ranges                        |
+| `GET /pyroscope/profile-types`        | Available profile types                                           |
+| `GET /pyroscope/label-names`          | Label discovery (reads JSON-string or map-typed attribute tables) |
+| `GET /pyroscope/label-values?label=…` | Values for one label                                              |
 
 Queries use Pyroscope selector syntax; time bounds accept unix seconds,
 unix milliseconds, or `now-1h` style expressions:
@@ -95,7 +95,9 @@ GET /pyroscope/render?query=cpu{service_name="checkout"}&from=now-1h&until=now
 ```
 
 The response is a flamebearer document that Grafana's flamegraph panel
-(and the bundled SignalDB datasource plugin) renders directly.
+(and the bundled SignalDB datasource plugin) renders directly. A window
+with no matching profiles returns an empty flamegraph with HTTP 200, not
+an error.
 
 ### SQL
 

--- a/src/router/src/endpoints/api_error.rs
+++ b/src/router/src/endpoints/api_error.rs
@@ -1,0 +1,110 @@
+//! JSON error responses for the query HTTP surfaces.
+//!
+//! Loki- and Prometheus-style clients expect failures as
+//! `{"status":"error","errorType":"...","error":"..."}`; a bare status code
+//! with an empty body leaves UIs nothing to display.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+/// An HTTP error with a client-visible message.
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, message)
+    }
+
+    /// Map a querier Flight status to an HTTP error, preserving its message.
+    pub fn from_flight(status: &tonic::Status, what: &str) -> Self {
+        let code = match status.code() {
+            tonic::Code::NotFound => StatusCode::NOT_FOUND,
+            tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+            tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+            tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+            tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+            tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+            _ => {
+                tracing::error!(error = %status, query_kind = what, "Flight query failed");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        Self::new(code, status.message().to_string())
+    }
+
+    fn error_type(&self) -> &'static str {
+        match self.status {
+            StatusCode::BAD_REQUEST => "bad_data",
+            StatusCode::NOT_FOUND => "not_found",
+            StatusCode::TOO_MANY_REQUESTS => "rate_limited",
+            StatusCode::GATEWAY_TIMEOUT => "timeout",
+            StatusCode::SERVICE_UNAVAILABLE => "unavailable",
+            StatusCode::NOT_IMPLEMENTED => "not_implemented",
+            _ => "internal",
+        }
+    }
+}
+
+/// Statuses raised without further context keep their canonical reason as
+/// the message, so `?` on existing `StatusCode` sites stays valid.
+impl From<StatusCode> for ApiError {
+    fn from(status: StatusCode) -> Self {
+        let message = status
+            .canonical_reason()
+            .unwrap_or("request failed")
+            .to_string();
+        Self { status, message }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = Json(json!({
+            "status": "error",
+            "errorType": self.error_type(),
+            "error": self.message,
+        }));
+        (self.status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carries_message_and_error_type() {
+        let err = ApiError::bad_request("parse error at line 1");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.error_type(), "bad_data");
+        assert_eq!(err.message, "parse error at line 1");
+    }
+
+    #[test]
+    fn from_flight_preserves_the_querier_message() {
+        let status = tonic::Status::invalid_argument("unknown label foo");
+        let err = ApiError::from_flight(&status, "logs");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.message, "unknown label foo");
+    }
+
+    #[test]
+    fn from_status_code_uses_the_canonical_reason() {
+        let err = ApiError::from(StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.message, "Service Unavailable");
+        assert_eq!(err.error_type(), "unavailable");
+    }
+}

--- a/src/router/src/endpoints/flight_decode.rs
+++ b/src/router/src/endpoints/flight_decode.rs
@@ -1,0 +1,70 @@
+//! Shared decoding of querier Flight responses for the HTTP query endpoints.
+//!
+//! A query whose result set is empty produces a well-formed empty Flight
+//! stream: zero messages, not even a schema frame. `flight_data_to_batches`
+//! errors on that ("Need at least one FlightData for schema"), so every
+//! endpoint must treat no-frames as "no rows" rather than a decode failure.
+
+use arrow_flight::FlightData;
+use arrow_flight::utils::flight_data_to_batches;
+use axum::http::StatusCode;
+use datafusion::arrow::record_batch::RecordBatch;
+
+/// Decode collected Flight frames into record batches. Zero frames is a
+/// valid empty result. `what` names the query kind in the error log.
+pub(crate) fn decode_flight_batches(
+    data: &[FlightData],
+    what: &str,
+) -> Result<Vec<RecordBatch>, StatusCode> {
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+    flight_data_to_batches(data).map_err(|e| {
+        tracing::error!(error = %e, query_kind = what, "Failed to decode Flight data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_flight::utils::batches_to_flight_data;
+    use datafusion::arrow::array::StringArray;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn sample_batch() -> (Arc<Schema>, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["a", "b"]))],
+        )
+        .expect("batch");
+        (schema, batch)
+    }
+
+    #[test]
+    fn empty_stream_decodes_to_no_batches() {
+        let batches = decode_flight_batches(&[], "logs").expect("empty is valid");
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn frames_decode_to_batches() {
+        let (schema, batch) = sample_batch();
+        let data = batches_to_flight_data(&schema, vec![batch]).expect("encode");
+        let batches = decode_flight_batches(&data, "logs").expect("decode");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
+    }
+
+    #[test]
+    fn garbage_frames_are_a_500() {
+        let bogus = FlightData {
+            data_body: vec![1, 2, 3].into(),
+            ..Default::default()
+        };
+        let err = decode_flight_batches(&[bogus], "logs").expect_err("must fail");
+        assert_eq!(err, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 
 use crate::RouterState;
-use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use arrow_flight::Ticket;
 use axum::{
     Router,
     extract::{Path, Query, State},
@@ -550,10 +550,7 @@ async fn execute_ticket<S: RouterState>(
         data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
     }
 
-    flight_data_to_batches(&data).map_err(|e| {
-        tracing::error!(error = %e, "Failed to decode log Flight data");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })
+    super::flight_decode::decode_flight_batches(&data, "logs")
 }
 
 fn flight_status_to_http(status: &tonic::Status) -> StatusCode {

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 
+use super::api_error::ApiError;
 use crate::RouterState;
 use arrow_flight::Ticket;
 use axum::{
@@ -104,20 +105,22 @@ pub struct MetadataParams {
 
 /// Reject requests without a `query` parameter, mirroring Loki's
 /// "empty query" error status.
-fn require_query(query: &Option<String>) -> Result<String, StatusCode> {
+fn require_query(query: &Option<String>) -> Result<String, ApiError> {
     query
         .as_deref()
         .map(str::trim)
         .filter(|q| !q.is_empty())
         .map(str::to_string)
-        .ok_or(StatusCode::BAD_REQUEST)
+        .ok_or_else(|| ApiError::bad_request("missing or empty 'query' parameter"))
 }
 
 /// Validate the `direction` parameter.
-fn validate_direction(direction: &str) -> Result<(), StatusCode> {
+fn validate_direction(direction: &str) -> Result<(), ApiError> {
     match direction {
         "forward" | "backward" => Ok(()),
-        _ => Err(StatusCode::BAD_REQUEST),
+        _ => Err(ApiError::bad_request(
+            "invalid 'direction': expected 'forward' or 'backward'",
+        )),
     }
 }
 
@@ -138,7 +141,7 @@ pub async fn query<S: RouterState>(
     State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<InstantQueryParams>,
-) -> Result<axum::Json<QueryResponse>, StatusCode> {
+) -> Result<axum::Json<QueryResponse>, ApiError> {
     let logql = require_query(&params.query)?;
     validate_direction(&params.direction)?;
 
@@ -171,7 +174,7 @@ pub async fn query_range<S: RouterState>(
     State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<RangeQueryParams>,
-) -> Result<axum::Json<QueryResponse>, StatusCode> {
+) -> Result<axum::Json<QueryResponse>, ApiError> {
     let logql = require_query(&params.query)?;
     validate_direction(&params.direction)?;
 
@@ -215,7 +218,7 @@ pub async fn labels<S: RouterState>(
     State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<MetadataParams>,
-) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+) -> Result<axum::Json<LabelsResponse>, ApiError> {
     let (start, end) = metadata_window(&params);
     let ticket = format!(
         "query_logs_labels:{}:{}:{start}:{end}",
@@ -241,9 +244,9 @@ pub async fn label_values<S: RouterState>(
     tenant_ctx: TenantContextExtractor,
     Path(name): Path<String>,
     Query(params): Query<MetadataParams>,
-) -> Result<axum::Json<LabelsResponse>, StatusCode> {
+) -> Result<axum::Json<LabelsResponse>, ApiError> {
     if name.trim().is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
+        return Err(ApiError::bad_request("label name must not be empty"));
     }
     let (start, end) = metadata_window(&params);
     let ticket = format!(
@@ -268,7 +271,7 @@ pub async fn series<S: RouterState>(
     State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<MetadataParams>,
-) -> Result<axum::Json<SeriesResponse>, StatusCode> {
+) -> Result<axum::Json<SeriesResponse>, ApiError> {
     let selector = params
         .matcher
         .as_deref()
@@ -318,7 +321,7 @@ pub async fn detected_fields<S: RouterState>(
     State(state): State<S>,
     tenant_ctx: TenantContextExtractor,
     Query(params): Query<DetectedFieldsParams>,
-) -> Result<axum::Json<DetectedFieldsResponse>, StatusCode> {
+) -> Result<axum::Json<DetectedFieldsResponse>, ApiError> {
     let meta = MetadataParams {
         start: params.start.clone(),
         end: params.end.clone(),
@@ -364,7 +367,7 @@ async fn run_log_query<S: RouterState>(
     end: i64,
     limit: u32,
     direction: &str,
-) -> Result<Vec<Stream>, StatusCode> {
+) -> Result<Vec<Stream>, ApiError> {
     let payload = serde_json::json!({
         "query": logql,
         "start": start,
@@ -395,7 +398,7 @@ async fn run_metric_query<S: RouterState>(
     start: i64,
     end: i64,
     step: i64,
-) -> Result<Vec<loki_api::MetricSeries>, StatusCode> {
+) -> Result<Vec<loki_api::MetricSeries>, ApiError> {
     let payload = serde_json::json!({
         "query": logql,
         "start": start,
@@ -522,14 +525,17 @@ fn default_step_ns(start: i64, end: i64) -> i64 {
 async fn execute_ticket<S: RouterState>(
     state: &S,
     ticket_content: String,
-) -> Result<Vec<RecordBatch>, StatusCode> {
+) -> Result<Vec<RecordBatch>, ApiError> {
     let mut client = state
         .service_registry()
         .get_flight_client_for_capability(ServiceCapability::QueryExecution)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to get Flight client for log query");
-            StatusCode::SERVICE_UNAVAILABLE
+            ApiError::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no querier service available",
+            )
         })?;
 
     let ticket = Ticket::new(ticket_content);
@@ -542,30 +548,15 @@ async fn execute_ticket<S: RouterState>(
     let mut stream = client
         .do_get(flight_request)
         .await
-        .map_err(|e| flight_status_to_http(&e))?
+        .map_err(|e| ApiError::from_flight(&e, "logs"))?
         .into_inner();
 
     let mut data = Vec::new();
     while let Some(flight_data) = stream.next().await {
-        data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
+        data.push(flight_data.map_err(|e| ApiError::from_flight(&e, "logs"))?);
     }
 
-    super::flight_decode::decode_flight_batches(&data, "logs")
-}
-
-fn flight_status_to_http(status: &tonic::Status) -> StatusCode {
-    match status.code() {
-        tonic::Code::NotFound => StatusCode::NOT_FOUND,
-        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
-        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
-        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
-        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
-        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
-        _ => {
-            tracing::error!(error = %status, "Log Flight query failed");
-            StatusCode::INTERNAL_SERVER_ERROR
-        }
-    }
+    super::flight_decode::decode_flight_batches(&data, "logs").map_err(ApiError::from)
 }
 
 /// Group the projected log rows into Loki streams by their label set,

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod flight;
+mod flight_decode;
 pub mod logql;
 pub mod promql;
 pub mod pyroscope;

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod api_error;
 pub mod flight;
 mod flight_decode;
 pub mod logql;

--- a/src/router/src/endpoints/promql.rs
+++ b/src/router/src/endpoints/promql.rs
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 
 use crate::RouterState;
-use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use arrow_flight::Ticket;
 use axum::{
     Router,
     extract::{Path, Query, State},
@@ -255,17 +255,7 @@ async fn execute_ticket<S: RouterState>(
         data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
     }
 
-    // An empty result is a well-formed empty stream (no schema frame). Return
-    // no batches rather than letting `flight_data_to_batches` error on it — a
-    // query whose window contains no data must yield an empty vector/matrix.
-    if data.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    flight_data_to_batches(&data).map_err(|e| {
-        tracing::error!(error = %e, "Failed to decode PromQL Flight data");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })
+    super::flight_decode::decode_flight_batches(&data, "promql")
 }
 
 fn flight_status_to_http(status: &tonic::Status) -> StatusCode {

--- a/src/router/src/endpoints/pyroscope.rs
+++ b/src/router/src/endpoints/pyroscope.rs
@@ -12,7 +12,7 @@
 //! the JSON results into `pyroscope-api` types.
 
 use crate::RouterState;
-use arrow_flight::{Ticket, utils::flight_data_to_batches};
+use arrow_flight::Ticket;
 use axum::{
     Router,
     extract::{Query, State},
@@ -202,10 +202,7 @@ async fn execute_ticket<S: RouterState>(
         data.push(flight_data.map_err(|e| flight_status_to_http(&e))?);
     }
 
-    flight_data_to_batches(&data).map_err(|e| {
-        tracing::error!(error = %e, "Failed to decode profile Flight data");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })
+    super::flight_decode::decode_flight_batches(&data, "profiles")
 }
 
 fn flight_status_to_http(status: &tonic::Status) -> StatusCode {


### PR DESCRIPTION
Two contract fixes on the router's HTTP query surfaces, both found via the explore UI field audit (#769, finding 1).

## Empty Flight streams are valid empty results

A query with zero matching rows produces a well-formed empty Flight stream — zero frames, not even a schema — which `flight_data_to_batches` rejects. Net effect: **every zero-result LogQL or Pyroscope query returned an empty-body 500** (e.g. the UI's trace→logs pivot, or any `|=` filter matching nothing). The PromQL endpoint already guarded this; the guard is now a shared `decode_flight_batches` helper used by logql, promql, and pyroscope.

Corrected diagnosis vs. the original issue text: `trace_id`/`span_id` selectors were lowering correctly all along (dedicated columns; unmaterialized labels fall back to typed-map/JSON matching). The 500 was purely this decode gap.

## JSON error bodies on the Loki surface

logql handlers returned bare status codes with empty bodies. They now return `{"status":"error","errorType":"...","error":"..."}` via a new `ApiError`, preserving the querier's Flight status message — a LogQL parse error reaches the client as e.g. `expected matcher operator, found end of input at line 1, column 10`.

## Testing

- Unit tests for `decode_flight_batches` (empty → no batches, frames → batches, garbage → 500) and `ApiError` (message/errorType mapping, Flight-status preservation, canonical-reason fallback).
- Verified live against a dev stack: no-match line filters and trace-id selectors return 200 with `"result":[]`; malformed LogQL returns 400 with the parser message; invalid `direction` returns 400 with a hint.

Refs #769.