### PR TITLE
feat: embedded UI session auth + tenant-scoped whoami

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -70,7 +70,7 @@ Key details:
    - `/loki` (LogQL, epic #366): `LogsService` executes log queries (streams) and metric queries (`rate`/`count_over_time`/`sum by`, `date_bin` bucketed matrix); `LogsService` also backs `/loki` labels/values/series and `detected_fields` (sampled attribute-field discovery: name, inferred type, approx cardinality — epic #737 L3).
    - `/prometheus` (PromQL, epic #328): `MetricsService` executes selectors, `sum/avg/min/max/count [by]`, and `rate`/`increase` over `metrics_gauge`+`metrics_sum` (`date_bin` bucketed matrix), plus `histogram_quantile(phi, metric)` interpolated from `metrics_histogram` OTLP buckets; `MetricsService` also backs `/prometheus` labels/values/series. `histogram_quantile` over an inner `rate()`, binary ops, and `topk` remain pending (#335).
    - `/pyroscope` (profiles) via `ProfileService`.
-7. Router serves the explore UI (static SPA from `src/ui`) at `/ui` from the directory named by `SIGNALDB_UI_DIR` (`src/router/src/ui.rs`); unset -> placeholder page, set-but-invalid -> startup failure. Container images ship the assets preinstalled.
+7. Router serves the explore UI (static SPA from `src/ui`) at `/ui` from the directory named by `SIGNALDB_UI_DIR` (`src/router/src/ui.rs`); unset -> placeholder page, set-but-invalid -> startup failure. Container images ship the assets preinstalled. Browser auth: `POST/DELETE /ui/session` (`src/router/src/endpoints/session.rs`) sets/clears an HttpOnly `signaldb_session` cookie the auth middleware accepts in place of auth headers; `GET /api/v1/whoami` returns the authenticated tenant + datasets.
 
 ## Service Components
 

--- a/.claude/skills/crate-map/SKILL.md
+++ b/.claude/skills/crate-map/SKILL.md
@@ -10,126 +10,127 @@ sources:
 
 ## Workspace Members
 
-| Crate | Path | Type | Description |
-|-------|------|------|-------------|
-| **common** | `src/common/` | Library | Shared everything: config, auth, WAL, Flight, catalog, schema, storage |
-| **acceptor** | `src/acceptor/` | Binary + Library | OTLP gRPC/HTTP ingestion endpoint |
-| **writer** | `src/writer/` | Binary + Library | Iceberg-based data persistence (the "Ingester") |
-| **router** | `src/router/` | Binary + Library | HTTP API gateway + Flight routing layer |
-| **querier** | `src/querier/` | Binary + Library | DataFusion query execution engine |
-| **compactor** | `src/compactor/` | Binary + Library | Complete data lifecycle: compaction planning/execution (Phase 1-2), retention enforcement, snapshot expiration, orphan cleanup (Phase 3); binary is `signaldb-compactor` |
-| **pyroscope-api** | `src/pyroscope-api/` | Library | Pyroscope-compatible API types (flamebearer, profile types) |
-| **tempo-api** | `src/tempo-api/` | Library | Grafana Tempo API types and protobuf definitions |
-| **loki-api** | `src/loki-api/` | Library | Loki HTTP API response types (LogQL query surface) |
-| **prometheus-api** | `src/prometheus-api/` | Library | Prometheus HTTP API response types (PromQL query surface) |
-| **signaldb-bin** | `src/signaldb-bin/` | Binary | Monolithic mode runner (all services in one process) |
-| **signaldb-api** | `src/signaldb-api/` | Library | OpenAPI-generated admin API types |
-| **signaldb-cli** | `src/signaldb-cli/` | Binary | CLI for tenant, API key, dataset management |
-| **signaldb-sdk** | `src/signaldb-sdk/` | Library | Generated SDK client |
-| **grafana-plugin** | `src/grafana-plugin/` | Plugin | Grafana datasource (TypeScript frontend + Rust backend); the backend is a standalone cargo workspace, not a root workspace member |
-| **signal-producer** | `src/signal-producer/` | Binary | Test data generator (OTLP traces) |
-| **tests-integration** | `tests-integration/` | Test crate | End-to-end integration tests |
-| **xtask** | `xtask/` | Binary | Build automation tasks |
+| Crate                 | Path                   | Type             | Description                                                                                                                                                              |
+| --------------------- | ---------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **common**            | `src/common/`          | Library          | Shared everything: config, auth, WAL, Flight, catalog, schema, storage                                                                                                   |
+| **acceptor**          | `src/acceptor/`        | Binary + Library | OTLP gRPC/HTTP ingestion endpoint                                                                                                                                        |
+| **writer**            | `src/writer/`          | Binary + Library | Iceberg-based data persistence (the "Ingester")                                                                                                                          |
+| **router**            | `src/router/`          | Binary + Library | HTTP API gateway + Flight routing layer                                                                                                                                  |
+| **querier**           | `src/querier/`         | Binary + Library | DataFusion query execution engine                                                                                                                                        |
+| **compactor**         | `src/compactor/`       | Binary + Library | Complete data lifecycle: compaction planning/execution (Phase 1-2), retention enforcement, snapshot expiration, orphan cleanup (Phase 3); binary is `signaldb-compactor` |
+| **pyroscope-api**     | `src/pyroscope-api/`   | Library          | Pyroscope-compatible API types (flamebearer, profile types)                                                                                                              |
+| **tempo-api**         | `src/tempo-api/`       | Library          | Grafana Tempo API types and protobuf definitions                                                                                                                         |
+| **loki-api**          | `src/loki-api/`        | Library          | Loki HTTP API response types (LogQL query surface)                                                                                                                       |
+| **prometheus-api**    | `src/prometheus-api/`  | Library          | Prometheus HTTP API response types (PromQL query surface)                                                                                                                |
+| **signaldb-bin**      | `src/signaldb-bin/`    | Binary           | Monolithic mode runner (all services in one process)                                                                                                                     |
+| **signaldb-api**      | `src/signaldb-api/`    | Library          | OpenAPI-generated admin API types                                                                                                                                        |
+| **signaldb-cli**      | `src/signaldb-cli/`    | Binary           | CLI for tenant, API key, dataset management                                                                                                                              |
+| **signaldb-sdk**      | `src/signaldb-sdk/`    | Library          | Generated SDK client                                                                                                                                                     |
+| **grafana-plugin**    | `src/grafana-plugin/`  | Plugin           | Grafana datasource (TypeScript frontend + Rust backend); the backend is a standalone cargo workspace, not a root workspace member                                        |
+| **signal-producer**   | `src/signal-producer/` | Binary           | Test data generator (OTLP traces)                                                                                                                                        |
+| **tests-integration** | `tests-integration/`   | Test crate       | End-to-end integration tests                                                                                                                                             |
+| **xtask**             | `xtask/`               | Binary           | Build automation tasks                                                                                                                                                   |
 
 ## The `common` Crate (most important)
 
 This is the shared foundation. Key modules:
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| `config` | `src/common/src/config/mod.rs` | Configuration structs, TOML parsing, env vars |
-| `auth` | `src/common/src/auth/` | Authenticator, middleware, validation, TenantContext |
-| `catalog` | `src/common/src/catalog.rs` | Service catalog (PostgreSQL/SQLite) |
-| `cli` | `src/common/src/cli.rs` | Common CLI functionality shared across binaries |
-| `dataset` | `src/common/src/dataset.rs` | `DataSetType` enum (signal type naming) |
-| `model` | `src/common/src/model/` | Trace/span data models |
-| `ratelimit` | `src/common/src/ratelimit.rs` | Per-tenant token-bucket ingest rate limiting |
-| `self_monitoring` | `src/common/src/self_monitoring/` | Dogfooding: app metrics, profiling, suppression |
-| `tenant_api` | `src/common/src/tenant_api.rs` | Tenant API shared types and validation |
-| `testing` | `src/common/src/testing/` | Test utilities (config builder) |
-| `catalog_manager` | `src/common/src/catalog_manager.rs` | CatalogManager singleton for Iceberg catalog |
-| `wal` | `src/common/src/wal/mod.rs` | Write-Ahead Log implementation |
-| `flight` | `src/common/src/flight/` | Flight schemas, conversions, transport |
-| `flight/schema.rs` | `src/common/src/flight/schema.rs` | Arrow schema definitions for OTLP data |
-| `flight/transport.rs` | `src/common/src/flight/transport.rs` | InMemoryFlightTransport, connection pooling |
-| `iceberg` | `src/common/src/iceberg/` | Consolidated Iceberg integration |
-| `iceberg/mod.rs` | | Catalog creation, object store builders |
-| `iceberg/schemas.rs` | | Schema creation functions for traces/logs/metrics, partition specs |
-| `iceberg/names.rs` | | Naming utilities: `build_table_identifier`, `build_namespace`, `build_table_location` |
-| `iceberg/table_manager.rs` | | IcebergTableManager with catalog caching |
-| `schema` | `src/common/src/schema/` | Schema definitions and parsing |
-| `schema/schema_parser.rs` | | TOML schema parser with inheritance |
-| `storage` | `src/common/src/storage.rs` | Object store creation from DSN |
-| `service_bootstrap` | `src/common/src/service_bootstrap.rs` | Service registration + heartbeat |
+| Module                     | Path                                  | Purpose                                                                               |
+| -------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| `config`                   | `src/common/src/config/mod.rs`        | Configuration structs, TOML parsing, env vars                                         |
+| `auth`                     | `src/common/src/auth/`                | Authenticator, middleware, validation, TenantContext                                  |
+| `catalog`                  | `src/common/src/catalog.rs`           | Service catalog (PostgreSQL/SQLite)                                                   |
+| `cli`                      | `src/common/src/cli.rs`               | Common CLI functionality shared across binaries                                       |
+| `dataset`                  | `src/common/src/dataset.rs`           | `DataSetType` enum (signal type naming)                                               |
+| `model`                    | `src/common/src/model/`               | Trace/span data models                                                                |
+| `ratelimit`                | `src/common/src/ratelimit.rs`         | Per-tenant token-bucket ingest rate limiting                                          |
+| `self_monitoring`          | `src/common/src/self_monitoring/`     | Dogfooding: app metrics, profiling, suppression                                       |
+| `tenant_api`               | `src/common/src/tenant_api.rs`        | Tenant API shared types and validation                                                |
+| `testing`                  | `src/common/src/testing/`             | Test utilities (config builder)                                                       |
+| `catalog_manager`          | `src/common/src/catalog_manager.rs`   | CatalogManager singleton for Iceberg catalog                                          |
+| `wal`                      | `src/common/src/wal/mod.rs`           | Write-Ahead Log implementation                                                        |
+| `flight`                   | `src/common/src/flight/`              | Flight schemas, conversions, transport                                                |
+| `flight/schema.rs`         | `src/common/src/flight/schema.rs`     | Arrow schema definitions for OTLP data                                                |
+| `flight/transport.rs`      | `src/common/src/flight/transport.rs`  | InMemoryFlightTransport, connection pooling                                           |
+| `iceberg`                  | `src/common/src/iceberg/`             | Consolidated Iceberg integration                                                      |
+| `iceberg/mod.rs`           |                                       | Catalog creation, object store builders                                               |
+| `iceberg/schemas.rs`       |                                       | Schema creation functions for traces/logs/metrics, partition specs                    |
+| `iceberg/names.rs`         |                                       | Naming utilities: `build_table_identifier`, `build_namespace`, `build_table_location` |
+| `iceberg/table_manager.rs` |                                       | IcebergTableManager with catalog caching                                              |
+| `schema`                   | `src/common/src/schema/`              | Schema definitions and parsing                                                        |
+| `schema/schema_parser.rs`  |                                       | TOML schema parser with inheritance                                                   |
+| `storage`                  | `src/common/src/storage.rs`           | Object store creation from DSN                                                        |
+| `service_bootstrap`        | `src/common/src/service_bootstrap.rs` | Service registration + heartbeat                                                      |
 
 ## The `writer` Crate
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| `processor.rs` | `src/writer/src/processor.rs` | WalProcessor -- background WAL->Iceberg |
-| `schema_transform.rs` | `src/writer/src/schema_transform.rs` | Flight v1 -> Iceberg v2 transform |
-| `storage/iceberg.rs` | `src/writer/src/storage/iceberg.rs` | IcebergTableWriter -- table creation + writes |
-| `flight_iceberg.rs` | `src/writer/src/flight_iceberg.rs` | IcebergWriterFlightService |
+| Module                | Path                                 | Purpose                                       |
+| --------------------- | ------------------------------------ | --------------------------------------------- |
+| `processor.rs`        | `src/writer/src/processor.rs`        | WalProcessor -- background WAL->Iceberg       |
+| `schema_transform.rs` | `src/writer/src/schema_transform.rs` | Flight v1 -> Iceberg v2 transform             |
+| `storage/iceberg.rs`  | `src/writer/src/storage/iceberg.rs`  | IcebergTableWriter -- table creation + writes |
+| `flight_iceberg.rs`   | `src/writer/src/flight_iceberg.rs`   | IcebergWriterFlightService                    |
 
 ## The `querier` Crate
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| `flight.rs` | `src/querier/src/flight.rs` | QuerierFlightService, TenantCatalog |
-| `query` | `src/querier/src/query/` | Query execution modules |
-| `query/table_ref.rs` | `src/querier/src/query/table_ref.rs` | Safe table reference with slug validation |
-| `query/trace.rs` | `src/querier/src/query/trace.rs` | Trace query handlers |
-| `query/logs.rs` / `query/logql.rs` | `src/querier/src/query/` | LogQL log query execution + Expr lowering |
-| `query/metrics.rs` / `query/promql.rs` | `src/querier/src/query/` | PromQL metrics query execution + lowering |
-| `query/error.rs` | `src/querier/src/query/error.rs` | Query error types |
-| `query/search_filter.rs` | `src/querier/src/query/search_filter.rs` | Search filter parsing/handling |
-| `services` | `src/querier/src/services/` | Service implementations |
+| Module                                 | Path                                     | Purpose                                   |
+| -------------------------------------- | ---------------------------------------- | ----------------------------------------- |
+| `flight.rs`                            | `src/querier/src/flight.rs`              | QuerierFlightService, TenantCatalog       |
+| `query`                                | `src/querier/src/query/`                 | Query execution modules                   |
+| `query/table_ref.rs`                   | `src/querier/src/query/table_ref.rs`     | Safe table reference with slug validation |
+| `query/trace.rs`                       | `src/querier/src/query/trace.rs`         | Trace query handlers                      |
+| `query/logs.rs` / `query/logql.rs`     | `src/querier/src/query/`                 | LogQL log query execution + Expr lowering |
+| `query/metrics.rs` / `query/promql.rs` | `src/querier/src/query/`                 | PromQL metrics query execution + lowering |
+| `query/error.rs`                       | `src/querier/src/query/error.rs`         | Query error types                         |
+| `query/search_filter.rs`               | `src/querier/src/query/search_filter.rs` | Search filter parsing/handling            |
+| `services`                             | `src/querier/src/services/`              | Service implementations                   |
 
 ## The `router` Crate
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| `lib.rs` | `src/router/src/lib.rs` | Router assembly: route mounting, auth layers |
-| `main.rs` | `src/router/src/main.rs` | Standalone router binary |
-| `discovery.rs` | `src/router/src/discovery.rs` | Cached service discovery for the router |
-| `endpoints/tempo.rs` | `src/router/src/endpoints/tempo.rs` | Tempo-compatible API handlers |
-| `endpoints/logql.rs` | `src/router/src/endpoints/logql.rs` | Loki-compatible API handlers under `/loki` (stubs until LogQL execution lands) |
-| `endpoints/pyroscope.rs` | `src/router/src/endpoints/pyroscope.rs` | Pyroscope-compatible profile query handlers |
-| `endpoints/admin.rs` | `src/router/src/endpoints/admin.rs` | Admin API for tenant/key/dataset CRUD |
-| `endpoints/tenant.rs` | `src/router/src/endpoints/tenant.rs` | Tenant self-service API |
-| `endpoints/flight.rs` | `src/router/src/endpoints/flight.rs` | Router Flight service |
+| Module                   | Path                                    | Purpose                                                                        |
+| ------------------------ | --------------------------------------- | ------------------------------------------------------------------------------ |
+| `lib.rs`                 | `src/router/src/lib.rs`                 | Router assembly: route mounting, auth layers                                   |
+| `main.rs`                | `src/router/src/main.rs`                | Standalone router binary                                                       |
+| `discovery.rs`           | `src/router/src/discovery.rs`           | Cached service discovery for the router                                        |
+| `endpoints/tempo.rs`     | `src/router/src/endpoints/tempo.rs`     | Tempo-compatible API handlers                                                  |
+| `endpoints/logql.rs`     | `src/router/src/endpoints/logql.rs`     | Loki-compatible API handlers under `/loki` (stubs until LogQL execution lands) |
+| `endpoints/pyroscope.rs` | `src/router/src/endpoints/pyroscope.rs` | Pyroscope-compatible profile query handlers                                    |
+| `endpoints/admin.rs`     | `src/router/src/endpoints/admin.rs`     | Admin API for tenant/key/dataset CRUD                                          |
+| `endpoints/tenant.rs`    | `src/router/src/endpoints/tenant.rs`    | Tenant self-service API                                                        |
+| `endpoints/session.rs`   | `src/router/src/endpoints/session.rs`   | UI session login/logout (`/ui/session`) + `/api/v1/whoami`                     |
+| `endpoints/flight.rs`    | `src/router/src/endpoints/flight.rs`    | Router Flight service                                                          |
 
 ## The `compactor` Crate
 
-| Module | Path | Purpose |
-|--------|------|---------|
-| `main.rs` | `src/compactor/src/main.rs` | `signaldb-compactor` binary entry point |
-| `planner.rs` | `src/compactor/src/planner.rs` | Compaction planning -- identifies candidates |
-| `executor.rs` | `src/compactor/src/executor.rs` | Compaction execution -- rewrites Parquet files |
-| `scheduler/` | `src/compactor/src/scheduler/` | Round-robin per-tenant scheduling (Phase 4) |
-| `lease/` | `src/compactor/src/lease/` | Distributed leases for multi-instance safety (Phase 4) |
-| `flight.rs` | `src/compactor/src/flight.rs` | CompactorFlightService (Flight :50055) |
-| `http.rs` | `src/compactor/src/http.rs` | Observability HTTP endpoint (/metrics, /status, /health) |
-| `rewriter.rs` | `src/compactor/src/rewriter.rs` | Parquet file rewriting logic |
-| `commit.rs` | `src/compactor/src/commit.rs` | Atomic commit to Iceberg tables |
-| `metrics.rs` | `src/compactor/src/metrics.rs` | Prometheus metrics for compactor operations |
-| `retention/` | `src/compactor/src/retention/` | Phase 3: Retention enforcement |
-| `retention/config.rs` | | Retention policy configuration with 3-tier overrides |
-| `retention/enforcer.rs` | | Retention enforcement engine, partition dropping |
-| `orphan/` | `src/compactor/src/orphan/` | Phase 3: Orphan file cleanup |
-| `orphan/config.rs` | | Orphan cleanup configuration |
-| `orphan/detector.rs` | | 4-phase orphan detection algorithm |
-| `iceberg/` | `src/compactor/src/iceberg/` | Iceberg extensions for compactor |
-| `iceberg/partition.rs` | | Partition operations: list, parse, drop |
-| `iceberg/snapshot.rs` | | Snapshot operations: list, expire |
-| `iceberg/manifest.rs` | | Manifest parsing, file reference extraction |
+| Module                  | Path                            | Purpose                                                  |
+| ----------------------- | ------------------------------- | -------------------------------------------------------- |
+| `main.rs`               | `src/compactor/src/main.rs`     | `signaldb-compactor` binary entry point                  |
+| `planner.rs`            | `src/compactor/src/planner.rs`  | Compaction planning -- identifies candidates             |
+| `executor.rs`           | `src/compactor/src/executor.rs` | Compaction execution -- rewrites Parquet files           |
+| `scheduler/`            | `src/compactor/src/scheduler/`  | Round-robin per-tenant scheduling (Phase 4)              |
+| `lease/`                | `src/compactor/src/lease/`      | Distributed leases for multi-instance safety (Phase 4)   |
+| `flight.rs`             | `src/compactor/src/flight.rs`   | CompactorFlightService (Flight :50055)                   |
+| `http.rs`               | `src/compactor/src/http.rs`     | Observability HTTP endpoint (/metrics, /status, /health) |
+| `rewriter.rs`           | `src/compactor/src/rewriter.rs` | Parquet file rewriting logic                             |
+| `commit.rs`             | `src/compactor/src/commit.rs`   | Atomic commit to Iceberg tables                          |
+| `metrics.rs`            | `src/compactor/src/metrics.rs`  | Prometheus metrics for compactor operations              |
+| `retention/`            | `src/compactor/src/retention/`  | Phase 3: Retention enforcement                           |
+| `retention/config.rs`   |                                 | Retention policy configuration with 3-tier overrides     |
+| `retention/enforcer.rs` |                                 | Retention enforcement engine, partition dropping         |
+| `orphan/`               | `src/compactor/src/orphan/`     | Phase 3: Orphan file cleanup                             |
+| `orphan/config.rs`      |                                 | Orphan cleanup configuration                             |
+| `orphan/detector.rs`    |                                 | 4-phase orphan detection algorithm                       |
+| `iceberg/`              | `src/compactor/src/iceberg/`    | Iceberg extensions for compactor                         |
+| `iceberg/partition.rs`  |                                 | Partition operations: list, parse, drop                  |
+| `iceberg/snapshot.rs`   |                                 | Snapshot operations: list, expire                        |
+| `iceberg/manifest.rs`   |                                 | Manifest parsing, file reference extraction              |
 
 ## Key Root Files
 
-| File | Purpose |
-|------|---------|
-| `Cargo.toml` | Workspace definition + shared dependencies |
-| `schemas.toml` | Signal type schema definitions (compiled into binary) |
-| `signaldb.dist.toml` | Example configuration file |
-| `compose.yml` | Development environment setup |
-| `Dockerfile` | Multi-stage build for all services |
+| File                 | Purpose                                               |
+| -------------------- | ----------------------------------------------------- |
+| `Cargo.toml`         | Workspace definition + shared dependencies            |
+| `schemas.toml`       | Signal type schema definitions (compiled into binary) |
+| `signaldb.dist.toml` | Example configuration file                            |
+| `compose.yml`        | Development environment setup                         |
+| `Dockerfile`         | Multi-stage build for all services                    |

--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -8,6 +8,7 @@ sources:
   - src/common/src/ratelimit.rs
   - src/router/src/endpoints/admin.rs
   - src/router/src/endpoints/tenant.rs
+  - src/router/src/endpoints/session.rs
 ---
 
 # SignalDB Multi-Tenancy & Authentication
@@ -33,20 +34,31 @@ Tenant (e.g., "acme", slug: "acme")
 4. Resolves dataset: explicit header -> tenant default_dataset -> first `is_default` -> 400 error
 5. Returns `TenantContext { tenant_id, dataset_id, tenant_slug, dataset_slug }`
 
+### Session-Cookie Fallback (Embedded UI)
+
+When a router HTTP request has no `Authorization` header, `auth_middleware`
+falls back to the `signaldb_session` cookie (base64 JSON of
+api_key/tenant/dataset; codec in `src/common/src/auth/session.rs`). The
+cookie supplies the API key; explicit `X-Tenant-ID`/`X-Dataset-ID` headers
+still win over cookie values. The cookie is set by `POST /ui/session` and
+cleared by `DELETE /ui/session` (`src/router/src/endpoints/session.rs`),
+both public routes on the router.
+
 ### Error Codes
+
 - **400**: Missing/malformed auth headers
 - **401**: Invalid API key
 - **403**: Key valid but wrong tenant/dataset
 
 ## Isolation Layers
 
-| Layer | Mechanism |
-|-------|-----------|
-| **WAL** | `{wal_dir}/{tenant_id}/{dataset_id}/{signal_type}/` |
-| **Iceberg Namespace** | `[tenant_slug, dataset_slug]` |
-| **Object Store** | `{base}/{tenant_slug}/{dataset_slug}/{table}/` |
-| **DataFusion** | Per-tenant catalog in SessionContext |
-| **Storage Backend** | Per-dataset storage override |
+| Layer                 | Mechanism                                           |
+| --------------------- | --------------------------------------------------- |
+| **WAL**               | `{wal_dir}/{tenant_id}/{dataset_id}/{signal_type}/` |
+| **Iceberg Namespace** | `[tenant_slug, dataset_slug]`                       |
+| **Object Store**      | `{base}/{tenant_slug}/{dataset_slug}/{table}/`      |
+| **DataFusion**        | Per-tenant catalog in SessionContext                |
+| **Storage Backend**   | Per-dataset storage override                        |
 
 ## Slug-Based Naming
 
@@ -94,14 +106,14 @@ name = "Production Key"
 `[[auth.tenants]].limits`; resolved by `AuthConfig::limits_for`). Unset
 fields mean unlimited; DB-provisioned tenants get the defaults.
 
-| Limit | Enforced at | On exceed |
-|-------|-------------|-----------|
-| `max_ingest_requests_per_sec` / `max_ingest_bytes_per_sec` | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED |
-| `max_query_requests_per_sec` | Router HTTP query API (`/tempo`, `/api/v1`) | 429 |
-| `max_api_keys` (active keys only) | Admin API key creation | 429 `quota_exceeded` |
-| `max_datasets` | Admin API dataset creation | 429 `quota_exceeded` |
-| `max_storage_bytes` | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED `quota_exceeded` |
-| `[querier] max_concurrent_queries_per_tenant` | Querier | query rejected |
+| Limit                                                      | Enforced at                                                           | On exceed                                 |
+| ---------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------- |
+| `max_ingest_requests_per_sec` / `max_ingest_bytes_per_sec` | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED                  |
+| `max_query_requests_per_sec`                               | Router HTTP query API (`/tempo`, `/api/v1`)                           | 429                                       |
+| `max_api_keys` (active keys only)                          | Admin API key creation                                                | 429 `quota_exceeded`                      |
+| `max_datasets`                                             | Admin API dataset creation                                            | 429 `quota_exceeded`                      |
+| `max_storage_bytes`                                        | Acceptor (OTLP gRPC incl. profiles, OTLP/HTTP profiles, remote_write) | 429 / RESOURCE_EXHAUSTED `quota_exceeded` |
+| `[querier] max_concurrent_queries_per_tenant`              | Querier                                                               | query rejected                            |
 
 Token buckets per dimension (`common::ratelimit::TenantRateLimiter`);
 ingest and query budgets are independent. Storage quotas
@@ -115,27 +127,28 @@ usage is exported as the `signaldb.tenant.storage_usage` gauge.
 
 Mounted at `/api/v1/admin`, requires `admin_api_key` (`src/router/src/lib.rs`):
 
-| Endpoint | Methods | Description |
-|----------|---------|-------------|
-| `/api/v1/admin/tenants` | GET, POST | List/create tenants |
-| `/api/v1/admin/tenants/{id}` | GET, PUT, DELETE | Manage a tenant |
-| `/api/v1/admin/tenants/{id}/api-keys` | GET, POST | List/create API keys |
-| `/api/v1/admin/tenants/{id}/api-keys/{key_id}` | DELETE | Revoke API key |
-| `/api/v1/admin/tenants/{id}/datasets` | GET, POST | List/create datasets |
-| `/api/v1/admin/tenants/{id}/datasets/{dataset_id}` | DELETE | Delete dataset |
+| Endpoint                                           | Methods          | Description          |
+| -------------------------------------------------- | ---------------- | -------------------- |
+| `/api/v1/admin/tenants`                            | GET, POST        | List/create tenants  |
+| `/api/v1/admin/tenants/{id}`                       | GET, PUT, DELETE | Manage a tenant      |
+| `/api/v1/admin/tenants/{id}/api-keys`              | GET, POST        | List/create API keys |
+| `/api/v1/admin/tenants/{id}/api-keys/{key_id}`     | DELETE           | Revoke API key       |
+| `/api/v1/admin/tenants/{id}/datasets`              | GET, POST        | List/create datasets |
+| `/api/v1/admin/tenants/{id}/datasets/{dataset_id}` | DELETE           | Delete dataset       |
 
 ## Tenant Self-Service API (Router)
 
 Mounted at `/api/v1` with tenant auth (`src/router/src/endpoints/tenant.rs`):
 
-| Endpoint | Methods | Description |
-|----------|---------|-------------|
-| `/api/v1/tenants` | GET | List tenants visible to the caller |
-| `/api/v1/tenants/{id}` | GET | Tenant details |
-| `/api/v1/tenants/{id}/tables` | GET | List tenant tables |
-| `/api/v1/tenants/{id}/tables/create` | POST | Create tenant tables |
-| `/api/v1/tenants/{id}/schemas` | GET | List tenant schemas |
-| `/api/v1/schemas/available` | GET | List available schema definitions |
+| Endpoint                             | Methods | Description                                                                                 |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------- |
+| `/api/v1/whoami`                     | GET     | Authenticated tenant (id, slug, name) + datasets + default dataset (`endpoints/session.rs`) |
+| `/api/v1/tenants`                    | GET     | List tenants visible to the caller                                                          |
+| `/api/v1/tenants/{id}`               | GET     | Tenant details                                                                              |
+| `/api/v1/tenants/{id}/tables`        | GET     | List tenant tables                                                                          |
+| `/api/v1/tenants/{id}/tables/create` | POST    | Create tenant tables                                                                        |
+| `/api/v1/tenants/{id}/schemas`       | GET     | List tenant schemas                                                                         |
+| `/api/v1/schemas/available`          | GET     | List available schema definitions                                                           |
 
 ## CLI Tool
 
@@ -152,14 +165,16 @@ signaldb-cli tui                # Interactive terminal UI
 
 ## Key Implementation Files
 
-| File | Purpose |
-|------|---------|
-| `src/common/src/config/mod.rs` | Tenant/dataset config structs |
-| `src/common/src/auth/` | Authenticator, TenantContext, middleware, validation |
-| `src/common/src/catalog_manager.rs` | Slug resolution |
-| `src/router/src/endpoints/admin.rs` | Admin API endpoints (incl. quota checks) |
-| `src/router/src/endpoints/tenant.rs` | Tenant self-service API endpoints |
-| `src/common/src/ratelimit.rs` | Per-tenant token-bucket rate limiter |
-| `src/signaldb-cli/` | CLI for tenant management |
+| File                                  | Purpose                                              |
+| ------------------------------------- | ---------------------------------------------------- |
+| `src/common/src/config/mod.rs`        | Tenant/dataset config structs                        |
+| `src/common/src/auth/`                | Authenticator, TenantContext, middleware, validation |
+| `src/common/src/catalog_manager.rs`   | Slug resolution                                      |
+| `src/router/src/endpoints/admin.rs`   | Admin API endpoints (incl. quota checks)             |
+| `src/router/src/endpoints/tenant.rs`  | Tenant self-service API endpoints                    |
+| `src/router/src/endpoints/session.rs` | UI session login/logout + whoami endpoints           |
+| `src/common/src/auth/session.rs`      | Session cookie codec (`signaldb_session`)            |
+| `src/common/src/ratelimit.rs`         | Per-tenant token-bucket rate limiter                 |
+| `src/signaldb-cli/`                   | CLI for tenant management                            |
 
-Under `[compactor.attr_promotion]` (auto-promotion decision pass), a tenant's resolved materialized-label allowlist is the *pinned* set: those keys are never demotion candidates.
+Under `[compactor.attr_promotion]` (auto-promotion decision pass), a tenant's resolved materialized-label allowlist is the _pinned_ set: those keys are never demotion candidates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "axum",
+ "base64",
  "bincode",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ uuid = { version = "1.21.0", features = ["serde", "v4"] }
 humantime-serde = "1.1.1"
 
 hex = "0.4"
+base64 = "0.22"
 env_logger = "0.11.5"
 tower = "0.5.2"
 dashmap = "6.2"

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -198,6 +198,13 @@ The router also serves the explore UI (a static SPA built from `src/ui`)
 under `/ui`, from the directory named by `SIGNALDB_UI_DIR`. See
 [the explore UI guide](../users/explore-ui.md).
 
+For browsers, the router exposes `POST`/`DELETE /ui/session`
+(`src/router/src/endpoints/session.rs`): a public login endpoint that
+validates tenant credentials and sets/clears an `HttpOnly` session cookie
+the auth middleware accepts in place of the auth headers. A tenant-scoped
+`GET /api/v1/whoami` returns the authenticated tenant and its datasets
+for the UI's tenant selector.
+
 **Tempo API Endpoints**:
 
 | Endpoint                                         | Status                                                                                     |

--- a/docs/users/authentication.md
+++ b/docs/users/authentication.md
@@ -6,6 +6,8 @@ sources:
   - src/acceptor/src/middleware/grpc_auth.rs
   - src/acceptor/src/middleware/auth.rs
   - src/router/src/endpoints/tenant.rs
+  - src/router/src/endpoints/session.rs
+  - src/common/src/auth/session.rs
 ---
 
 # Authentication reference
@@ -19,11 +21,11 @@ Every authenticated surface uses the same three values. HTTP APIs read
 them as headers; gRPC/Flight surfaces read them as request metadata
 (lowercase keys).
 
-| HTTP header | gRPC metadata key | Required | Value |
-|---|---|---|---|
-| `Authorization` | `authorization` | yes | `Bearer <api-key>` (HTTP accepts any casing of the scheme; gRPC/Flight accepts only `Bearer` or `bearer`) |
-| `X-Tenant-ID` | `x-tenant-id` | yes | tenant the request acts on |
-| `X-Dataset-ID` | `x-dataset-id` | no | dataset within the tenant; omitted → the tenant's default dataset |
+| HTTP header     | gRPC metadata key | Required | Value                                                                                                     |
+| --------------- | ----------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `Authorization` | `authorization`   | yes      | `Bearer <api-key>` (HTTP accepts any casing of the scheme; gRPC/Flight accepts only `Bearer` or `bearer`) |
+| `X-Tenant-ID`   | `x-tenant-id`     | yes      | tenant the request acts on                                                                                |
+| `X-Dataset-ID`  | `x-dataset-id`    | no       | dataset within the tenant; omitted → the tenant's default dataset                                         |
 
 Tenant and dataset IDs are validated: restricted character set, length
 cap, and path-traversal patterns rejected (they become WAL paths and
@@ -31,22 +33,36 @@ Iceberg namespaces). Invalid IDs fail with 400 / `INVALID_ARGUMENT`.
 
 ## Where the headers are required
 
-| Surface | Port | Doc |
-|---|---|---|
-| OTLP gRPC ingestion | 4317 | [Sending OTLP data](sending-otlp.md) |
-| Prometheus remote_write (`/api/v1/write`) | 4318 | [Prometheus remote_write](prometheus-remote-write.md) |
-| Tempo HTTP API (`/tempo/*`) | 3000 | [Tempo API reference](tempo-api-reference.md) |
-| Loki HTTP API (`/loki/*`) | 3000 | [LogQL reference](logql-reference.md) |
-| Flight SQL queries | 50053 | [Querying with SQL](querying-sql.md); enforced when the operator has enabled Flight auth |
-| Tenant self-service API (`/api/v1/*`) | 3000 | see below |
+| Surface                                   | Port  | Doc                                                                                      |
+| ----------------------------------------- | ----- | ---------------------------------------------------------------------------------------- |
+| OTLP gRPC ingestion                       | 4317  | [Sending OTLP data](sending-otlp.md)                                                     |
+| Prometheus remote_write (`/api/v1/write`) | 4318  | [Prometheus remote_write](prometheus-remote-write.md)                                    |
+| Tempo HTTP API (`/tempo/*`)               | 3000  | [Tempo API reference](tempo-api-reference.md)                                            |
+| Loki HTTP API (`/loki/*`)                 | 3000  | [LogQL reference](logql-reference.md)                                                    |
+| Flight SQL queries                        | 50053 | [Querying with SQL](querying-sql.md); enforced when the operator has enabled Flight auth |
+| Tenant self-service API (`/api/v1/*`)     | 3000  | see below                                                                                |
+
+## Browser sessions (embedded UI)
+
+The router's HTTP APIs additionally accept a session cookie in place of
+the headers, for browsers using the [embedded explore UI](explore-ui.md):
+
+- `POST /ui/session` (public) takes `{"api_key", "tenant", "dataset"?}`
+  as JSON, validates it exactly like the headers, and sets an `HttpOnly`,
+  `SameSite=Strict` cookie (`signaldb_session`) carrying those values.
+  Returns 204 on success, an error status with a JSON `error` message
+  otherwise. `DELETE /ui/session` clears the cookie.
+- On requests without an `Authorization` header, the router falls back to
+  the cookie for the API key and for any tenant/dataset values not given
+  as headers. Explicit headers always win over cookie values.
 
 ## Error codes
 
-| HTTP | gRPC | Meaning |
-|---|---|---|
-| 400 | `INVALID_ARGUMENT` | Header missing or malformed (wrong scheme, invalid tenant/dataset ID) |
-| 401 | `UNAUTHENTICATED` | API key unknown or revoked |
-| 403 | `PERMISSION_DENIED` | Key is valid but not authorized for the named tenant or dataset |
+| HTTP | gRPC                | Meaning                                                               |
+| ---- | ------------------- | --------------------------------------------------------------------- |
+| 400  | `INVALID_ARGUMENT`  | Header missing or malformed (wrong scheme, invalid tenant/dataset ID) |
+| 401  | `UNAUTHENTICATED`   | API key unknown or revoked                                            |
+| 403  | `PERMISSION_DENIED` | Key is valid but not authorized for the named tenant or dataset       |
 
 ## Tenants and datasets
 
@@ -64,11 +80,11 @@ Iceberg namespaces). Invalid IDs fail with 400 / `INVALID_ARGUMENT`.
 Tenants, datasets, and API keys are managed by your SignalDB operator via
 one of:
 
-| Method | Where |
-|---|---|
-| Static config | `[[auth.tenants]]` blocks in `signaldb.toml` |
-| Admin API | `/api/v1/admin/*` on the router (port 3000), authenticated with `Authorization: Bearer <admin-api-key>` |
-| CLI | `signaldb-cli tenant\|api-key\|dataset ...` — a client for the admin API (`--url`, default `http://localhost:3000`; `--admin-key` or `SIGNALDB_ADMIN_KEY`) |
+| Method        | Where                                                                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Static config | `[[auth.tenants]]` blocks in `signaldb.toml`                                                                                                               |
+| Admin API     | `/api/v1/admin/*` on the router (port 3000), authenticated with `Authorization: Bearer <admin-api-key>`                                                    |
+| CLI           | `signaldb-cli tenant\|api-key\|dataset ...` — a client for the admin API (`--url`, default `http://localhost:3000`; `--admin-key` or `SIGNALDB_ADMIN_KEY`) |
 
 Example (operator-side):
 
@@ -85,11 +101,12 @@ With a regular tenant API key (the three headers above), the router
 exposes tenant-scoped endpoints under `/api/v1` (read-only, plus one
 table-creation endpoint):
 
-| Method | Path | Returns |
-|---|---|---|
-| GET | `/api/v1/tenants` | All configured tenants |
-| GET | `/api/v1/tenants/{tenant_id}` | Tenant details |
-| GET | `/api/v1/tenants/{tenant_id}/tables` | The tenant's tables |
-| POST | `/api/v1/tenants/{tenant_id}/tables/create` | Creates the tenant's signal tables |
-| GET | `/api/v1/tenants/{tenant_id}/schemas` | The tenant's schema configuration |
-| GET | `/api/v1/schemas/available` | Available schema definitions |
+| Method | Path                                        | Returns                                                                          |
+| ------ | ------------------------------------------- | -------------------------------------------------------------------------------- |
+| GET    | `/api/v1/whoami`                            | The authenticated tenant (id, slug, name), its datasets, and the default dataset |
+| GET    | `/api/v1/tenants`                           | All configured tenants                                                           |
+| GET    | `/api/v1/tenants/{tenant_id}`               | Tenant details                                                                   |
+| GET    | `/api/v1/tenants/{tenant_id}/tables`        | The tenant's tables                                                              |
+| POST   | `/api/v1/tenants/{tenant_id}/tables/create` | Creates the tenant's signal tables                                               |
+| GET    | `/api/v1/tenants/{tenant_id}/schemas`       | The tenant's schema configuration                                                |
+| GET    | `/api/v1/schemas/available`                 | Available schema definitions                                                     |

--- a/docs/users/explore-ui.md
+++ b/docs/users/explore-ui.md
@@ -5,6 +5,7 @@ status: living
 sources:
   - src/ui/**
   - src/router/src/ui.rs
+  - src/router/src/endpoints/session.rs
 ---
 
 # Explore UI
@@ -26,6 +27,31 @@ visible in the UI is equally queryable from Grafana.
   the span panel links back to logs filtered by that trace.
 - Every view is a URL: time range, filters, and selection live in query
   parameters, so views can be bookmarked and shared.
+
+## Signing in
+
+On an embedded deployment (the UI served by the router at `/ui`), the
+first query that fails as unauthenticated opens a sign-in form. Enter a
+tenant API key, the tenant ID, and optionally a dataset (defaults to the
+tenant's default dataset) — the same credentials any API client uses, see
+[the authentication reference](authentication.md).
+
+Signing in calls `POST /ui/session`, which validates the credentials and
+sets an `HttpOnly`, `SameSite=Strict` session cookie. Subsequent API
+requests from the browser authenticate through that cookie, so the key
+never lives in page JavaScript, `localStorage`, or URLs. The session
+lasts for the browser session; `DELETE /ui/session` (or clearing cookies)
+ends it.
+
+Once signed in, the tenant/dataset selector in the top bar shows the
+session's tenant read-only and offers the tenant's datasets as a
+drop-down (server support permitting; against older servers it falls back
+to free-text fields). The explicit tenant/dataset chosen there is still
+sent as `X-Tenant-ID`/`X-Dataset-ID` headers and wins over the cookie's
+values.
+
+In development the Vite proxy injects credentials from `.env.local`
+instead, so no sign-in is needed.
 
 ## Availability
 

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 bincode.workspace = true
 hex.workspace = true
+base64.workspace = true
 opentelemetry.workspace = true
 opentelemetry-proto.workspace = true
 async-trait.workspace = true

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -13,13 +13,19 @@ use axum::{
 use std::sync::Arc;
 
 /// Extract authentication headers from HTTP request
+///
+/// When the request carries no `Authorization` header, falls back to the
+/// UI session cookie (see [`super::session`]) for the API key and any
+/// tenant/dataset values not supplied as explicit headers. Explicit
+/// headers always win over cookie values.
 fn extract_auth_headers(
     headers: &HeaderMap,
 ) -> Result<(String, String, Option<String>), AuthError> {
-    // Extract Authorization header
-    let auth_header = headers
-        .get("authorization")
-        .ok_or_else(|| AuthError::bad_request("Missing Authorization header"))?
+    // Extract Authorization header, falling back to the session cookie.
+    let Some(auth_value) = headers.get("authorization") else {
+        return extract_auth_from_session(headers);
+    };
+    let auth_header = auth_value
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid Authorization header"))?;
 
@@ -45,6 +51,40 @@ fn extract_auth_headers(
     };
 
     Ok((api_key, tenant_id, dataset_id))
+}
+
+/// Resolve credentials from the UI session cookie for requests without an
+/// `Authorization` header.
+///
+/// The cookie supplies the API key; tenant and dataset come from explicit
+/// `X-Tenant-ID`/`X-Dataset-ID` headers when present (headers win) and
+/// from the cookie otherwise. All values pass the same validation as
+/// header-supplied ones. A missing or malformed cookie yields the same
+/// error as a missing Authorization header.
+fn extract_auth_from_session(
+    headers: &HeaderMap,
+) -> Result<(String, String, Option<String>), AuthError> {
+    let session = super::session::session_from_headers(headers)
+        .ok_or_else(|| AuthError::bad_request("Missing Authorization header"))?;
+
+    let tenant_id_raw = match headers.get("x-tenant-id") {
+        Some(value) => value
+            .to_str()
+            .map_err(|_| AuthError::bad_request("Invalid X-Tenant-ID header"))?,
+        None => session.tenant.as_str(),
+    };
+    let tenant_id = validate_tenant_id(tenant_id_raw)?;
+
+    let dataset_raw = match headers.get("x-dataset-id").and_then(|v| v.to_str().ok()) {
+        Some(id) => Some(id.to_string()),
+        None => session.dataset.clone(),
+    };
+    let dataset_id = match dataset_raw {
+        Some(id) => Some(validate_dataset_id(&id)?),
+        None => None,
+    };
+
+    Ok((session.api_key, tenant_id, dataset_id))
 }
 
 /// Axum middleware function for HTTP authentication
@@ -387,6 +427,187 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_extract_auth_headers_uses_session_cookie_without_authorization() {
+        use crate::auth::session::{SESSION_COOKIE, SessionData, encode_session};
+
+        let cookie = encode_session(&SessionData {
+            api_key: "cookie-key".to_string(),
+            tenant: "acme".to_string(),
+            dataset: Some("production".to_string()),
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            HeaderValue::from_str(&format!("{SESSION_COOKIE}={cookie}")).unwrap(),
+        );
+
+        let (api_key, tenant_id, dataset_id) = extract_auth_headers(&headers).unwrap();
+        assert_eq!(api_key, "cookie-key");
+        assert_eq!(tenant_id, "acme");
+        assert_eq!(dataset_id, Some("production".to_string()));
+    }
+
+    #[test]
+    fn test_extract_auth_headers_explicit_headers_win_over_cookie() {
+        use crate::auth::session::{SESSION_COOKIE, SessionData, encode_session};
+
+        let cookie = encode_session(&SessionData {
+            api_key: "cookie-key".to_string(),
+            tenant: "acme".to_string(),
+            dataset: Some("production".to_string()),
+        });
+
+        // Tenant/dataset headers override the cookie's values (the cookie
+        // still supplies the key when Authorization is absent).
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            HeaderValue::from_str(&format!("{SESSION_COOKIE}={cookie}")).unwrap(),
+        );
+        headers.insert("x-tenant-id", HeaderValue::from_static("other"));
+        headers.insert("x-dataset-id", HeaderValue::from_static("staging"));
+
+        let (api_key, tenant_id, dataset_id) = extract_auth_headers(&headers).unwrap();
+        assert_eq!(api_key, "cookie-key");
+        assert_eq!(tenant_id, "other");
+        assert_eq!(dataset_id, Some("staging".to_string()));
+
+        // An Authorization header disables the cookie entirely.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            HeaderValue::from_str(&format!("{SESSION_COOKIE}={cookie}")).unwrap(),
+        );
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer header-key"),
+        );
+        headers.insert("x-tenant-id", HeaderValue::from_static("other"));
+
+        let (api_key, tenant_id, dataset_id) = extract_auth_headers(&headers).unwrap();
+        assert_eq!(api_key, "header-key");
+        assert_eq!(tenant_id, "other");
+        assert_eq!(dataset_id, None);
+    }
+
+    #[test]
+    fn test_extract_auth_headers_malformed_cookie_is_missing_auth() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            HeaderValue::from_static("signaldb_session=not-a-session"),
+        );
+
+        let err = extract_auth_headers(&headers).unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("Authorization"));
+    }
+
+    #[test]
+    fn test_extract_auth_headers_cookie_values_are_validated() {
+        use crate::auth::session::{SESSION_COOKIE, SessionData, encode_session};
+
+        let cookie = encode_session(&SessionData {
+            api_key: "cookie-key".to_string(),
+            tenant: "../evil".to_string(),
+            dataset: None,
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            HeaderValue::from_str(&format!("{SESSION_COOKIE}={cookie}")).unwrap(),
+        );
+
+        let err = extract_auth_headers(&headers).unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("path traversal"));
+    }
+
+    #[tokio::test]
+    async fn session_cookie_round_trip_authenticates_request() {
+        use crate::auth::session::{SESSION_COOKIE, SessionData, encode_session};
+        use axum::{
+            Router,
+            body::Body,
+            http::{Request, StatusCode},
+            middleware,
+            routing::get,
+        };
+        use tower::ServiceExt;
+
+        let catalog = Arc::new(Catalog::new("sqlite::memory:").await.unwrap());
+        let auth_config = AuthConfig {
+            tenants: vec![TenantConfig {
+                id: "acme".to_string(),
+                slug: "acme".to_string(),
+                name: "Acme Corp".to_string(),
+                default_dataset: Some("production".to_string()),
+                datasets: vec![DatasetConfig {
+                    id: "production".to_string(),
+                    slug: "production".to_string(),
+                    is_default: true,
+                    storage: None,
+                }],
+                api_keys: vec![ApiKeyConfig {
+                    key: "test-key-123".to_string(),
+                    name: Some("test-key".to_string()),
+                }],
+                schema_config: None,
+                limits: None,
+            }],
+            ..Default::default()
+        };
+        let authenticator = Arc::new(Authenticator::new(auth_config, catalog));
+
+        async fn test_handler(tenant_ctx: TenantContextExtractor) -> String {
+            format!(
+                "tenant={},dataset={}",
+                tenant_ctx.0.tenant_id, tenant_ctx.0.dataset_id
+            )
+        }
+
+        let auth = authenticator.clone();
+        let app = Router::new()
+            .route("/test", get(test_handler))
+            .layer(middleware::from_fn(move |req, next| {
+                auth_middleware(auth.clone(), req, next)
+            }));
+
+        let cookie = encode_session(&SessionData {
+            api_key: "test-key-123".to_string(),
+            tenant: "acme".to_string(),
+            dataset: None,
+        });
+
+        // Cookie alone authenticates and resolves the default dataset.
+        let request = Request::builder()
+            .uri("/test")
+            .header("cookie", format!("{SESSION_COOKIE}={cookie}"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body, "tenant=acme,dataset=production");
+
+        // A wrong key in the cookie still fails authentication.
+        let bad_cookie = encode_session(&SessionData {
+            api_key: "wrong-key".to_string(),
+            tenant: "acme".to_string(),
+            dataset: None,
+        });
+        let request = Request::builder()
+            .uri("/test")
+            .header("cookie", format!("{SESSION_COOKIE}={bad_cookie}"))
+            .body(Body::empty())
+            .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }

--- a/src/common/src/auth/mod.rs
+++ b/src/common/src/auth/mod.rs
@@ -5,10 +5,12 @@
 
 mod authenticator;
 mod middleware;
+pub mod session;
 pub mod validation;
 
 pub use authenticator::Authenticator;
 pub use middleware::{TenantContextExtractor, admin_auth_middleware, auth_middleware};
+pub use session::{SESSION_COOKIE, SessionData, decode_session, encode_session};
 pub use validation::{ValidationError, validate_dataset_id, validate_id, validate_tenant_id};
 
 /// Tenant context extracted from authenticated request

--- a/src/common/src/auth/session.rs
+++ b/src/common/src/auth/session.rs
@@ -1,0 +1,128 @@
+//! # UI session cookie
+//!
+//! Encoding/decoding for the browser session cookie used by the embedded
+//! explore UI. The cookie holds the same three values the auth headers
+//! carry (API key, tenant, optional dataset) as base64-encoded JSON — it
+//! is deliberately not encrypted: the key is client-held credential
+//! material either way, and `HttpOnly` keeps it out of reach of page
+//! scripts. The auth middleware falls back to this cookie when a request
+//! carries no `Authorization` header.
+
+use axum::http::HeaderMap;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+/// Name of the session cookie set by `POST /ui/session`.
+pub const SESSION_COOKIE: &str = "signaldb_session";
+
+/// Credential triple stored in the session cookie.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionData {
+    /// Raw tenant API key (what `Authorization: Bearer` would carry).
+    pub api_key: String,
+    /// Tenant ID (what `X-Tenant-ID` would carry).
+    pub tenant: String,
+    /// Optional dataset ID (what `X-Dataset-ID` would carry).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset: Option<String>,
+}
+
+/// Encode session data into the cookie value (URL-safe base64 JSON).
+pub fn encode_session(data: &SessionData) -> String {
+    let json = serde_json::to_vec(data).expect("SessionData serializes to JSON");
+    URL_SAFE_NO_PAD.encode(json)
+}
+
+/// Decode a cookie value produced by [`encode_session`].
+///
+/// Returns `None` for anything malformed — an invalid cookie is treated
+/// as absent, never as an error the client must handle.
+pub fn decode_session(value: &str) -> Option<SessionData> {
+    let bytes = URL_SAFE_NO_PAD.decode(value.trim()).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Extract session data from a request's `Cookie` header(s), if present
+/// and well-formed.
+pub fn session_from_headers(headers: &HeaderMap) -> Option<SessionData> {
+    for header in headers.get_all(axum::http::header::COOKIE) {
+        let Ok(cookies) = header.to_str() else {
+            continue;
+        };
+        for pair in cookies.split(';') {
+            let Some((name, value)) = pair.split_once('=') else {
+                continue;
+            };
+            if name.trim() == SESSION_COOKIE
+                && let Some(session) = decode_session(value)
+            {
+                return Some(session);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn sample() -> SessionData {
+        SessionData {
+            api_key: "sk-test-key".to_string(),
+            tenant: "acme".to_string(),
+            dataset: Some("production".to_string()),
+        }
+    }
+
+    #[test]
+    fn encode_decode_round_trip() {
+        let data = sample();
+        assert_eq!(decode_session(&encode_session(&data)), Some(data));
+    }
+
+    #[test]
+    fn round_trip_without_dataset() {
+        let data = SessionData {
+            dataset: None,
+            ..sample()
+        };
+        assert_eq!(decode_session(&encode_session(&data)), Some(data));
+    }
+
+    #[test]
+    fn decode_rejects_garbage() {
+        assert_eq!(decode_session("not base64 at all!!"), None);
+        // Valid base64, invalid JSON payload.
+        assert_eq!(decode_session(&URL_SAFE_NO_PAD.encode("not json")), None);
+    }
+
+    #[test]
+    fn session_from_headers_finds_cookie_among_others() {
+        let mut headers = HeaderMap::new();
+        let value = format!(
+            "theme=dark; {SESSION_COOKIE}={}; other=1",
+            encode_session(&sample())
+        );
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_str(&value).unwrap(),
+        );
+        assert_eq!(session_from_headers(&headers), Some(sample()));
+    }
+
+    #[test]
+    fn session_from_headers_absent_or_malformed() {
+        let headers = HeaderMap::new();
+        assert_eq!(session_from_headers(&headers), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_static("signaldb_session=%%%broken%%%"),
+        );
+        assert_eq!(session_from_headers(&headers), None);
+    }
+}

--- a/src/router/src/endpoints/mod.rs
+++ b/src/router/src/endpoints/mod.rs
@@ -3,5 +3,6 @@ pub mod flight;
 pub mod logql;
 pub mod promql;
 pub mod pyroscope;
+pub mod session;
 pub mod tempo;
 pub mod tenant;

--- a/src/router/src/endpoints/session.rs
+++ b/src/router/src/endpoints/session.rs
@@ -1,0 +1,480 @@
+//! # UI session and whoami endpoints
+//!
+//! Browser-facing authentication for the embedded explore UI:
+//!
+//! - `POST /ui/session` validates an API key + tenant (+ optional dataset)
+//!   with the same [`Authenticator`] path the auth middleware uses and, on
+//!   success, sets an `HttpOnly` session cookie the middleware accepts in
+//!   place of the auth headers.
+//! - `DELETE /ui/session` clears that cookie.
+//! - `GET /api/v1/whoami` (behind the tenant auth middleware) returns the
+//!   authenticated tenant and its datasets, strictly scoped to that tenant.
+
+use crate::RouterState;
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use common::auth::{
+    SESSION_COOKIE, SessionData, TenantContextExtractor, encode_session, validate_dataset_id,
+    validate_tenant_id,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Routes mounted at the router root (absolute `/ui/session` paths, so the
+/// session endpoint coexists with the `/ui` static-asset service).
+pub fn router<S: RouterState>() -> Router<S> {
+    Router::new().route(
+        "/ui/session",
+        post(create_session::<S>).delete(delete_session),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    pub api_key: String,
+    pub tenant: String,
+    #[serde(default)]
+    pub dataset: Option<String>,
+}
+
+/// POST /ui/session
+///
+/// Validates the credentials and sets the session cookie. 204 on success,
+/// 401/403 with a JSON error body on invalid credentials, 400 on malformed
+/// tenant/dataset IDs.
+pub async fn create_session<S: RouterState>(
+    State(state): State<S>,
+    Json(body): Json<CreateSessionRequest>,
+) -> Response {
+    let tenant = match validate_tenant_id(&body.tenant) {
+        Ok(t) => t,
+        Err(e) => return error_response(400, e.to_string()),
+    };
+    let dataset = match body.dataset.as_deref().map(str::trim) {
+        Some("") | None => None,
+        Some(d) => match validate_dataset_id(d) {
+            Ok(d) => Some(d),
+            Err(e) => return error_response(400, e.to_string()),
+        },
+    };
+
+    match state
+        .authenticator()
+        .authenticate(&body.api_key, &tenant, dataset.as_deref())
+        .await
+    {
+        Ok(ctx) => {
+            tracing::info!(tenant_id = %ctx.tenant_id, dataset = %ctx.dataset_id, "UI session created");
+            let cookie = encode_session(&SessionData {
+                api_key: body.api_key,
+                tenant,
+                dataset,
+            });
+            (
+                StatusCode::NO_CONTENT,
+                [(
+                    header::SET_COOKIE,
+                    format!("{SESSION_COOKIE}={cookie}; HttpOnly; SameSite=Strict; Path=/"),
+                )],
+            )
+                .into_response()
+        }
+        Err(err) => {
+            tracing::warn!(tenant_id = %tenant, "UI session login failed: {}", err.message);
+            error_response(err.status_code, err.message)
+        }
+    }
+}
+
+/// DELETE /ui/session
+///
+/// Clears the session cookie (logout).
+pub async fn delete_session() -> Response {
+    (
+        StatusCode::NO_CONTENT,
+        [(
+            header::SET_COOKIE,
+            format!("{SESSION_COOKIE}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0"),
+        )],
+    )
+        .into_response()
+}
+
+fn error_response(status: u16, message: String) -> Response {
+    (
+        StatusCode::from_u16(status).unwrap_or(StatusCode::UNAUTHORIZED),
+        Json(json!({ "error": message })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Serialize)]
+pub struct WhoamiTenant {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WhoamiDataset {
+    pub id: String,
+    pub slug: String,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WhoamiResponse {
+    pub tenant: WhoamiTenant,
+    pub datasets: Vec<WhoamiDataset>,
+    pub default_dataset: Option<String>,
+}
+
+/// GET /api/v1/whoami
+///
+/// Returns the authenticated tenant with its datasets and default dataset,
+/// resolved from the same sources the [`common::auth::Authenticator`] uses
+/// (config tenants first, then catalog tenants). Strictly scoped to the
+/// tenant in the request's [`common::auth::TenantContext`].
+pub async fn whoami<S: RouterState>(
+    State(state): State<S>,
+    TenantContextExtractor(ctx): TenantContextExtractor,
+) -> Response {
+    // Config-defined tenants first (mirrors Authenticator precedence).
+    if let Some(tc) = state
+        .config()
+        .auth
+        .tenants
+        .iter()
+        .find(|t| t.id == ctx.tenant_id)
+    {
+        let default_dataset = tc.default_dataset.clone().or_else(|| {
+            tc.datasets
+                .iter()
+                .find(|d| d.is_default)
+                .map(|d| d.id.clone())
+        });
+        let response = WhoamiResponse {
+            tenant: WhoamiTenant {
+                id: tc.id.clone(),
+                slug: tc.slug.clone(),
+                name: tc.name.clone(),
+            },
+            datasets: tc
+                .datasets
+                .iter()
+                .map(|d| WhoamiDataset {
+                    id: d.id.clone(),
+                    slug: d.slug.clone(),
+                    is_default: d.is_default,
+                })
+                .collect(),
+            default_dataset,
+        };
+        return Json(response).into_response();
+    }
+
+    // Database-defined tenants (created via the admin API).
+    let tenant = match state.catalog().get_tenant(&ctx.tenant_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return error_response(404, format!("Tenant '{}' not found", ctx.tenant_id));
+        }
+        Err(e) => {
+            tracing::error!(tenant_id = %ctx.tenant_id, error = %e, "whoami: tenant lookup failed");
+            return error_response(500, "Failed to resolve tenant".to_string());
+        }
+    };
+    let datasets = match state.catalog().get_datasets(&ctx.tenant_id).await {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::error!(tenant_id = %ctx.tenant_id, error = %e, "whoami: dataset lookup failed");
+            return error_response(500, "Failed to resolve datasets".to_string());
+        }
+    };
+
+    let response = WhoamiResponse {
+        tenant: WhoamiTenant {
+            // DB tenants use IDs as slugs, matching the Authenticator.
+            id: tenant.id.clone(),
+            slug: tenant.id.clone(),
+            name: tenant.name,
+        },
+        datasets: datasets
+            .into_iter()
+            .map(|d| WhoamiDataset {
+                is_default: Some(d.name.as_str()) == tenant.default_dataset.as_deref(),
+                slug: d.name.clone(),
+                id: d.name,
+            })
+            .collect(),
+        default_dataset: tenant.default_dataset,
+    };
+    Json(response).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{InMemoryStateImpl, create_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+    use common::catalog::Catalog;
+    use common::config::{ApiKeyConfig, AuthConfig, Configuration, DatasetConfig, TenantConfig};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    fn tenant(
+        id: &str,
+        key: &str,
+        datasets: &[(&str, bool)],
+        default_dataset: Option<&str>,
+    ) -> TenantConfig {
+        TenantConfig {
+            id: id.to_string(),
+            slug: format!("{id}-slug"),
+            name: format!("{id} Inc"),
+            default_dataset: default_dataset.map(str::to_string),
+            datasets: datasets
+                .iter()
+                .map(|(name, is_default)| DatasetConfig {
+                    id: name.to_string(),
+                    slug: name.to_string(),
+                    is_default: *is_default,
+                    storage: None,
+                })
+                .collect(),
+            api_keys: vec![ApiKeyConfig {
+                key: key.to_string(),
+                name: Some("test".to_string()),
+            }],
+            schema_config: None,
+            limits: None,
+        }
+    }
+
+    async fn test_app() -> axum::Router {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let config = Configuration {
+            auth: AuthConfig {
+                tenants: vec![
+                    tenant(
+                        "acme",
+                        "acme-key",
+                        &[("production", true), ("staging", false)],
+                        Some("production"),
+                    ),
+                    tenant("globex", "globex-key", &[("main", true)], Some("main")),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        create_router(InMemoryStateImpl::new(catalog, config))
+    }
+
+    async fn create_session(app: &axum::Router, body: Value) -> axum::response::Response {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/ui/session")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.clone().oneshot(request).await.unwrap()
+    }
+
+    async fn json_body(res: axum::response::Response) -> Value {
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// The Set-Cookie value minus attributes, e.g. `signaldb_session=abc`.
+    fn cookie_pair(res: &axum::response::Response) -> String {
+        let set_cookie = res
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("Set-Cookie present")
+            .to_str()
+            .unwrap();
+        set_cookie
+            .split(';')
+            .next()
+            .expect("cookie name=value")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn create_session_with_valid_key_sets_httponly_cookie() {
+        let app = test_app().await;
+        let res = create_session(
+            &app,
+            serde_json::json!({"api_key": "acme-key", "tenant": "acme", "dataset": "staging"}),
+        )
+        .await;
+
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        let set_cookie = res
+            .headers()
+            .get(header::SET_COOKIE)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(set_cookie.starts_with("signaldb_session="));
+        assert!(set_cookie.contains("HttpOnly"));
+        assert!(set_cookie.contains("SameSite=Strict"));
+        assert!(set_cookie.contains("Path=/"));
+
+        // The cookie value round-trips through the shared session codec.
+        let value = cookie_pair(&res);
+        let value = value.strip_prefix("signaldb_session=").unwrap();
+        let session = common::auth::decode_session(value).expect("decodable session");
+        assert_eq!(session.api_key, "acme-key");
+        assert_eq!(session.tenant, "acme");
+        assert_eq!(session.dataset.as_deref(), Some("staging"));
+    }
+
+    #[tokio::test]
+    async fn create_session_with_invalid_key_returns_401_json() {
+        let app = test_app().await;
+        let res = create_session(
+            &app,
+            serde_json::json!({"api_key": "wrong-key", "tenant": "acme"}),
+        )
+        .await;
+
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        assert!(res.headers().get(header::SET_COOKIE).is_none());
+        let body = json_body(res).await;
+        assert!(body["error"].as_str().unwrap().contains("API key"));
+    }
+
+    #[tokio::test]
+    async fn create_session_with_wrong_dataset_is_rejected() {
+        let app = test_app().await;
+        let res = create_session(
+            &app,
+            serde_json::json!({"api_key": "acme-key", "tenant": "acme", "dataset": "nope"}),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        assert!(res.headers().get(header::SET_COOKIE).is_none());
+    }
+
+    #[tokio::test]
+    async fn session_cookie_authenticates_query_route() {
+        let app = test_app().await;
+        let res = create_session(
+            &app,
+            serde_json::json!({"api_key": "acme-key", "tenant": "acme"}),
+        )
+        .await;
+        let cookie = cookie_pair(&res);
+
+        // A query route accepts the cookie in place of the auth headers.
+        let request = Request::builder()
+            .uri("/tempo/api/echo")
+            .header(header::COOKIE, &cookie)
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        // Without cookie or headers the same route rejects the request.
+        let request = Request::builder()
+            .uri("/tempo/api/echo")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn explicit_headers_override_session_cookie() {
+        let app = test_app().await;
+        let res = create_session(
+            &app,
+            serde_json::json!({"api_key": "acme-key", "tenant": "acme"}),
+        )
+        .await;
+        let cookie = cookie_pair(&res);
+
+        // Full explicit headers for another tenant win over the cookie.
+        let request = Request::builder()
+            .uri("/api/v1/whoami")
+            .header(header::COOKIE, &cookie)
+            .header("authorization", "Bearer globex-key")
+            .header("x-tenant-id", "globex")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = json_body(res).await;
+        assert_eq!(body["tenant"]["id"], "globex");
+    }
+
+    #[tokio::test]
+    async fn whoami_returns_only_own_tenant_and_datasets() {
+        let app = test_app().await;
+        let request = Request::builder()
+            .uri("/api/v1/whoami")
+            .header("authorization", "Bearer acme-key")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = json_body(res).await;
+        assert_eq!(body["tenant"]["id"], "acme");
+        assert_eq!(body["tenant"]["slug"], "acme-slug");
+        assert_eq!(body["tenant"]["name"], "acme Inc");
+        assert_eq!(body["default_dataset"], "production");
+        let datasets = body["datasets"].as_array().unwrap();
+        assert_eq!(datasets.len(), 2);
+        assert_eq!(datasets[0]["id"], "production");
+        assert_eq!(datasets[0]["is_default"], true);
+        assert_eq!(datasets[1]["id"], "staging");
+        assert_eq!(datasets[1]["is_default"], false);
+        // No cross-tenant data leaks into the response.
+        assert!(!body.to_string().contains("globex"));
+    }
+
+    #[tokio::test]
+    async fn whoami_requires_authentication() {
+        let app = test_app().await;
+        let request = Request::builder()
+            .uri("/api/v1/whoami")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn logout_clears_session_cookie() {
+        let app = test_app().await;
+        let request = Request::builder()
+            .method("DELETE")
+            .uri("/ui/session")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.clone().oneshot(request).await.unwrap();
+
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
+        let set_cookie = res
+            .headers()
+            .get(header::SET_COOKIE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(set_cookie.starts_with("signaldb_session=;"));
+        assert!(set_cookie.contains("Max-Age=0"));
+        assert!(set_cookie.contains("HttpOnly"));
+    }
+}

--- a/src/router/src/lib.rs
+++ b/src/router/src/lib.rs
@@ -230,6 +230,9 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
                 .layer(query_rate_layer.clone())
                 .layer(auth_layer.clone()),
         )
+        // UI session login/logout (public; sets/clears the HttpOnly session
+        // cookie the auth middleware accepts in place of auth headers)
+        .merge(endpoints::session::router())
         // Explore UI static assets (public, served from SIGNALDB_UI_DIR)
         .nest_service("/ui", ui::service_from_env())
         // Admin routes with admin authentication
@@ -237,6 +240,7 @@ pub fn create_router<S: RouterState>(state: S) -> Router {
         .nest(
             "/api/v1",
             endpoints::tenant::router()
+                .route("/whoami", get(endpoints::session::whoami::<S>))
                 .layer(query_rate_layer)
                 .layer(auth_layer),
         )

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -12,10 +12,13 @@ pnpm ui:dev                                # http://localhost:5173/ui/
 ```
 
 The dev server hot-reloads and proxies all API paths (`/loki`, `/tempo`,
-`/prometheus`, `/api`) to `SIGNALDB_TARGET` — a local `./scripts/run-dev.sh`
-instance or any live deployment. Auth headers are injected by the proxy from
-`.env.local`, so browser code is identical to the embedded production build
-and API keys never reach the client.
+`/prometheus`, `/api`, `/ui/session`) to `SIGNALDB_TARGET` — a local
+`./scripts/run-dev.sh` instance or any live deployment. Auth headers are
+injected by the proxy from `.env.local`, so browser code is identical to
+the embedded production build and API keys never reach the client. In the
+embedded build there is no proxy; queries rejected with 401 open a login
+form that creates an HttpOnly session cookie via `POST /ui/session` (see
+`docs/users/explore-ui.md`).
 
 ## Commands
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { setTenantContext } from "./api/http";
 import { ExploreView } from "./features/explore/ExploreView";
+import { LoginGate } from "./features/shell/LoginPanel";
 import { TopBar } from "./features/shell/TopBar";
 import { useExploreState } from "./lib/urlState";
 
@@ -14,6 +15,11 @@ export function App() {
       <main className="app-main">
         <ExploreView state={state} update={update} />
       </main>
+      <LoginGate
+        tenant={state.tenant}
+        dataset={state.dataset}
+        onLoggedIn={({ tenant, dataset }) => update({ tenant, dataset })}
+      />
     </div>
   );
 }

--- a/src/ui/src/api/http.ts
+++ b/src/ui/src/api/http.ts
@@ -7,6 +7,24 @@ export interface TenantContext {
   dataset: string;
 }
 
+/** HTTP error with the response status attached, so callers can react to
+ * specific codes (401 → show the login form). */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/** True when the error is an authentication failure (missing/invalid
+ * credentials) that a login can fix. */
+export function isAuthError(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401;
+}
+
 let current: TenantContext = { tenant: "", dataset: "" };
 
 export function setTenantContext(ctx: TenantContext): void {

--- a/src/ui/src/api/loki.ts
+++ b/src/ui/src/api/loki.ts
@@ -3,7 +3,7 @@
 // attributes appear as stream labels.
 
 import { msToNanos, nanosToMs, type ResolvedRange } from "../lib/time";
-import { tenantHeaders } from "./http";
+import { ApiError, tenantHeaders } from "./http";
 
 export interface LogRow {
   tsNs: string;
@@ -39,8 +39,9 @@ async function lokiFetch<T>(path: string, params: URLSearchParams): Promise<T> {
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
+    throw new ApiError(
       `Loki API ${path} failed (${res.status}): ${body.slice(0, 300)}`,
+      res.status,
     );
   }
   return (await res.json()) as T;

--- a/src/ui/src/api/prom.ts
+++ b/src/ui/src/api/prom.ts
@@ -1,7 +1,7 @@
 // Client for the router's Prometheus-compatible API (/prometheus/api/v1).
 
 import type { ResolvedRange } from "../lib/time";
-import { tenantHeaders } from "./http";
+import { ApiError, tenantHeaders } from "./http";
 
 export interface PromSeries {
   labels: Record<string, string>;
@@ -36,8 +36,9 @@ export async function promQueryRange(
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
+    throw new ApiError(
       `Prometheus query_range failed (${res.status}): ${body.slice(0, 300)}`,
+      res.status,
     );
   }
   const json = (await res.json()) as PromResponse;

--- a/src/ui/src/api/session.test.ts
+++ b/src/ui/src/api/session.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, setTenantContext } from "./http";
+import { createSession, deleteSession, whoami } from "./session";
+
+function mockFetchOnce(body: unknown, status = 200) {
+  const fn = vi.fn().mockResolvedValue(
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createSession", () => {
+  it("POSTs the credentials as JSON and resolves on 204", async () => {
+    const fn = mockFetchOnce(null, 204);
+    await createSession({ apiKey: "sk-1", tenant: "acme", dataset: "prod" });
+    expect(String(fn.mock.calls[0]?.[0])).toBe("/ui/session");
+    const init = fn.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      api_key: "sk-1",
+      tenant: "acme",
+      dataset: "prod",
+    });
+  });
+
+  it("omits the dataset field when not provided", async () => {
+    const fn = mockFetchOnce(null, 204);
+    await createSession({ apiKey: "sk-1", tenant: "acme" });
+    const init = fn.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      api_key: "sk-1",
+      tenant: "acme",
+    });
+  });
+
+  it("throws the server's error message with the status on failure", async () => {
+    mockFetchOnce({ error: "Invalid or revoked API key" }, 401);
+    const err = await createSession({ apiKey: "bad", tenant: "acme" }).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+    expect((err as ApiError).message).toBe("Invalid or revoked API key");
+  });
+
+  it("falls back to a generic message on non-JSON error bodies", async () => {
+    const fn = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fn);
+    await expect(createSession({ apiKey: "k", tenant: "t" })).rejects.toThrow(
+      /Login failed \(500\)/,
+    );
+  });
+});
+
+describe("deleteSession", () => {
+  it("sends DELETE /ui/session", async () => {
+    const fn = mockFetchOnce(null, 204);
+    await deleteSession();
+    expect(String(fn.mock.calls[0]?.[0])).toBe("/ui/session");
+    expect((fn.mock.calls[0]?.[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("throws on failure", async () => {
+    mockFetchOnce({}, 500);
+    await expect(deleteSession()).rejects.toThrow(/Logout failed \(500\)/);
+  });
+});
+
+describe("whoami", () => {
+  const BODY = {
+    tenant: { id: "acme", slug: "acme", name: "Acme Corp" },
+    datasets: [
+      { id: "production", slug: "production", is_default: true },
+      { id: "staging", slug: "staging", is_default: false },
+    ],
+    default_dataset: "production",
+  };
+
+  it("returns the parsed response and attaches tenant headers", async () => {
+    const fn = mockFetchOnce(BODY);
+    setTenantContext({ tenant: "acme", dataset: "prod" });
+    try {
+      const res = await whoami();
+      expect(res).toEqual(BODY);
+    } finally {
+      setTenantContext({ tenant: "", dataset: "" });
+    }
+    expect(String(fn.mock.calls[0]?.[0])).toBe("/api/v1/whoami");
+    const init = fn.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      "X-Tenant-ID": "acme",
+      "X-Dataset-ID": "prod",
+    });
+  });
+
+  it("throws an ApiError carrying the status when unavailable", async () => {
+    mockFetchOnce({}, 404);
+    const err = await whoami().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+  });
+});

--- a/src/ui/src/api/session.ts
+++ b/src/ui/src/api/session.ts
@@ -1,0 +1,66 @@
+// Client for the router's UI session endpoints (/ui/session) and the
+// tenant-scoped whoami endpoint (/api/v1/whoami). The session cookie is
+// HttpOnly — browser code never reads it; it only creates and clears it.
+
+import { ApiError, tenantHeaders } from "./http";
+
+export interface SessionCredentials {
+  apiKey: string;
+  tenant: string;
+  dataset?: string;
+}
+
+export interface WhoamiDataset {
+  id: string;
+  slug: string;
+  is_default: boolean;
+}
+
+export interface WhoamiResponse {
+  tenant: { id: string; slug: string; name: string };
+  datasets: WhoamiDataset[];
+  default_dataset: string | null;
+}
+
+/** Create a session: the server validates the credentials and sets the
+ * HttpOnly session cookie. Throws `ApiError` with the server's message on
+ * invalid credentials. */
+export async function createSession(creds: SessionCredentials): Promise<void> {
+  const res = await fetch("/ui/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      api_key: creds.apiKey,
+      tenant: creds.tenant,
+      ...(creds.dataset ? { dataset: creds.dataset } : {}),
+    }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new ApiError(
+      body?.error ?? `Login failed (${res.status})`,
+      res.status,
+    );
+  }
+}
+
+/** Log out: the server clears the session cookie. */
+export async function deleteSession(): Promise<void> {
+  const res = await fetch("/ui/session", { method: "DELETE" });
+  if (!res.ok) {
+    throw new ApiError(`Logout failed (${res.status})`, res.status);
+  }
+}
+
+/** Fetch the authenticated tenant and its datasets. Throws `ApiError`
+ * (404 on servers without the endpoint, 401 when unauthenticated) — the
+ * UI falls back to free-text tenant entry on any failure. */
+export async function whoami(): Promise<WhoamiResponse> {
+  const res = await fetch("/api/v1/whoami", { headers: tenantHeaders() });
+  if (!res.ok) {
+    throw new ApiError(`whoami failed (${res.status})`, res.status);
+  }
+  return (await res.json()) as WhoamiResponse;
+}

--- a/src/ui/src/api/tempo.ts
+++ b/src/ui/src/api/tempo.ts
@@ -1,7 +1,7 @@
 // Client for the router's Tempo-compatible API (/tempo/api).
 
 import type { ResolvedRange } from "../lib/time";
-import { tenantHeaders } from "./http";
+import { ApiError, tenantHeaders } from "./http";
 
 export type AttrValue = string | number | boolean;
 
@@ -91,8 +91,9 @@ async function tempoFetch<T>(
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(
+    throw new ApiError(
       `Tempo API ${path} failed (${res.status}): ${body.slice(0, 300)}`,
+      res.status,
     );
   }
   return (await res.json()) as T;

--- a/src/ui/src/features/shell/LoginPanel.css
+++ b/src/ui/src/features/shell/LoginPanel.css
@@ -1,0 +1,78 @@
+.login-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  backdrop-filter: blur(2px);
+}
+
+.login-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(320px, calc(100vw - 32px));
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+.login-panel h2 {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.login-hint {
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.login-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.login-optional {
+  color: var(--faint);
+}
+
+.login-panel input {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 5px;
+  padding: 6px 8px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.login-panel input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.login-error {
+  font-size: 12px;
+  color: var(--err);
+}
+
+.login-panel button[type="submit"] {
+  margin-top: 4px;
+  padding: 7px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.login-panel button[type="submit"]:disabled {
+  opacity: 0.6;
+}

--- a/src/ui/src/features/shell/LoginPanel.test.tsx
+++ b/src/ui/src/features/shell/LoginPanel.test.tsx
@@ -1,0 +1,116 @@
+import { useQuery } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../../api/http";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { LoginGate, LoginPanel } from "./LoginPanel";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("LoginPanel", () => {
+  it("POSTs the entered credentials and reports success", async () => {
+    const fetchFn = stubFetchRoutes([{ match: "/ui/session", body: null }]);
+    const onSuccess = vi.fn();
+    renderWithClient(<LoginPanel tenant="acme" onSuccess={onSuccess} />);
+
+    await userEvent.type(screen.getByLabelText("API key"), "sk-secret");
+    await userEvent.type(screen.getByLabelText("Login dataset"), "prod");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    expect(onSuccess).toHaveBeenCalledWith({ tenant: "acme", dataset: "prod" });
+    const call = fetchFn.mock.calls.find((c) =>
+      String(c[0]).includes("/ui/session"),
+    );
+    const init = call?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      api_key: "sk-secret",
+      tenant: "acme",
+      dataset: "prod",
+    });
+  });
+
+  it("shows the server's error message on rejected credentials", async () => {
+    stubFetchRoutes([
+      {
+        match: "/ui/session",
+        body: { error: "Invalid or revoked API key" },
+        status: 401,
+      },
+    ]);
+    const onSuccess = vi.fn();
+    renderWithClient(<LoginPanel tenant="acme" onSuccess={onSuccess} />);
+
+    await userEvent.type(screen.getByLabelText("API key"), "bad-key");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Invalid or revoked API key",
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("LoginGate", () => {
+  function Probe({ queryFn }: { queryFn: () => Promise<string> }) {
+    const query = useQuery({ queryKey: ["probe"], queryFn, retry: false });
+    return <div data-testid="probe">{query.data ?? "pending"}</div>;
+  }
+
+  it("appears on a 401 query failure and retries after login", async () => {
+    stubFetchRoutes([{ match: "/ui/session", body: null }]);
+    // First query fails as unauthenticated; after login it succeeds.
+    let calls = 0;
+    const queryFn = vi.fn().mockImplementation(() => {
+      calls += 1;
+      return calls === 1
+        ? Promise.reject(new ApiError("Loki API failed (401)", 401))
+        : Promise.resolve("data");
+    });
+
+    renderWithClient(
+      <>
+        <Probe queryFn={queryFn} />
+        <LoginGate tenant="acme" />
+      </>,
+    );
+
+    // The 401 surfaces the login dialog.
+    const dialog = await screen.findByRole("dialog", { name: "Sign in" });
+    expect(dialog).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText("API key"), "sk-secret");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Login hides the dialog and invalidation retries the query.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Sign in" }),
+      ).not.toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("probe")).toHaveTextContent("data"),
+    );
+    expect(queryFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays hidden for non-auth query failures", async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValue(new ApiError("Loki API failed (500)", 500));
+    renderWithClient(
+      <>
+        <Probe queryFn={queryFn} />
+        <LoginGate />
+      </>,
+    );
+    await waitFor(() => expect(queryFn).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("dialog", { name: "Sign in" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/src/features/shell/LoginPanel.tsx
+++ b/src/ui/src/features/shell/LoginPanel.tsx
@@ -1,0 +1,138 @@
+// Session login for embedded deployments: when any query fails with 401
+// the gate overlays a minimal form that POSTs /ui/session; on success the
+// React Query cache is invalidated so every view retries with the new
+// session cookie.
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { isAuthError } from "../../api/http";
+import { createSession } from "../../api/session";
+import "./LoginPanel.css";
+
+export interface LoginResult {
+  tenant: string;
+  dataset: string;
+}
+
+interface GateProps {
+  /** Initial values for the form (usually the current URL state). */
+  tenant?: string;
+  dataset?: string;
+  /** Called after a successful login, before queries are retried. */
+  onLoggedIn?: (result: LoginResult) => void;
+}
+
+/**
+ * Watches the query cache for 401 failures and shows the login panel when
+ * one occurs. Successful login hides the panel and refetches everything.
+ */
+export function LoginGate({ tenant, dataset, onLoggedIn }: GateProps) {
+  const client = useQueryClient();
+  const [needsLogin, setNeedsLogin] = useState(false);
+
+  useEffect(
+    () =>
+      client.getQueryCache().subscribe((event) => {
+        if (isAuthError(event.query.state.error)) {
+          setNeedsLogin(true);
+        }
+      }),
+    [client],
+  );
+
+  if (!needsLogin) return null;
+
+  return (
+    <LoginPanel
+      tenant={tenant}
+      dataset={dataset}
+      onSuccess={(result) => {
+        setNeedsLogin(false);
+        onLoggedIn?.(result);
+        // Retry everything with the fresh session cookie.
+        void client.invalidateQueries();
+      }}
+    />
+  );
+}
+
+interface PanelProps {
+  tenant?: string;
+  dataset?: string;
+  onSuccess: (result: LoginResult) => void;
+}
+
+export function LoginPanel({ tenant, dataset, onSuccess }: PanelProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <div className="login-backdrop" role="dialog" aria-label="Sign in">
+      <form
+        className="login-panel"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const data = new FormData(e.currentTarget);
+          const creds = {
+            apiKey: String(data.get("api_key") ?? ""),
+            tenant: String(data.get("tenant") ?? "").trim(),
+            dataset: String(data.get("dataset") ?? "").trim() || undefined,
+          };
+          setBusy(true);
+          setError(null);
+          createSession(creds)
+            .then(() =>
+              onSuccess({ tenant: creds.tenant, dataset: creds.dataset ?? "" }),
+            )
+            .catch((err: unknown) => {
+              setError(err instanceof Error ? err.message : String(err));
+            })
+            .finally(() => setBusy(false));
+        }}
+      >
+        <h2>Sign in to SignalDB</h2>
+        <p className="login-hint">
+          Queries were rejected as unauthenticated. Enter a tenant API key to
+          start a browser session.
+        </p>
+        <label>
+          API key
+          <input
+            name="api_key"
+            type="password"
+            aria-label="API key"
+            autoComplete="off"
+            required
+            autoFocus
+          />
+        </label>
+        <label>
+          Tenant
+          <input
+            name="tenant"
+            aria-label="Login tenant"
+            defaultValue={tenant ?? ""}
+            required
+          />
+        </label>
+        <label>
+          Dataset <span className="login-optional">(optional)</span>
+          <input
+            name="dataset"
+            aria-label="Login dataset"
+            defaultValue={dataset ?? ""}
+            placeholder="tenant default"
+          />
+        </label>
+        {error && (
+          <p className="login-error" role="alert">
+            {error}
+          </p>
+        )}
+        <button type="submit" disabled={busy}>
+          {busy ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/ui/src/features/shell/TopBar.css
+++ b/src/ui/src/features/shell/TopBar.css
@@ -60,13 +60,23 @@
   align-items: center;
 }
 
-.tenant-form input {
+.tenant-form input,
+.tenant-form select {
   border: 1px solid var(--border);
   background: var(--surface2);
   border-radius: 5px;
   padding: 3px 8px;
   font-size: 12px;
   width: 130px;
+  color: var(--text);
+}
+
+/* Read-only tenant display when the server reports the session's tenant. */
+.tenant-fixed {
+  font-size: 12px;
+  padding: 3px 8px;
+  border: 1px solid transparent;
+  color: var(--dim);
 }
 
 .tenant-form button {

--- a/src/ui/src/features/shell/TopBar.test.tsx
+++ b/src/ui/src/features/shell/TopBar.test.tsx
@@ -1,0 +1,90 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_STATE } from "../../lib/urlState";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { TopBar } from "./TopBar";
+
+const WHOAMI = {
+  tenant: { id: "acme", slug: "acme", name: "Acme Corp" },
+  datasets: [
+    { id: "production", slug: "production", is_default: true },
+    { id: "staging", slug: "staging", is_default: false },
+  ],
+  default_dataset: "production",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TenantSelector with whoami", () => {
+  it("shows the tenant read-only and datasets as a selector", async () => {
+    stubFetchRoutes([{ match: "/api/v1/whoami", body: WHOAMI }]);
+    const update = vi.fn();
+    renderWithClient(<TopBar state={DEFAULT_STATE} update={update} />);
+
+    // Chip reflects the server-reported tenant and default dataset.
+    await waitFor(() =>
+      expect(
+        screen.getByTitle("Tenant / dataset context for all queries"),
+      ).toHaveTextContent("acme·production"),
+    );
+    await userEvent.click(
+      screen.getByTitle("Tenant / dataset context for all queries"),
+    );
+
+    // Tenant is plain text, not an editable input.
+    expect(screen.queryByLabelText("Tenant")).not.toBeInTheDocument();
+    expect(screen.getByText("acme")).toBeInTheDocument();
+
+    // Dataset is a select over the tenant's datasets, defaulting to the
+    // default dataset.
+    const select = screen.getByLabelText("Dataset");
+    expect(select.tagName).toBe("SELECT");
+    expect(select).toHaveValue("production");
+    const options = screen
+      .getAllByRole("option")
+      .map((o) => (o as HTMLOptionElement).value);
+    expect(options).toEqual(["production", "staging"]);
+
+    await userEvent.selectOptions(select, "staging");
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(update).toHaveBeenCalledWith({ tenant: "acme", dataset: "staging" });
+  });
+
+  it("keeps an explicitly selected dataset over the default", async () => {
+    stubFetchRoutes([{ match: "/api/v1/whoami", body: WHOAMI }]);
+    renderWithClient(
+      <TopBar
+        state={{ ...DEFAULT_STATE, tenant: "acme", dataset: "staging" }}
+        update={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByTitle("Tenant / dataset context for all queries"),
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Dataset")).toHaveValue("staging"),
+    );
+  });
+
+  it("falls back to free-text inputs when whoami is unavailable", async () => {
+    // Older servers: /api/v1/whoami does not exist (404).
+    stubFetchRoutes([
+      { match: "/api/v1/whoami", body: { error: "not found" }, status: 404 },
+    ]);
+    const update = vi.fn();
+    renderWithClient(<TopBar state={DEFAULT_STATE} update={update} />);
+
+    await userEvent.click(
+      screen.getByTitle("Tenant / dataset context for all queries"),
+    );
+    const tenantInput = await screen.findByLabelText("Tenant");
+    expect(tenantInput.tagName).toBe("INPUT");
+    await userEvent.type(tenantInput, "acme");
+    await userEvent.type(screen.getByLabelText("Dataset"), "prod");
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(update).toHaveBeenCalledWith({ tenant: "acme", dataset: "prod" });
+  });
+});

--- a/src/ui/src/features/shell/TopBar.tsx
+++ b/src/ui/src/features/shell/TopBar.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { DEFAULT_DATASET, DEFAULT_TENANT } from "../../api/http";
+import { whoami } from "../../api/session";
 import type { ExploreState } from "../../lib/urlState";
 import "./TopBar.css";
 
@@ -37,8 +39,21 @@ export function TopBar({ state, update }: Props) {
 
 function TenantSelector({ state, update }: Props) {
   const [editing, setEditing] = useState(false);
-  const effectiveTenant = state.tenant || DEFAULT_TENANT;
-  const effectiveDataset = state.dataset || DEFAULT_DATASET;
+  // The server knows which tenant the session/key belongs to and which
+  // datasets exist; when available (issue #771) the tenant becomes
+  // read-only and the dataset a proper selector. On any failure (older
+  // server without the endpoint, unauthenticated) the free-text form
+  // remains as the fallback.
+  const { data: who } = useQuery({
+    queryKey: ["whoami"],
+    queryFn: whoami,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const effectiveTenant = state.tenant || who?.tenant.id || DEFAULT_TENANT;
+  const effectiveDataset =
+    state.dataset || who?.default_dataset || DEFAULT_DATASET;
 
   if (!editing) {
     return (
@@ -52,6 +67,43 @@ function TenantSelector({ state, update }: Props) {
         {effectiveDataset || "default"}
         <span className="tenant-caret">▾</span>
       </button>
+    );
+  }
+
+  if (who) {
+    return (
+      <form
+        className="tenant-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const data = new FormData(e.currentTarget);
+          update({
+            tenant: who.tenant.id,
+            dataset: String(data.get("dataset") ?? ""),
+          });
+          setEditing(false);
+        }}
+      >
+        <span className="tenant-fixed" title={who.tenant.name}>
+          {who.tenant.id}
+        </span>
+        <select
+          name="dataset"
+          aria-label="Dataset"
+          defaultValue={state.dataset || who.default_dataset || ""}
+          autoFocus
+        >
+          {who.datasets.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.is_default ? `${d.id} (default)` : d.id}
+            </option>
+          ))}
+        </select>
+        <button type="submit">Apply</button>
+        <button type="button" onClick={() => setEditing(false)}>
+          Cancel
+        </button>
+      </form>
     );
   }
 

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -4,8 +4,9 @@ import { defineConfig, loadEnv, type ProxyOptions } from "vite";
 
 // Paths the SignalDB router serves; the dev server forwards them to a live
 // instance so the browser only ever sees same-origin requests, exactly as in
-// the embedded production build.
-const PROXIED_PATHS = ["/loki", "/tempo", "/prometheus", "/api"];
+// the embedded production build. /ui/session is the router's session login
+// endpoint — everything else under /ui stays with the dev server itself.
+const PROXIED_PATHS = ["/loki", "/tempo", "/prometheus", "/api", "/ui/session"];
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "SIGNALDB_");


### PR DESCRIPTION
The explore UI served at `:3000/ui` could not query outside the dev proxy: browsers had no way to authenticate. This adds a session flow plus a tenant-scoped whoami endpoint and wires the UI to both.

Closes #771

## Backend (router / common)

- **`POST /ui/session`** (public): validates `{"api_key", "tenant", "dataset"?}` via the existing `Authenticator` and sets an `HttpOnly`, `SameSite=Strict`, `Path=/` cookie (`signaldb_session` = URL-safe base64 JSON of the credential triple — no invented crypto; the key is client-held either way, the cookie just keeps it out of JS reach). 204 on success, 401/403 with a JSON `error` body otherwise. **`DELETE /ui/session`** clears the cookie.
- **`auth_middleware` fallback**: with no `Authorization` header, the session cookie supplies the API key and any tenant/dataset values not given as headers; explicit `X-Tenant-ID`/`X-Dataset-ID` headers always win. Cookie values pass the same validation as headers. Admin middleware untouched.
- **`GET /api/v1/whoami`** (behind tenant auth): the authenticated tenant (id, slug, name), its datasets (id, slug, is_default), and default_dataset — resolved the same way the `Authenticator` does (config tenants first, catalog tenants otherwise). Strictly scoped to the request's tenant.

## Frontend (src/ui)

- `src/api/session.ts`: `createSession` / `deleteSession` / `whoami` clients; API clients now throw `ApiError` carrying the HTTP status.
- **Login flow**: any query failing with 401 opens a minimal login overlay that POSTs `/ui/session`, then invalidates the React Query cache so all views retry with the fresh cookie.
- **Tenant selector (#771)**: backed by `whoami` — tenant becomes a read-only display, dataset a `<select>` of the tenant's datasets defaulting to `default_dataset`; free-text fallback kept for older servers / errors. URL state and `X-Tenant-ID`/`X-Dataset-ID` header plumbing remain the source of truth.
- Vite dev proxy forwards `/ui/session` so the login flow also works in dev.

## Tests

Backend (axum `oneshot` through `create_router`):
- `create_session_with_valid_key_sets_httponly_cookie`, `create_session_with_invalid_key_returns_401_json`, `create_session_with_wrong_dataset_is_rejected`
- `session_cookie_authenticates_query_route`, `explicit_headers_override_session_cookie`
- `whoami_returns_only_own_tenant_and_datasets`, `whoami_requires_authentication`, `logout_clears_session_cookie`
- middleware: `session_cookie_round_trip_authenticates_request`, `test_extract_auth_headers_uses_session_cookie_without_authorization`, `test_extract_auth_headers_explicit_headers_win_over_cookie`, `test_extract_auth_headers_malformed_cookie_is_missing_auth`, `test_extract_auth_headers_cookie_values_are_validated`
- session codec unit tests in `common::auth::session`

Frontend (vitest + testing-library, 126 tests green):
- `session.test.ts` (create/delete/whoami clients, error paths)
- `LoginPanel.test.tsx` (submit success/failure, `LoginGate` shows on 401, retries after login, ignores non-401 errors)
- `TopBar.test.tsx` (read-only tenant + dataset select defaulting to default_dataset, explicit dataset preserved, free-text fallback on 404)

## Docs

`docs/users/explore-ui.md` (signing in on an embedded deployment), `docs/users/authentication.md` (browser-session surface + whoami), `docs/architecture/overview.md`, and the architecture/crate-map/multi-tenancy skills.
