### PR TITLE
fix(auth): return 401 for missing credentials instead of 400

### DIFF
--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -46,8 +46,8 @@ both public routes on the router.
 
 ### Error Codes
 
-- **400**: Missing/malformed auth headers
-- **401**: Invalid API key
+- **400**: Malformed auth headers (wrong scheme, invalid tenant/dataset ID)
+- **401**: Missing credentials (no auth header/cookie or tenant ID) or invalid API key
 - **403**: Key valid but wrong tenant/dataset
 
 ## Isolation Layers

--- a/docs/users/authentication.md
+++ b/docs/users/authentication.md
@@ -58,11 +58,11 @@ the headers, for browsers using the [embedded explore UI](explore-ui.md):
 
 ## Error codes
 
-| HTTP | gRPC                | Meaning                                                               |
-| ---- | ------------------- | --------------------------------------------------------------------- |
-| 400  | `INVALID_ARGUMENT`  | Header missing or malformed (wrong scheme, invalid tenant/dataset ID) |
-| 401  | `UNAUTHENTICATED`   | API key unknown or revoked                                            |
-| 403  | `PERMISSION_DENIED` | Key is valid but not authorized for the named tenant or dataset       |
+| HTTP | gRPC                | Meaning                                                                                    |
+| ---- | ------------------- | ------------------------------------------------------------------------------------------ |
+| 400  | `INVALID_ARGUMENT`  | Header malformed (wrong scheme, invalid tenant/dataset ID)                                 |
+| 401  | `UNAUTHENTICATED`   | Credentials missing (no auth header/cookie or no tenant ID), or API key unknown or revoked |
+| 403  | `PERMISSION_DENIED` | Key is valid but not authorized for the named tenant or dataset                            |
 
 ## Tenants and datasets
 

--- a/docs/users/prometheus-remote-write.md
+++ b/docs/users/prometheus-remote-write.md
@@ -69,11 +69,11 @@ signaldb-cli query sql "SELECT * FROM metrics_gauge LIMIT 5" \
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `400 Missing Authorization header` / `Missing X-Tenant-ID header` | Auth headers not configured | Add the `authorization` and `headers` blocks shown above |
-| `401` | API key invalid or revoked | Check the key — see [Authentication](authentication.md) |
-| `403` | Key not valid for that tenant/dataset | Use a key issued for the tenant in `X-Tenant-ID` |
-| `400` decode error | Body is not snappy-block-compressed protobuf | Use a standard remote_write client; do not gzip or send framed snappy |
-| `429` | Per-tenant ingest rate limit hit | Prometheus retries automatically; ask your operator about tenant limits |
-| `429` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retries will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
+| Symptom                                                           | Cause                                                        | Fix                                                                                                             |
+| ----------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `401 Missing Authorization header` / `Missing X-Tenant-ID header` | Auth headers not configured                                  | Add the `authorization` and `headers` blocks shown above                                                        |
+| `401`                                                             | API key invalid or revoked                                   | Check the key — see [Authentication](authentication.md)                                                         |
+| `403`                                                             | Key not valid for that tenant/dataset                        | Use a key issued for the tenant in `X-Tenant-ID`                                                                |
+| `400` decode error                                                | Body is not snappy-block-compressed protobuf                 | Use a standard remote_write client; do not gzip or send framed snappy                                           |
+| `429`                                                             | Per-tenant ingest rate limit hit                             | Prometheus retries automatically; ask your operator about tenant limits                                         |
+| `429` mentioning `quota_exceeded`                                 | Tenant is at or over its storage quota (`max_storage_bytes`) | Retries will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |

--- a/docs/users/sending-otlp.md
+++ b/docs/users/sending-otlp.md
@@ -50,11 +50,11 @@ http://<acceptor-host>:4318/v1/metrics
 Each request — gRPC metadata or HTTP headers alike — must carry these keys
 (see [Authentication](authentication.md) for details):
 
-| Metadata key / header | Required | Value |
-|---|---|---|
-| `authorization` | yes | `Bearer <api-key>` |
-| `x-tenant-id` | yes | your tenant ID |
-| `x-dataset-id` | no | dataset within the tenant; omitted → tenant default |
+| Metadata key / header | Required | Value                                               |
+| --------------------- | -------- | --------------------------------------------------- |
+| `authorization`       | yes      | `Bearer <api-key>`                                  |
+| `x-tenant-id`         | yes      | your tenant ID                                      |
+| `x-dataset-id`        | no       | dataset within the tenant; omitted → tenant default |
 
 ### 3. Configure your exporter
 
@@ -104,12 +104,12 @@ successful export response means the data is durable.
 
 ## Per-signal support
 
-| Signal | OTLP/gRPC :4317 | OTLP/HTTP :4318 | Stored as |
-|---|---|---|---|
-| Traces | yes | yes (`POST /v1/traces`) | `traces` table |
-| Logs | yes | yes (`POST /v1/logs`) | `logs` table |
-| Metrics | yes | yes (`POST /v1/metrics`) | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
-| Profiles | yes | yes (`POST /v1development/profiles`) | `profiles` table (see [profiles](profiles.md)) |
+| Signal   | OTLP/gRPC :4317 | OTLP/HTTP :4318                      | Stored as                                                  |
+| -------- | --------------- | ------------------------------------ | ---------------------------------------------------------- |
+| Traces   | yes             | yes (`POST /v1/traces`)              | `traces` table                                             |
+| Logs     | yes             | yes (`POST /v1/logs`)                | `logs` table                                               |
+| Metrics  | yes             | yes (`POST /v1/metrics`)             | `metrics_gauge`, `metrics_sum`, `metrics_histogram` tables |
+| Profiles | yes             | yes (`POST /v1development/profiles`) | `profiles` table (see [profiles](profiles.md))             |
 
 ## OTLP/HTTP support
 
@@ -126,12 +126,12 @@ uncompressed.
 A successful export returns `200 OK` with an `Export*ServiceResponse`
 body in the same encoding as the request. Error responses:
 
-| Status | Meaning |
-|---|---|
-| `400 Bad Request` | Malformed payload, or missing/malformed `Authorization` / `X-Tenant-ID` headers |
-| `401 Unauthorized` | API key is wrong or revoked |
-| `403 Forbidden` | Key does not belong to the tenant/dataset you named |
-| `429 Too Many Requests` | Per-tenant ingest rate limit or storage quota hit |
+| Status                  | Meaning                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `400 Bad Request`       | Malformed payload, or malformed `Authorization` / `X-Tenant-ID` headers      |
+| `401 Unauthorized`      | Missing `Authorization` / `X-Tenant-ID` headers, or API key wrong or revoked |
+| `403 Forbidden`         | Key does not belong to the tenant/dataset you named                          |
+| `429 Too Many Requests` | Per-tenant ingest rate limit or storage quota hit                            |
 
 To use OTLP/HTTP from the OpenTelemetry Collector:
 
@@ -142,7 +142,7 @@ exporters:
     headers:
       authorization: "Bearer sk-acme-prod-key-123"
       x-tenant-id: "acme"
-    compression: none   # gzip request bodies are not supported
+    compression: none # gzip request bodies are not supported
 
 service:
   pipelines:
@@ -156,13 +156,13 @@ service:
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `INVALID_ARGUMENT: Missing authorization metadata` | No `authorization` metadata on the request | Add `authorization: Bearer <key>` to exporter headers |
-| `INVALID_ARGUMENT: Missing x-tenant-id metadata` | No tenant header | Add `x-tenant-id` |
-| `UNAUTHENTICATED` | API key is wrong or revoked | Check the key with your operator, see [Authentication](authentication.md) |
-| `PERMISSION_DENIED` | Key does not belong to the tenant/dataset you named | Use a key issued for that tenant |
-| `RESOURCE_EXHAUSTED` | Per-tenant ingest rate limit hit | Back off and retry; ask your operator about tenant limits |
-| `RESOURCE_EXHAUSTED` mentioning `quota_exceeded` | Tenant is at or over its storage quota (`max_storage_bytes`) | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
-| `429 Too Many Requests` on an OTLP/HTTP endpoint | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above | Back off and retry (rate limit), or talk to your operator (quota) |
-| `400 Bad Request` on an OTLP/HTTP endpoint with a JSON body | Payload is not valid protojson (e.g. base64 trace IDs instead of hex) | Use a protojson-compliant encoder; trace/span IDs must be hex strings |
+| Symptom                                                     | Cause                                                                 | Fix                                                                                                              |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `UNAUTHENTICATED: Missing authorization metadata`           | No `authorization` metadata on the request                            | Add `authorization: Bearer <key>` to exporter headers                                                            |
+| `UNAUTHENTICATED: Missing x-tenant-id metadata`             | No tenant header                                                      | Add `x-tenant-id`                                                                                                |
+| `UNAUTHENTICATED`                                           | API key is wrong or revoked                                           | Check the key with your operator, see [Authentication](authentication.md)                                        |
+| `PERMISSION_DENIED`                                         | Key does not belong to the tenant/dataset you named                   | Use a key issued for that tenant                                                                                 |
+| `RESOURCE_EXHAUSTED`                                        | Per-tenant ingest rate limit hit                                      | Back off and retry; ask your operator about tenant limits                                                        |
+| `RESOURCE_EXHAUSTED` mentioning `quota_exceeded`            | Tenant is at or over its storage quota (`max_storage_bytes`)          | Retrying will not help until data is deleted, retention shortens, or the quota is raised — talk to your operator |
+| `429 Too Many Requests` on an OTLP/HTTP endpoint            | HTTP analog of the two `RESOURCE_EXHAUSTED` cases above               | Back off and retry (rate limit), or talk to your operator (quota)                                                |
+| `400 Bad Request` on an OTLP/HTTP endpoint with a JSON body | Payload is not valid protojson (e.g. base64 trace IDs instead of hex) | Use a protojson-compliant encoder; trace/span IDs must be hex strings                                            |

--- a/src/acceptor/src/middleware/auth.rs
+++ b/src/acceptor/src/middleware/auth.rs
@@ -18,10 +18,11 @@ use std::sync::Arc;
 fn extract_auth_headers(
     headers: &HeaderMap,
 ) -> Result<(String, String, Option<String>), AuthError> {
-    // Extract Authorization header
+    // Extract Authorization header. Absent credentials are 401
+    // (unauthenticated), not 400; malformed ones stay 400.
     let auth_header = headers
         .get("authorization")
-        .ok_or_else(|| AuthError::bad_request("Missing Authorization header"))?
+        .ok_or_else(|| AuthError::unauthorized("Missing Authorization header"))?
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid Authorization header"))?;
 
@@ -59,7 +60,7 @@ fn extract_auth_headers(
     // Extract and validate X-Tenant-ID header
     let tenant_id_raw = headers
         .get("x-tenant-id")
-        .ok_or_else(|| AuthError::bad_request("Missing X-Tenant-ID header"))?
+        .ok_or_else(|| AuthError::unauthorized("Missing X-Tenant-ID header"))?
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid X-Tenant-ID header"))?;
 
@@ -231,7 +232,7 @@ mod tests {
         let result = extract_auth_headers(&headers);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("Authorization"));
     }
 
@@ -246,7 +247,7 @@ mod tests {
         let result = extract_auth_headers(&headers);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("X-Tenant-ID"));
     }
 
@@ -448,7 +449,7 @@ mod tests {
             .unwrap();
 
         let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         // Test invalid API key
         let request = Request::builder()

--- a/src/acceptor/src/middleware/grpc_auth.rs
+++ b/src/acceptor/src/middleware/grpc_auth.rs
@@ -13,10 +13,11 @@ use tonic::{Request, Status};
 fn extract_grpc_auth_headers(
     metadata: &tonic::metadata::MetadataMap,
 ) -> Result<(String, String, Option<String>), AuthError> {
-    // Extract authorization header (Bearer token)
+    // Extract authorization header (Bearer token). Absent credentials map
+    // to UNAUTHENTICATED (401); malformed ones stay INVALID_ARGUMENT (400).
     let auth_header = metadata
         .get("authorization")
-        .ok_or_else(|| AuthError::bad_request("Missing authorization metadata"))?
+        .ok_or_else(|| AuthError::unauthorized("Missing authorization metadata"))?
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid authorization metadata"))?;
 
@@ -32,7 +33,7 @@ fn extract_grpc_auth_headers(
     // these IDs end up in WAL paths and Iceberg namespaces)
     let tenant_id_raw = metadata
         .get("x-tenant-id")
-        .ok_or_else(|| AuthError::bad_request("Missing x-tenant-id metadata"))?
+        .ok_or_else(|| AuthError::unauthorized("Missing x-tenant-id metadata"))?
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid x-tenant-id metadata"))?;
     let tenant_id = validate_tenant_id(tenant_id_raw)?;
@@ -196,7 +197,7 @@ mod tests {
         let result = extract_grpc_auth_headers(&metadata);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("authorization"));
     }
 
@@ -211,7 +212,7 @@ mod tests {
         let result = extract_grpc_auth_headers(&metadata);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("x-tenant-id"));
     }
 

--- a/src/acceptor/src/middleware/grpc_auth.rs
+++ b/src/acceptor/src/middleware/grpc_auth.rs
@@ -340,7 +340,7 @@ mod tests {
         let result = grpc_auth_interceptor(authenticator, request);
         assert!(result.is_err());
         let status = result.unwrap_err();
-        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/acceptor/tests/otlp_http_logs.rs
+++ b/src/acceptor/tests/otlp_http_logs.rs
@@ -268,8 +268,8 @@ async fn otlp_http_logs_missing_auth_headers_is_rejected() {
 
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
-        "Expected 400 Bad Request for a request without auth headers"
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for a request without auth headers"
     );
     assert_eq!(logs_wal_entry_count(&wal_manager).await, 0);
 }

--- a/src/acceptor/tests/otlp_http_metrics.rs
+++ b/src/acceptor/tests/otlp_http_metrics.rs
@@ -273,8 +273,8 @@ async fn otlp_http_metrics_missing_auth_headers_is_rejected() {
 
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
-        "Expected 400 Bad Request for a request without auth headers"
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for a request without auth headers"
     );
     assert_eq!(metrics_wal_entry_count(&wal_manager).await, 0);
 }

--- a/src/acceptor/tests/otlp_http_traces.rs
+++ b/src/acceptor/tests/otlp_http_traces.rs
@@ -276,8 +276,8 @@ async fn otlp_http_traces_missing_auth_headers_is_rejected() {
 
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
-        "Expected 400 Bad Request for a request without auth headers"
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized for a request without auth headers"
     );
     assert_eq!(traces_wal_entry_count(&wal_manager).await, 0);
 }

--- a/src/common/src/auth/middleware.rs
+++ b/src/common/src/auth/middleware.rs
@@ -35,10 +35,11 @@ fn extract_auth_headers(
         .ok_or_else(|| AuthError::bad_request("Authorization header must use Bearer scheme"))?
         .to_string();
 
-    // Extract and validate X-Tenant-ID header
+    // Extract and validate X-Tenant-ID header. Absent credentials are 401
+    // (unauthenticated), not 400 — the embedded UI's login gate keys on 401.
     let tenant_id_raw = headers
         .get("x-tenant-id")
-        .ok_or_else(|| AuthError::bad_request("Missing X-Tenant-ID header"))?
+        .ok_or_else(|| AuthError::unauthorized("Missing X-Tenant-ID header"))?
         .to_str()
         .map_err(|_| AuthError::bad_request("Invalid X-Tenant-ID header"))?;
 
@@ -65,7 +66,7 @@ fn extract_auth_from_session(
     headers: &HeaderMap,
 ) -> Result<(String, String, Option<String>), AuthError> {
     let session = super::session::session_from_headers(headers)
-        .ok_or_else(|| AuthError::bad_request("Missing Authorization header"))?;
+        .ok_or_else(|| AuthError::unauthorized("Missing Authorization header"))?;
 
     let tenant_id_raw = match headers.get("x-tenant-id") {
         Some(value) => value
@@ -311,7 +312,7 @@ mod tests {
         let result = extract_auth_headers(&headers);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("Authorization"));
     }
 
@@ -326,8 +327,17 @@ mod tests {
         let result = extract_auth_headers(&headers);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("X-Tenant-ID"));
+    }
+
+    #[test]
+    fn test_extract_auth_headers_no_credentials_at_all_is_unauthorized() {
+        // A fresh browser hitting the API sends neither headers nor a
+        // session cookie; the UI login gate keys on 401.
+        let err = extract_auth_headers(&HeaderMap::new()).unwrap_err();
+        assert_eq!(err.status_code, 401);
+        assert!(err.message.contains("Authorization"));
     }
 
     #[test]
@@ -417,7 +427,7 @@ mod tests {
             .unwrap();
 
         let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         // Test invalid API key
         let request = Request::builder()
@@ -504,7 +514,7 @@ mod tests {
         );
 
         let err = extract_auth_headers(&headers).unwrap_err();
-        assert_eq!(err.status_code, 400);
+        assert_eq!(err.status_code, 401);
         assert!(err.message.contains("Authorization"));
     }
 

--- a/src/router/src/endpoints/logql.rs
+++ b/src/router/src/endpoints/logql.rs
@@ -797,14 +797,14 @@ mod tests {
     async fn logql_endpoints_require_authentication() {
         let app = test_app().await;
 
-        // Missing Authorization header is a 400 (middleware contract),
-        // a wrong key a 401.
+        // Missing credentials and a wrong key are both 401 (middleware
+        // contract; the UI login gate keys on 401).
         let request = Request::builder()
             .uri("/loki/api/v1/labels")
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         let request = Request::builder()
             .uri("/loki/api/v1/labels")

--- a/src/router/src/endpoints/session.rs
+++ b/src/router/src/endpoints/session.rs
@@ -385,13 +385,14 @@ mod tests {
         let res = app.clone().oneshot(request).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
 
-        // Without cookie or headers the same route rejects the request.
+        // Without cookie or headers the same route rejects the request as
+        // unauthenticated (401 — what the UI login gate keys on).
         let request = Request::builder()
             .uri("/tempo/api/echo")
             .body(Body::empty())
             .unwrap();
         let res = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
@@ -453,7 +454,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let res = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/tests-integration/tests/prometheus_remote_write_test.rs
+++ b/tests-integration/tests/prometheus_remote_write_test.rs
@@ -615,8 +615,8 @@ async fn test_prometheus_remote_write_missing_auth() {
 
     let response = app.oneshot(http_request).await.unwrap();
 
-    // Should fail - 400 Bad Request for missing required Authorization header
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Should fail - 401 Unauthorized for missing required Authorization header
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/tests-integration/tests/router_tempo_endpoints.rs
+++ b/tests-integration/tests/router_tempo_endpoints.rs
@@ -1317,7 +1317,7 @@ async fn test_read_path_authentication_failures() {
     println!("Missing auth header status: {}", response.status());
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
+        StatusCode::UNAUTHORIZED,
         "Should reject missing Authorization header"
     );
 
@@ -1333,7 +1333,7 @@ async fn test_read_path_authentication_failures() {
     println!("Missing tenant header status: {}", response.status());
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
+        StatusCode::UNAUTHORIZED,
         "Should reject missing X-Tenant-ID header"
     );
 


### PR DESCRIPTION
## Problem

Requests carrying no credentials at all — no `Authorization` header, no session cookie, or no `X-Tenant-ID` — were rejected with **400 Bad Request** by both the router and acceptor auth middleware. Two problems with that:

1. **HTTP semantics**: absent credentials are an authentication failure (401), not a malformed request (400).
2. **The embedded UI's login gate never fires.** `LoginGate` keys strictly on 401 (`isAuthError`). A fresh browser session — e.g. reaching the UI through a reverse proxy on a new hostname, where no `signaldb_session` cookie exists for that host — sends requests with no credentials, gets 400s, and the user sees a dead UI shell with silently failing queries instead of the login form. Found in the field exposing the explore UI through a Pangolin tunnel.

## Change

- Router middleware (`common::auth::middleware`): missing `Authorization`/session cookie and missing `X-Tenant-ID` → `AuthError::unauthorized` (401). A malformed session cookie is treated as absent, so it lands on 401 too.
- Acceptor middleware: same flip for its copies of the two checks.
- **Malformed** input is unchanged and stays 400: non-Bearer scheme, invalid header encoding, empty token, invalid tenant/dataset ids.
- Tests updated across common/acceptor/router plus the two integration binaries; new unit test covers the credential-less fresh-browser case. Doc table in `docs/users/prometheus-remote-write.md` updated (400 → 401).

## Behavior change note

Unauthenticated ingest/query requests that previously saw `400` now see `401`. Clients matching on the status code for *missing* headers will observe the new code; invalid-key responses were already 401.

## Testing

- `cargo test -p common auth`, `-p acceptor middleware`, `-p router` — green (16/13/8 in the touched suites)
- `cargo test -p tests-integration --test router_tempo_endpoints --test prometheus_remote_write_test` — green (10 + 8)
- fmt, clippy, deny via pre-commit hook — clean