### PR TITLE
chore(deps): bump iceberg-rust to 96f28c18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.10.0"
-source = "git+https://github.com/JanKaul/iceberg-rust?rev=170ef972#170ef97276860d85edfa86bfd3d40cda5f56b383"
+source = "git+https://github.com/JanKaul/iceberg-rust?rev=96f28c18#96f28c18b69debcbff8b9db2b2b1c3e761097a5c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3469,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.10.0"
-source = "git+https://github.com/JanKaul/iceberg-rust?rev=170ef972#170ef97276860d85edfa86bfd3d40cda5f56b383"
+source = "git+https://github.com/JanKaul/iceberg-rust?rev=96f28c18#96f28c18b69debcbff8b9db2b2b1c3e761097a5c"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.10.0"
-source = "git+https://github.com/JanKaul/iceberg-rust?rev=170ef972#170ef97276860d85edfa86bfd3d40cda5f56b383"
+source = "git+https://github.com/JanKaul/iceberg-rust?rev=96f28c18#96f28c18b69debcbff8b9db2b2b1c3e761097a5c"
 dependencies = [
  "apache-avro",
  "arrow-schema",
@@ -3531,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "iceberg-sql-catalog"
 version = "0.10.0"
-source = "git+https://github.com/JanKaul/iceberg-rust?rev=170ef972#170ef97276860d85edfa86bfd3d40cda5f56b383"
+source = "git+https://github.com/JanKaul/iceberg-rust?rev=96f28c18#96f28c18b69debcbff8b9db2b2b1c3e761097a5c"
 dependencies = [
  "async-trait",
  "futures",
@@ -5446,7 +5446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -5467,7 +5467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,9 @@ arrow-flight = { version = "58.3.0" }
 object_store = { version = "0.13.2", features = ["aws"] }
 
 # Iceberg table format support (schema, catalog, and write operations)
-datafusion_iceberg = { git = "https://github.com/JanKaul/iceberg-rust", rev = "170ef972" }
-iceberg-rust = { git = "https://github.com/JanKaul/iceberg-rust", rev = "170ef972" }
-iceberg-sql-catalog = { git = "https://github.com/JanKaul/iceberg-rust", rev = "170ef972" }
+datafusion_iceberg = { git = "https://github.com/JanKaul/iceberg-rust", rev = "96f28c18" }
+iceberg-rust = { git = "https://github.com/JanKaul/iceberg-rust", rev = "96f28c18" }
+iceberg-sql-catalog = { git = "https://github.com/JanKaul/iceberg-rust", rev = "96f28c18" }
 
 tonic = { version = "0.14.2", features = ["transport", "channel"] }
 tonic-build = "0.14.2"

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -195,7 +195,7 @@ impl ParquetRewriter {
         };
         // The table's current label_<key> columns and the pinned allowlist.
         let label_columns: Vec<String> = table
-            .current_schema(None)
+            .current_schema()
             .map(|schema| {
                 schema
                     .fields()

--- a/src/writer/src/storage/iceberg.rs
+++ b/src/writer/src/storage/iceberg.rs
@@ -85,7 +85,7 @@ impl IcebergTableWriter {
         );
 
         let table_metadata = table.metadata();
-        let current_schema = table.current_schema(None)?;
+        let current_schema = table.current_schema()?;
         log::debug!("Table location: {}", table_metadata.location);
         log::debug!("Schema has {} fields", current_schema.fields().len());
 
@@ -277,7 +277,7 @@ impl IcebergTableWriter {
         // timestamps), so coerce after the wire→storage transformation.
         let target_schema: ArrowSchemaRef = Arc::new(
             self.table
-                .current_schema(None)
+                .current_schema()
                 .map_err(|e| anyhow::anyhow!("Failed to get current Iceberg schema: {e}"))?
                 .fields()
                 .try_into()

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -365,7 +365,7 @@ async fn test_write_and_query_with_slugs() -> Result<()> {
     // Step 6: Load the table through the querier catalog and verify schema
     match querier_catalog.clone().load_tabular(&slug_ident).await? {
         iceberg_rust::catalog::tabular::Tabular::Table(table) => {
-            let schema = table.current_schema(None)?;
+            let schema = table.current_schema()?;
             // Verify it has the expected traces fields
             let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name.as_str()).collect();
             assert!(
@@ -490,7 +490,7 @@ async fn test_map_attribute_column_end_to_end() -> Result<()> {
     };
     let arrow_schema: ArrowSchemaRef = Arc::new(
         table
-            .current_schema(None)?
+            .current_schema()?
             .fields()
             .try_into()
             .map_err(|e: iceberg_rust::spec::error::Error| anyhow::anyhow!("to arrow: {e}"))?,
@@ -591,17 +591,11 @@ async fn test_map_attribute_column_end_to_end() -> Result<()> {
 /// `SetCurrentSchema` via `Catalog::update_table` — followed by a write
 /// under the new schema and a read that null-fills the old files.
 ///
-/// IGNORED: blocked on a fork limitation. The metadata-only commit works
-/// (schemas {0,1}, current_schema_id=1), but `TableMetadata::
-/// current_schema(branch)` prefers the *current snapshot's* pinned
-/// schema_id, and the Append/Replace transaction ops both derive their
-/// new snapshot's schema from `current_schema(branch)` — so every new
-/// snapshot re-pins the old schema and the flip never takes effect
-/// (`updated current_schema` stays `["timestamp", "body"]`). Fix belongs
-/// in the fork: stamp new snapshots with `metadata.current_schema_id`
-/// (see the analysis on #734). Un-ignore once the fork is patched.
+/// Requires iceberg-rust rev >= 96f28c18: earlier revisions resolved
+/// `current_schema` through the current snapshot's pinned schema_id, so
+/// every new snapshot re-pinned the old schema and the flip never took
+/// effect (fixed upstream in JanKaul/iceberg-rust#378).
 #[tokio::test]
-#[ignore = "blocked on iceberg-rust fork: new snapshots re-pin the old schema_id (#734)"]
 async fn test_schema_evolution_add_label_column() -> Result<()> {
     use datafusion::prelude::SessionContext;
     use futures::stream;
@@ -723,7 +717,7 @@ async fn test_schema_evolution_add_label_column() -> Result<()> {
     };
     assert!(
         table
-            .current_schema(None)?
+            .current_schema()?
             .fields()
             .iter()
             .any(|f| f.name == "label_env"),


### PR DESCRIPTION
Bumps the JanKaul/iceberg-rust pin from `170ef972` to `96f28c18`, pulling in two upstream merges:

- **JanKaul/iceberg-rust#378** — `current_schema` now resolves via `current-schema-id` instead of the current snapshot's pinned schema id. This was the hard blocker for schema evolution driven from the compaction path (#734): every new snapshot re-pinned the old schema, so `SetCurrentSchema` never took effect.
- **JanKaul/iceberg-rust#379** — the Parquet writer honors per-column `write.parquet.bloom-filter-enabled.column.<name>` table properties, including nested columns and case-insensitive values. Groundwork for the label-materialization effort.

## Changes

- `Cargo.toml` / `Cargo.lock`: rev bump.
- Call-site adaptation for the upstream breaking change: `current_schema(None)` → `current_schema()` (the `branch` parameter was dropped upstream; a table's current schema is a table-level property).
- **Un-ignored `test_schema_evolution_add_label_column`** — the spike test for #734/#737 that was `#[ignore]`d pending exactly the fix in #378. It now passes: `AddSchema` + `SetCurrentSchema` via the catalog commit path, followed by a write under the new schema and a read that null-fills old files.

## Testing

- `test_schema_evolution_add_label_column` passes (previously blocked).
- `common` suite: 279/280 pass locally; the single failure is `test_flight_transport_with_postgres_catalog`, which requires Docker (not running locally) and touches no iceberg code.
- Workspace compiles clean with `--all-targets`; fmt + clippy green via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Iceberg table schema handling across compaction and data-writing workflows.
  * Updated schema retrieval to support current Iceberg behavior, helping prevent compatibility issues during writes and commits.
  * Improved handling of schema evolution, including adding label columns to existing tables.

* **Tests**
  * Enabled integration coverage for Iceberg schema evolution to verify updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->