### PR TITLE
feat(common): Parquet bloom filters on materialized label columns

### DIFF
--- a/src/common/src/iceberg/schemas.rs
+++ b/src/common/src/iceberg/schemas.rs
@@ -521,6 +521,27 @@ impl TableSchema {
         }
     }
 
+    /// The materialized-label allowlist that applies to this table from a
+    /// resolved per-tenant config: logs/traces/metrics/profiles map to their
+    /// signal's list, custom tables to none. This is the same routing
+    /// [`Self::schema_with_labels`] uses to inject `label_<key>` columns.
+    pub fn materialized_labels_of<'a>(
+        &self,
+        m: &'a crate::config::MaterializedLabels,
+    ) -> &'a [String] {
+        match self {
+            TableSchema::Traces => &m.traces,
+            TableSchema::Logs => &m.logs,
+            TableSchema::MetricsGauge
+            | TableSchema::MetricsSum
+            | TableSchema::MetricsHistogram
+            | TableSchema::MetricsExponentialHistogram
+            | TableSchema::MetricsSummary => &m.metrics,
+            TableSchema::Profiles => &m.profiles,
+            TableSchema::Custom(_) => &[],
+        }
+    }
+
     pub fn schema(&self) -> Result<Schema> {
         match self {
             TableSchema::Traces => create_traces_schema(),

--- a/src/common/src/iceberg/table_manager.rs
+++ b/src/common/src/iceberg/table_manager.rs
@@ -96,7 +96,16 @@ impl IcebergTableManager {
             }
         }
 
-        let table_create = CreateTableBuilder::default()
+        // Enable a Parquet bloom filter for every materialized label column
+        // so point lookups on promoted attributes can prune row groups. The
+        // pinned iceberg-rust Parquet writer reads these standard Iceberg
+        // properties from the table metadata on every write.
+        let bloom_properties = crate::schema::bloom_filter_properties_for_labels(
+            table_schema.materialized_labels_of(labels),
+        );
+
+        let mut builder = CreateTableBuilder::default();
+        builder
             .with_name(table_name.to_string())
             .with_schema(table_schema.schema_with_labels(labels)?)
             .with_partition_spec(table_schema.partition_spec()?)
@@ -104,7 +113,11 @@ impl IcebergTableManager {
                 tenant_slug,
                 dataset_slug,
                 table_name,
-            ))
+            ));
+        if !bloom_properties.is_empty() {
+            builder.with_properties(bloom_properties.into_iter().collect());
+        }
+        let table_create = builder
             .create()
             .map_err(|e| anyhow::anyhow!("Failed to build CreateTable for {ident}: {e}"))?;
 

--- a/src/common/src/schema/mod.rs
+++ b/src/common/src/schema/mod.rs
@@ -33,6 +33,36 @@ pub fn materialized_column_name(label: &str) -> String {
     out
 }
 
+/// Per-column Parquet bloom-filter table properties for a set of
+/// materialized attribute labels.
+///
+/// For each label key this yields
+/// `write.parquet.bloom-filter-enabled.column.label_<key> = "true"`, the
+/// standard Iceberg property the pinned iceberg-rust Parquet writer honors
+/// per column. Column names come from [`materialized_column_name`], so the
+/// properties always target the promoted `label_<key>` columns. Duplicate
+/// labels (after sanitization) collapse to a single property.
+///
+/// Shared by table creation and the compactor's attribute-promotion path,
+/// so both set identical properties for a promoted label.
+pub fn bloom_filter_properties_for_labels(labels: &[String]) -> Vec<(String, String)> {
+    use iceberg_rust::spec::table_metadata::WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX;
+
+    let mut seen = std::collections::HashSet::new();
+    labels
+        .iter()
+        .filter_map(|label| {
+            let column = materialized_column_name(label);
+            seen.insert(column.clone()).then(|| {
+                (
+                    format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}{column}"),
+                    "true".to_string(),
+                )
+            })
+        })
+        .collect()
+}
+
 /// Embedded schema definitions from schemas.toml
 pub const SCHEMA_DEFINITIONS_TOML: &str = include_str!("../../../../schemas.toml");
 
@@ -237,6 +267,30 @@ mod tests {
             materialized_column_name("k8s.pod/name"),
             "label_k8s_pod_name"
         );
+    }
+
+    #[test]
+    fn bloom_filter_properties_target_materialized_columns() {
+        let labels = vec![
+            "namespace".to_string(),
+            "http.method".to_string(),
+            // Sanitizes to the same column as `http.method` → collapsed.
+            "http_method".to_string(),
+        ];
+        assert_eq!(
+            bloom_filter_properties_for_labels(&labels),
+            vec![
+                (
+                    "write.parquet.bloom-filter-enabled.column.label_namespace".to_string(),
+                    "true".to_string()
+                ),
+                (
+                    "write.parquet.bloom-filter-enabled.column.label_http_method".to_string(),
+                    "true".to_string()
+                ),
+            ]
+        );
+        assert!(bloom_filter_properties_for_labels(&[]).is_empty());
     }
 
     #[test]

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -586,6 +586,128 @@ async fn test_map_attribute_column_end_to_end() -> Result<()> {
     Ok(())
 }
 
+/// Attribute-explorability epic (#731): creating a table with materialized
+/// label columns must also set the per-column bloom-filter table property
+/// for each `label_<key>` column, so the pinned iceberg-rust Parquet writer
+/// emits bloom filters for them on every write.
+#[tokio::test]
+async fn ensure_table_sets_bloom_properties_for_label_columns() -> Result<()> {
+    let mut config = Configuration::default();
+    config.schema.catalog_uri =
+        "sqlite:file:signaldb_bloom_props?mode=memory&cache=shared".to_string();
+    config.schema.materialized_labels.logs =
+        vec!["namespace".to_string(), "http.method".to_string()];
+    let manager = common::CatalogManager::new(config).await?;
+
+    let table = manager.ensure_table("default", "default", "logs").await?;
+    let properties = &table.metadata().properties;
+
+    assert_eq!(
+        properties
+            .get("write.parquet.bloom-filter-enabled.column.label_namespace")
+            .map(String::as_str),
+        Some("true"),
+        "properties: {properties:?}"
+    );
+    assert_eq!(
+        properties
+            .get("write.parquet.bloom-filter-enabled.column.label_http_method")
+            .map(String::as_str),
+        Some("true"),
+    );
+
+    // A table for a signal without configured labels gets no bloom keys.
+    let traces = manager.ensure_table("default", "default", "traces").await?;
+    assert!(
+        traces
+            .metadata()
+            .properties
+            .keys()
+            .all(|k| !k.starts_with("write.parquet.bloom-filter-enabled.column.")),
+    );
+
+    Ok(())
+}
+
+/// End-to-end proof for #731: a logs table created by `ensure_table` with a
+/// materialized label writes Parquet files whose `label_<key>` column chunk
+/// carries a bloom filter, while non-enabled columns do not.
+#[tokio::test]
+async fn label_column_write_produces_parquet_bloom_filter() -> Result<()> {
+    use datafusion::arrow::array::{
+        ArrayRef, Date32Array, Int32Array, TimestampMicrosecondArray, new_null_array,
+    };
+    use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
+    use futures::stream;
+    use iceberg_rust::arrow::write::write_parquet_partitioned;
+    use iceberg_rust::spec::util::strip_prefix;
+    use object_store::ObjectStoreExt as _;
+
+    let mut config = Configuration::default();
+    config.schema.catalog_uri =
+        "sqlite:file:signaldb_bloom_write?mode=memory&cache=shared".to_string();
+    config.schema.materialized_labels.logs = vec!["namespace".to_string()];
+    let manager = common::CatalogManager::new(config).await?;
+
+    let table = manager.ensure_table("default", "default", "logs").await?;
+
+    // Build a one-row batch in the table's derived Arrow schema: required
+    // columns get real values, `label_namespace` and `body` get strings
+    // (body proves bloom filters stay scoped to enabled columns), the rest
+    // stay null.
+    let arrow_schema: Arc<Schema> =
+        Arc::new(table.current_schema()?.fields().try_into().map_err(
+            |e: iceberg_rust::spec::error::Error| anyhow::anyhow!("schema to arrow: {e}"),
+        )?);
+    let columns: Vec<ArrayRef> = arrow_schema
+        .fields()
+        .iter()
+        .map(|field| -> ArrayRef {
+            match field.name().as_str() {
+                "timestamp" | "observed_timestamp" => {
+                    Arc::new(TimestampMicrosecondArray::from(vec![1_000_000_i64]))
+                }
+                "service_name" => Arc::new(StringArray::from(vec!["api"])),
+                "body" => Arc::new(StringArray::from(vec!["hello bloom"])),
+                "label_namespace" => Arc::new(StringArray::from(vec!["prod"])),
+                "date_day" => Arc::new(Date32Array::from(vec![0])),
+                "hour" => Arc::new(Int32Array::from(vec![0])),
+                _ => new_null_array(field.data_type(), 1),
+            }
+        })
+        .collect();
+    let batch = RecordBatch::try_new(arrow_schema, columns)?;
+
+    let files = write_parquet_partitioned(&table, stream::iter(vec![Ok(batch)]), None).await?;
+    assert_eq!(files.len(), 1, "expected exactly one data file");
+
+    // Read the Parquet footer straight from the table's object store and
+    // check bloom-filter presence per column chunk.
+    let path: object_store::path::Path = strip_prefix(files[0].file_path()).into();
+    let bytes = table.object_store().get(&path).await?.bytes().await?;
+    let reader = SerializedFileReader::new(bytes)?;
+    let row_group = reader.metadata().row_group(0);
+
+    let bloom_offset_of = |column: &str| {
+        row_group
+            .columns()
+            .iter()
+            .find(|c| c.column_path().string() == column)
+            .unwrap_or_else(|| panic!("column {column} not found in Parquet metadata"))
+            .bloom_filter_offset()
+    };
+    assert!(
+        bloom_offset_of("label_namespace").is_some(),
+        "label_namespace should carry a bloom filter"
+    );
+    assert!(
+        bloom_offset_of("body").is_none(),
+        "body has no bloom-filter property and should not carry one"
+    );
+
+    Ok(())
+}
+
 /// Spike for the attribute-explorability epic (#737 / #734): schema
 /// evolution through the low-level catalog commit path — `AddSchema` +
 /// `SetCurrentSchema` via `Catalog::update_table` — followed by a write


### PR DESCRIPTION
Part 1 of #731 (Layer 2 of the attribute-explorability plan, #737). Stacked series: this PR, then #TBD (attr_tokens).

Sets `write.parquet.bloom-filter-enabled.column.label_<key>=true` table properties at table creation for every configured `[schema.materialized_labels]` key, so the pinned iceberg-rust writer (rev `96f28c18`, JanKaul/iceberg-rust#379) emits Parquet split-block bloom filters on those columns.

- `common::schema::bloom_filter_properties_for_labels` — pure helper, reusable by the compactor auto-promotion path (#734).
- `ensure_table` passes the properties via `CreateTableBuilder::with_properties`.
- Verified empirically: integration test writes through `write_parquet_partitioned` and asserts the label column's chunk has `bloom_filter_offset` while `body` has none.

Note: properties apply at table **creation**; pre-existing tables gain them when the promotion path (#734) reuses the helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enabled Parquet bloom filters for configured materialized label columns, helping accelerate label-based data lookups.
  * Applied filtering improvements consistently across supported table types while avoiding unnecessary filters for unconfigured columns.
  * Improved handling of label names that resolve to the same storage column.
* **Testing**
  * Added coverage validating bloom-filter configuration and stored Parquet metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->