### PR TITLE
feat: attr_tokens key=value column with bloom for arbitrary attribute equality

### DIFF
--- a/src/common/src/iceberg/schemas.rs
+++ b/src/common/src/iceberg/schemas.rs
@@ -114,7 +114,8 @@ pub fn create_traces_schema_with(labels: &[String]) -> Result<Schema> {
 }
 
 /// Create Iceberg schema for logs table using TOML definitions, plus any
-/// configured materialized-label columns.
+/// configured materialized-label columns and the derived `attr_tokens`
+/// column (see [`crate::schema::ATTR_TOKENS_COLUMN`]).
 pub fn create_logs_schema_with(labels: &[String]) -> Result<Schema> {
     // Get the current log schema version from TOML
     let current_version = SCHEMA_DEFINITIONS.metadata.current_log_version.as_str();
@@ -123,7 +124,7 @@ pub fn create_logs_schema_with(labels: &[String]) -> Result<Schema> {
     // Promote configured attribute keys to dedicated columns. The schema is
     // materialized once at table-creation time; the global config is the
     // source of truth for which labels are promoted (empty when unset).
-    resolved_schema.to_iceberg_schema_with_labels(labels)
+    resolved_schema.to_iceberg_schema_with_labels_and_attr_tokens(labels)
 }
 
 /// Global-config variant of [`create_traces_schema_with`].

--- a/src/common/src/iceberg/table_manager.rs
+++ b/src/common/src/iceberg/table_manager.rs
@@ -100,9 +100,15 @@ impl IcebergTableManager {
         // so point lookups on promoted attributes can prune row groups. The
         // pinned iceberg-rust Parquet writer reads these standard Iceberg
         // properties from the table metadata on every write.
-        let bloom_properties = crate::schema::bloom_filter_properties_for_labels(
+        let mut bloom_properties = crate::schema::bloom_filter_properties_for_labels(
             table_schema.materialized_labels_of(labels),
         );
+        // Logs tables also carry the derived `attr_tokens` column; enable a
+        // bloom filter over its List leaf so `key=value` containment checks
+        // can prune row groups.
+        if matches!(table_schema, schemas::TableSchema::Logs) {
+            bloom_properties.push(crate::schema::bloom_filter_property_for_attr_tokens());
+        }
 
         let mut builder = CreateTableBuilder::default();
         builder

--- a/src/common/src/schema/mod.rs
+++ b/src/common/src/schema/mod.rs
@@ -33,6 +33,28 @@ pub fn materialized_column_name(label: &str) -> String {
     out
 }
 
+/// The derived `key=value` token column on logs tables. Each row carries
+/// one token per attribute across resource, scope, and record scopes, so a
+/// single bloom-filtered column can answer "does this file contain
+/// `key=value` for *any* attribute" without one column per key.
+pub const ATTR_TOKENS_COLUMN: &str = "attr_tokens";
+
+/// The bloom-filter table property for the derived [`ATTR_TOKENS_COLUMN`].
+///
+/// Parquet addresses the tokens through the List leaf column: arrow-rs
+/// writes a `List<Utf8>` with the 3-level encoding
+/// `attr_tokens (LIST) > list (repeated group) > item`, and the
+/// Iceberg-to-Arrow conversion names the element field `item`, so the leaf
+/// path is `attr_tokens.list.item`. The pinned iceberg-rust writer splits
+/// the property's column suffix on dots into exactly those path parts.
+pub fn bloom_filter_property_for_attr_tokens() -> (String, String) {
+    use iceberg_rust::spec::table_metadata::WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX;
+    (
+        format!("{WRITE_PARQUET_BLOOM_FILTER_ENABLED_COLUMN_PREFIX}{ATTR_TOKENS_COLUMN}.list.item"),
+        "true".to_string(),
+    )
+}
+
 /// Per-column Parquet bloom-filter table properties for a set of
 /// materialized attribute labels.
 ///
@@ -266,6 +288,17 @@ mod tests {
         assert_eq!(
             materialized_column_name("k8s.pod/name"),
             "label_k8s_pod_name"
+        );
+    }
+
+    #[test]
+    fn attr_tokens_bloom_property_targets_the_list_leaf() {
+        assert_eq!(
+            bloom_filter_property_for_attr_tokens(),
+            (
+                "write.parquet.bloom-filter-enabled.column.attr_tokens.list.item".to_string(),
+                "true".to_string()
+            )
         );
     }
 

--- a/src/common/src/schema/schema_parser.rs
+++ b/src/common/src/schema/schema_parser.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use iceberg_rust::spec::schema::Schema;
-use iceberg_rust::spec::types::{MapType, PrimitiveType, StructField, StructType, Type};
+use iceberg_rust::spec::types::{ListType, MapType, PrimitiveType, StructField, StructType, Type};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -177,6 +177,22 @@ impl ResolvedSchema {
     /// base-column-colliding labels are skipped, and field IDs continue
     /// after the base columns.
     pub fn to_iceberg_schema_with_labels(&self, labels: &[String]) -> Result<Schema> {
+        self.build_iceberg_schema(labels, false)
+    }
+
+    /// Like [`Self::to_iceberg_schema_with_labels`], but also appends the
+    /// derived optional `attr_tokens` `List<String>` column (see
+    /// [`crate::schema::ATTR_TOKENS_COLUMN`]). Used by the logs schema,
+    /// where the writer materializes `key=value` tokens over all attribute
+    /// scopes for bloom-filtered containment checks.
+    pub fn to_iceberg_schema_with_labels_and_attr_tokens(
+        &self,
+        labels: &[String],
+    ) -> Result<Schema> {
+        self.build_iceberg_schema(labels, true)
+    }
+
+    fn build_iceberg_schema(&self, labels: &[String], attr_tokens: bool) -> Result<Schema> {
         let mut fields = Vec::new();
 
         // Nested (map key/value) field IDs must be unique across the whole
@@ -256,6 +272,31 @@ impl ResolvedSchema {
             next_id += 1;
         }
 
+        // Derived `key=value` token column: an optional List<String> whose
+        // element ID follows every other ID in the schema.
+        if attr_tokens
+            && !fields
+                .iter()
+                .any(|f| f.name == crate::schema::ATTR_TOKENS_COLUMN)
+        {
+            fields.push(StructField {
+                id: next_id,
+                name: crate::schema::ATTR_TOKENS_COLUMN.to_string(),
+                required: false,
+                field_type: Type::List(ListType {
+                    element_id: next_id + 1,
+                    element_required: false,
+                    element: Box::new(Type::Primitive(PrimitiveType::String)),
+                }),
+                doc: Some(
+                    "Derived `key=value` tokens over resource, scope, and record attributes"
+                        .to_string(),
+                ),
+                initial_default: None,
+                write_default: None,
+            });
+        }
+
         Ok(Schema::from_struct_type(StructType::new(fields), 0, None))
     }
 
@@ -321,6 +362,73 @@ mod tests {
             .unwrap();
         assert!(!ns.required);
         assert_eq!(ns.field_type, Type::Primitive(PrimitiveType::String));
+    }
+
+    #[test]
+    fn attr_tokens_variant_appends_optional_list_column() {
+        let base = ResolvedSchema {
+            version: "v1".to_string(),
+            description: "test".to_string(),
+            fields: vec![
+                ResolvedField {
+                    name: "timestamp".to_string(),
+                    field_type: "timestamp_ns".to_string(),
+                    required: true,
+                    computed: None,
+                    field_id: 1,
+                },
+                ResolvedField {
+                    name: "log_attributes".to_string(),
+                    field_type: "map<string,string>".to_string(),
+                    required: false,
+                    computed: None,
+                    field_id: 2,
+                },
+            ],
+            partition_by: vec![],
+        };
+
+        let labels = vec!["namespace".to_string()];
+        let schema = base
+            .to_iceberg_schema_with_labels_and_attr_tokens(&labels)
+            .unwrap();
+
+        let tokens = schema
+            .fields()
+            .iter()
+            .find(|f| f.name == "attr_tokens")
+            .expect("attr_tokens column present");
+        assert!(!tokens.required);
+        let Type::List(list) = &tokens.field_type else {
+            panic!("attr_tokens should be a List, got {:?}", tokens.field_type);
+        };
+        assert_eq!(*list.element, Type::Primitive(PrimitiveType::String));
+        assert!(!list.element_required);
+
+        // IDs stay unique across top-level, nested map, label, and list
+        // element IDs.
+        let label = schema
+            .fields()
+            .iter()
+            .find(|f| f.name == "label_namespace")
+            .unwrap();
+        let mut ids = vec![1, 2, label.id, tokens.id, list.element_id];
+        if let Type::Map(m) = &schema
+            .fields()
+            .iter()
+            .find(|f| f.name == "log_attributes")
+            .unwrap()
+            .field_type
+        {
+            ids.push(m.key_id);
+            ids.push(m.value_id);
+        }
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len(), "duplicate field IDs in {ids:?}");
+
+        // The labels-only variant stays token-free.
+        let plain = base.to_iceberg_schema_with_labels(&labels).unwrap();
+        assert!(!plain.fields().iter().any(|f| f.name == "attr_tokens"));
     }
 
     #[test]

--- a/src/querier/src/query/logql.rs
+++ b/src/querier/src/query/logql.rs
@@ -45,12 +45,14 @@ use super::error::QuerierError;
 pub type MaterializedColumns = HashSet<String>;
 
 /// What the target table offers for attribute matching: which materialized
-/// `label_<key>` columns exist, and whether the attribute columns are
-/// typed maps (new tables) or JSON strings (legacy tables).
+/// `label_<key>` columns exist, whether the attribute columns are typed
+/// maps (new tables) or JSON strings (legacy tables), and whether the
+/// derived `attr_tokens` column exists for bloom-backed containment checks.
 #[derive(Debug, Default, Clone)]
 pub struct AttrContext {
     pub materialized: MaterializedColumns,
     pub map_attrs: bool,
+    pub attr_tokens: bool,
 }
 
 /// Attribute columns searched for a label that is not a dedicated column.
@@ -180,10 +182,23 @@ fn label_expr(
     if ctx.materialized.contains(&materialized) {
         return materialized_label_expr(&materialized, op, value);
     }
-    if ctx.map_attrs {
-        return map_attribute_expr(name, op, value);
+    let base = if ctx.map_attrs {
+        map_attribute_expr(name, op, value)?
+    } else {
+        attribute_expr(name, op, value)?
+    };
+    // Tables with the derived `attr_tokens` column get an extra exact
+    // containment conjunct on equality filters: it never changes the
+    // result (tokens are a superset of the attribute-column contents) but
+    // gives the Parquet layer a bloom-filtered column to prune with.
+    if ctx.attr_tokens && matches!(op, FilterOp::Eq | FilterOp::CmpEq) {
+        let token = format!("{name}={}", string_value(value)?);
+        return Ok(base.and(datafusion::functions_nested::expr_fn::array_has(
+            col(common::schema::ATTR_TOKENS_COLUMN),
+            lit(token),
+        )));
     }
-    attribute_expr(name, op, value)
+    Ok(base)
 }
 
 /// Predicate against typed `Map<Utf8, Utf8>` attribute columns: the value
@@ -383,7 +398,7 @@ mod tests {
         let q = parse_query(query).expect("parse");
         let ctx = AttrContext {
             materialized: columns.iter().map(|c| c.to_string()).collect(),
-            map_attrs: false,
+            ..Default::default()
         };
         let expr = log_query_filter_with_columns(&q, &ctx)
             .expect("lower")
@@ -397,6 +412,21 @@ mod tests {
         let ctx = AttrContext {
             materialized: MaterializedColumns::new(),
             map_attrs: true,
+            ..Default::default()
+        };
+        let expr = log_query_filter_with_columns(&q, &ctx)
+            .expect("lower")
+            .expect("some filter");
+        format!("{expr}")
+    }
+
+    /// Lower against a table that has the derived `attr_tokens` column.
+    fn sql_tokens(query: &str, map_attrs: bool) -> String {
+        let q = parse_query(query).expect("parse");
+        let ctx = AttrContext {
+            materialized: MaterializedColumns::new(),
+            map_attrs,
+            attr_tokens: true,
         };
         let expr = log_query_filter_with_columns(&q, &ctx)
             .expect("lower")
@@ -435,6 +465,61 @@ mod tests {
             log_query_filter_with_columns(&q, &AttrContext::default()),
             Err(QuerierError::Unsupported(_))
         ));
+    }
+
+    #[test]
+    fn attr_tokens_adds_containment_conjunct_on_equality_only() {
+        // Map-typed table with attr_tokens: the map predicate keeps the
+        // exact semantics, the array_has conjunct adds bloom prunability.
+        let eq = sql_tokens(r#"{namespace="prod"}"#, true);
+        assert!(
+            eq.contains("get_field(log_attributes") && eq.contains(r#"= Utf8("prod")"#),
+            "{eq}"
+        );
+        assert!(
+            eq.contains(r#"array_has(attr_tokens, Utf8("namespace=prod"))"#),
+            "{eq}"
+        );
+
+        // Legacy JSON table with attr_tokens: substring predicate + conjunct.
+        let eq_json = sql_tokens(r#"{namespace="prod"}"#, false);
+        assert!(eq_json.contains("contains(log_attributes"), "{eq_json}");
+        assert!(
+            eq_json.contains(r#"array_has(attr_tokens, Utf8("namespace=prod"))"#),
+            "{eq_json}"
+        );
+
+        // Non-equality operators stay untouched: no token conjunct.
+        for query in [
+            r#"{namespace!="prod"}"#,
+            r#"{namespace=~"pro.*"}"#,
+            r#"{namespace!~"pro.*"}"#,
+        ] {
+            let rendered = sql_tokens(query, true);
+            assert!(!rendered.contains("array_has"), "{query} -> {rendered}");
+        }
+
+        // Well-known labels route to dedicated columns, never to tokens.
+        let svc = sql_tokens(r#"{service_name="api"}"#, true);
+        assert_eq!(svc, r#"service_name = Utf8("api")"#);
+
+        // Materialized label columns also skip the token conjunct.
+        let q = parse_query(r#"{namespace="prod"}"#).expect("parse");
+        let ctx = AttrContext {
+            materialized: ["label_namespace".to_string()].into_iter().collect(),
+            map_attrs: true,
+            attr_tokens: true,
+        };
+        let expr = format!(
+            "{}",
+            log_query_filter_with_columns(&q, &ctx)
+                .expect("lower")
+                .expect("some filter")
+        );
+        assert_eq!(expr, r#"label_namespace = Utf8("prod")"#);
+
+        // Tables without the column are unchanged.
+        assert!(!sql_map(r#"{namespace="prod"}"#).contains("array_has"));
     }
 
     #[test]

--- a/src/querier/src/query/logs.rs
+++ b/src/querier/src/query/logs.rs
@@ -662,9 +662,15 @@ fn attr_context_of(df: &DataFrame) -> AttrContext {
         .fields()
         .iter()
         .any(|f| f.name() == "log_attributes" && matches!(f.data_type(), DataType::Map(_, _)));
+    // The derived `key=value` token column, when present, backs an extra
+    // bloom-prunable containment conjunct on attribute equality filters.
+    let attr_tokens = df.schema().fields().iter().any(|f| {
+        f.name() == common::schema::ATTR_TOKENS_COLUMN && matches!(f.data_type(), DataType::List(_))
+    });
     AttrContext {
         materialized: materialized_columns_of(df),
         map_attrs,
+        attr_tokens,
     }
 }
 

--- a/src/querier/src/query/metrics.rs
+++ b/src/querier/src/query/metrics.rs
@@ -2065,6 +2065,8 @@ fn apply_filters(
                     datafusion::arrow::datatypes::DataType::Map(_, _)
                 )
         }),
+        // Metrics tables carry no derived token column (logs only).
+        attr_tokens: false,
     };
     let mut predicate = col("metric_name").eq(lit(plan.metric_name.clone()));
     for m in &plan.matchers {
@@ -2659,7 +2661,7 @@ mod tests {
         // With the column → exact equality on `label_namespace`.
         let ctx = super::super::logql::AttrContext {
             materialized: ["label_namespace".to_string()].into_iter().collect(),
-            map_attrs: false,
+            ..Default::default()
         };
         let rendered = format!("{:?}", matcher_expr(&m, &ctx).unwrap());
         assert!(rendered.contains("label_namespace"), "{rendered}");

--- a/src/querier/src/query/search_filter.rs
+++ b/src/querier/src/query/search_filter.rs
@@ -502,6 +502,7 @@ mod tests {
         let ctx = AttrContext {
             materialized: MaterializedColumns::new(),
             map_attrs: true,
+            ..Default::default()
         };
         let condition = Condition {
             selector: Selector::AnyAttribute("namespace".to_string()),
@@ -533,7 +534,7 @@ mod tests {
         // With the column: exact equality on `label_namespace`.
         let ctx = AttrContext {
             materialized: ["label_namespace".to_string()].into_iter().collect(),
-            map_attrs: false,
+            ..Default::default()
         };
         let rendered = format!("{:?}", condition.to_expr(&ctx).unwrap());
         assert!(rendered.contains("label_namespace"), "{rendered}");

--- a/src/querier/src/query/trace.rs
+++ b/src/querier/src/query/trace.rs
@@ -454,6 +454,8 @@ impl TraceService {
                         datafusion::arrow::datatypes::DataType::Map(_, _)
                     )
             }),
+            // Traces tables carry no derived token column (logs only).
+            attr_tokens: false,
         };
         // Query demand (epic #737, #733): attribute conditions are
         // materialization candidates.

--- a/src/writer/src/schema_transform.rs
+++ b/src/writer/src/schema_transform.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Datelike, Timelike};
 use common::schema::schema_parser::ResolvedSchema;
-use common::schema::{SCHEMA_DEFINITIONS, materialized_column_name};
+use common::schema::{ATTR_TOKENS_COLUMN, SCHEMA_DEFINITIONS, materialized_column_name};
 use datafusion::arrow::{
     array::{
         Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Float64Array, Int32Array,
@@ -524,6 +524,74 @@ fn label_columns_from_maps(
     (fields, columns)
 }
 
+/// Parse a JSON-string column into per-row attribute objects the way the
+/// attribute *columns* are extracted: prefer the nested `attributes` object
+/// when present, else treat the root object as the attributes (matching the
+/// `resource_attributes` column's fallback).
+fn parse_attr_objects_with_root_fallback(
+    batch: &RecordBatch,
+    column: &str,
+) -> Result<Vec<Option<AttrMap>>> {
+    let col = get_column_by_name(batch, column)?;
+    let arr = col
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow!("{column} is not StringArray"))?;
+    Ok((0..arr.len())
+        .map(|i| {
+            if arr.is_null(i) {
+                return None;
+            }
+            let root: serde_json::Value = serde_json::from_str(arr.value(i)).ok()?;
+            match root.get("attributes") {
+                Some(serde_json::Value::Object(m)) => Some(m.clone()),
+                _ => match root {
+                    serde_json::Value::Object(m) => Some(m),
+                    _ => None,
+                },
+            }
+        })
+        .collect())
+}
+
+/// Build the derived `attr_tokens` `List<Utf8>` column: one `key=value`
+/// token per attribute across resource, scope, and record scopes,
+/// deduplicated per row. Rows always get a (possibly empty) list, never
+/// null, so an ANDed containment predicate cannot null out rows the
+/// attribute-column predicate matched.
+///
+/// The sources mirror the attribute-column extractions exactly — the
+/// querier ANDs `array_has(attr_tokens, 'key=value')` onto predicates over
+/// `log_attributes`/`resource_attributes`, so the tokens must cover at
+/// least everything those columns contain.
+fn attr_tokens_column(batch: &RecordBatch, num_rows: usize) -> Result<(Field, ArrayRef)> {
+    use datafusion::arrow::array::{ListBuilder, StringBuilder};
+
+    let resource = parse_attr_objects_with_root_fallback(batch, "resource_json")?;
+    let scope = parse_attr_objects(batch, "scope_json", Some("attributes"))?;
+    let record = parse_attr_objects(batch, "attributes_json", None)?;
+
+    let mut builder = ListBuilder::new(StringBuilder::new());
+    for i in 0..num_rows {
+        let mut seen = std::collections::HashSet::new();
+        for src in [resource.get(i), scope.get(i), record.get(i)] {
+            let Some(Some(map)) = src else { continue };
+            for (key, value) in map {
+                if let Some(s) = attr_value_to_string(value) {
+                    let token = format!("{key}={s}");
+                    if seen.insert(token.clone()) {
+                        builder.values().append_value(token);
+                    }
+                }
+            }
+        }
+        builder.append(true);
+    }
+    let array = builder.finish();
+    let field = Field::new(ATTR_TOKENS_COLUMN, array.data_type().clone(), true);
+    Ok((field, Arc::new(array)))
+}
+
 /// Append materialized-label fields/columns to a base batch schema. Returns
 /// the base schema unchanged when there are no label fields.
 fn extend_schema_with_labels(
@@ -831,6 +899,16 @@ pub fn transform_logs_v1_to_iceberg(batch: RecordBatch, labels: &[String]) -> Re
     let (label_fields, label_columns) = materialized_label_columns(&batch, num_rows, labels)?;
     let out_schema =
         extend_schema_with_labels(arrow_schema, label_fields, &mut new_columns, label_columns);
+
+    // Derived `key=value` token column for bloom-filtered containment
+    // checks; also dropped by coercion on tables that predate it.
+    let (token_field, token_column) = attr_tokens_column(&batch, num_rows)?;
+    let out_schema = extend_schema_with_labels(
+        out_schema,
+        vec![token_field],
+        &mut new_columns,
+        vec![token_column],
+    );
 
     let result = RecordBatch::try_new(out_schema, new_columns)
         .map_err(|e| anyhow!("Failed to create transformed log RecordBatch: {}", e))?;
@@ -2185,6 +2263,23 @@ mod tests {
         time_unix_nanos: &[u64],
         observed_time_unix_nanos: &[u64],
     ) -> RecordBatch {
+        let n = time_unix_nanos.len();
+        make_log_flight_batch_with_attrs(
+            time_unix_nanos,
+            observed_time_unix_nanos,
+            vec![None; n],
+            vec![None; n],
+            vec![None; n],
+        )
+    }
+
+    fn make_log_flight_batch_with_attrs(
+        time_unix_nanos: &[u64],
+        observed_time_unix_nanos: &[u64],
+        resource_json: Vec<Option<&str>>,
+        scope_json: Vec<Option<&str>>,
+        attributes_json: Vec<Option<&str>>,
+    ) -> RecordBatch {
         use datafusion::arrow::array::BinaryArray;
         use datafusion::arrow::datatypes::Fields;
 
@@ -2223,9 +2318,9 @@ mod tests {
                 Arc::new(BinaryArray::from(null_binaries.clone())),
                 Arc::new(BinaryArray::from(null_binaries)),
                 Arc::new(UInt32Array::from(null_u32.clone())),
-                Arc::new(StringArray::from(null_strings.clone())),
-                Arc::new(StringArray::from(null_strings.clone())),
-                Arc::new(StringArray::from(null_strings.clone())),
+                Arc::new(StringArray::from(attributes_json)),
+                Arc::new(StringArray::from(resource_json)),
+                Arc::new(StringArray::from(scope_json)),
                 Arc::new(UInt32Array::from(null_u32)),
                 Arc::new(StringArray::from(service_names)),
                 Arc::new(StringArray::from(null_strings)),
@@ -2305,6 +2400,74 @@ mod tests {
         // No configured labels → no extra columns.
         let (f, c) = materialized_label_columns(&batch, 2, &[]).unwrap();
         assert!(f.is_empty() && c.is_empty());
+    }
+
+    /// One row's tokens, sorted for stable comparison.
+    fn tokens_of(batch: &RecordBatch, row: usize) -> Vec<String> {
+        let list = batch
+            .column_by_name("attr_tokens")
+            .expect("attr_tokens column present")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("attr_tokens is a ListArray");
+        assert!(!list.is_null(row), "attr_tokens must never be null");
+        let values = list.value(row);
+        let strings = values.as_any().downcast_ref::<StringArray>().unwrap();
+        let mut out: Vec<String> = (0..strings.len())
+            .map(|i| strings.value(i).to_string())
+            .collect();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn log_transform_emits_attr_tokens_from_all_scopes() {
+        let ts: u64 = 1_700_000_000_000_000_000;
+        let batch = make_log_flight_batch_with_attrs(
+            &[ts, ts],
+            &[ts, ts],
+            vec![
+                // Flat root object (legacy shape).
+                Some(r#"{"namespace":"prod"}"#),
+                // Nested shape: tokens must come from `attributes`, not the
+                // envelope keys — mirroring the resource_attributes column.
+                Some(r#"{"attributes":{"env":"staging"},"schema_url":"http://x"}"#),
+            ],
+            vec![Some(r#"{"attributes":{"lib":"otel"}}"#), None],
+            vec![
+                // Non-string values serialize like the attribute columns do.
+                Some(r#"{"http.method":"GET","retries":2}"#),
+                Some(r#"{"http.method":"POST"}"#),
+            ],
+        );
+
+        let result = transform_logs_v1_to_iceberg(batch, &[]).unwrap();
+        assert_eq!(
+            tokens_of(&result, 0),
+            vec!["http.method=GET", "lib=otel", "namespace=prod", "retries=2"],
+        );
+        assert_eq!(
+            tokens_of(&result, 1),
+            vec!["env=staging", "http.method=POST"]
+        );
+    }
+
+    #[test]
+    fn log_transform_attr_tokens_dedupes_and_defaults_to_empty() {
+        let ts: u64 = 1_700_000_000_000_000_000;
+        let batch = make_log_flight_batch_with_attrs(
+            &[ts, ts],
+            &[ts, ts],
+            vec![Some(r#"{"env":"prod"}"#), None],
+            vec![None, None],
+            // Row 0 repeats env=prod in the record scope → single token.
+            vec![Some(r#"{"env":"prod"}"#), None],
+        );
+
+        let result = transform_logs_v1_to_iceberg(batch, &[]).unwrap();
+        assert_eq!(tokens_of(&result, 0), vec!["env=prod"]);
+        // No attributes anywhere → empty list, not null.
+        assert_eq!(tokens_of(&result, 1), Vec::<String>::new());
     }
 
     #[test]

--- a/tests-integration/tests/writer/iceberg_integration.rs
+++ b/tests-integration/tests/writer/iceberg_integration.rs
@@ -708,6 +708,142 @@ async fn label_column_write_produces_parquet_bloom_filter() -> Result<()> {
     Ok(())
 }
 
+/// End-to-end proof for #731 part 2: a wire-format logs batch written
+/// through `IcebergTableWriter` (transform → coercion → Parquet) lands with
+/// a populated `attr_tokens` column whose List leaf carries a bloom filter,
+/// and `array_has(attr_tokens, 'key=value')` filters rows correctly.
+#[tokio::test]
+async fn attr_tokens_write_populates_column_and_bloom_filter() -> Result<()> {
+    use datafusion::arrow::array::{BinaryArray, Int32Array, UInt32Array, UInt64Array};
+    use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
+    use datafusion::prelude::SessionContext;
+    use iceberg_rust::catalog::tabular::Tabular;
+    use object_store::ObjectStoreExt as _;
+
+    let mut config = Configuration::default();
+    config.schema.catalog_uri =
+        "sqlite:file:signaldb_attr_tokens?mode=memory&cache=shared".to_string();
+    let manager = CatalogManager::new(config).await?;
+    let object_store = Arc::new(InMemory::new());
+
+    let mut writer = IcebergTableWriter::new(
+        &manager,
+        object_store,
+        "default".to_string(),
+        "default".to_string(),
+        "logs".to_string(),
+    )
+    .await?;
+
+    // Two-row wire-format (v1) logs batch with attributes in all scopes.
+    let n = 2;
+    let ts: u64 = 1_700_000_000_000_000_000;
+    let wire_schema = Arc::new(Schema::new(vec![
+        Field::new("time_unix_nano", DataType::UInt64, false),
+        Field::new("observed_time_unix_nano", DataType::UInt64, false),
+        Field::new("severity_number", DataType::Int32, true),
+        Field::new("severity_text", DataType::Utf8, true),
+        Field::new("body", DataType::Utf8, true),
+        Field::new("trace_id", DataType::Binary, true),
+        Field::new("span_id", DataType::Binary, true),
+        Field::new("flags", DataType::UInt32, true),
+        Field::new("attributes_json", DataType::Utf8, true),
+        Field::new("resource_json", DataType::Utf8, true),
+        Field::new("scope_json", DataType::Utf8, true),
+        Field::new("dropped_attributes_count", DataType::UInt32, true),
+        Field::new("service_name", DataType::Utf8, true),
+        Field::new("event_name", DataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        wire_schema,
+        vec![
+            Arc::new(UInt64Array::from(vec![ts; n])),
+            Arc::new(UInt64Array::from(vec![ts; n])),
+            Arc::new(Int32Array::from(vec![None::<i32>; n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(StringArray::from(vec![Some("prod row"), Some("dev row")])),
+            Arc::new(BinaryArray::from(vec![None::<&[u8]>; n])),
+            Arc::new(BinaryArray::from(vec![None::<&[u8]>; n])),
+            Arc::new(UInt32Array::from(vec![None::<u32>; n])),
+            Arc::new(StringArray::from(vec![
+                Some(r#"{"env":"prod","team":"core"}"#),
+                Some(r#"{"env":"dev"}"#),
+            ])),
+            Arc::new(StringArray::from(vec![
+                Some(r#"{"attributes":{"namespace":"backend"}}"#),
+                None,
+            ])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+            Arc::new(UInt32Array::from(vec![None::<u32>; n])),
+            Arc::new(StringArray::from(vec![Some("api"); n])),
+            Arc::new(StringArray::from(vec![None::<&str>; n])),
+        ],
+    )?;
+
+    writer
+        .append_batches_with_marker("attr-tokens-test", vec![(uuid::Uuid::new_v4(), batch)])
+        .await?;
+
+    // Query back: token containment matches exactly one row per token.
+    let ident = manager.build_table_identifier("default", "default", "logs");
+    let Tabular::Table(table) = manager.catalog().load_tabular(&ident).await? else {
+        panic!("expected logs table");
+    };
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "logs",
+        Arc::new(datafusion_iceberg::DataFusionTable::from(table.clone())),
+    )?;
+    for (token, expected_body) in [
+        ("env=prod", "prod row"),
+        ("namespace=backend", "prod row"),
+        ("env=dev", "dev row"),
+    ] {
+        let rows = ctx
+            .sql(&format!(
+                "SELECT body FROM logs WHERE array_has(attr_tokens, '{token}')"
+            ))
+            .await?
+            .collect()
+            .await?;
+        let total: usize = rows.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1, "token {token} should match exactly one row");
+        let body = rows[0]
+            .column_by_name("body")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(body.value(0), expected_body, "token {token}");
+    }
+
+    // The written file's attr_tokens List leaf carries a bloom filter.
+    let store = table.object_store();
+    let mut listing = store.list(None);
+    let mut parquet_paths = Vec::new();
+    while let Some(meta) = futures::StreamExt::next(&mut listing).await {
+        let meta = meta?;
+        if meta.location.as_ref().ends_with(".parquet") {
+            parquet_paths.push(meta.location);
+        }
+    }
+    assert_eq!(parquet_paths.len(), 1, "expected one data file");
+    let bytes = store.get(&parquet_paths[0]).await?.bytes().await?;
+    let reader = SerializedFileReader::new(bytes)?;
+    let row_group = reader.metadata().row_group(0);
+    let leaf = row_group
+        .columns()
+        .iter()
+        .find(|c| c.column_path().string() == "attr_tokens.list.item")
+        .expect("attr_tokens.list.item leaf column present");
+    assert!(
+        leaf.bloom_filter_offset().is_some(),
+        "attr_tokens leaf should carry a bloom filter"
+    );
+
+    Ok(())
+}
+
 /// Spike for the attribute-explorability epic (#737 / #734): schema
 /// evolution through the low-level catalog commit path — `AddSchema` +
 /// `SetCurrentSchema` via `Catalog::update_table` — followed by a write


### PR DESCRIPTION
Part 2 of #731, stacked on #776. Completes Layer 2 for logs.

Emits a derived `attr_tokens` `List<Utf8>` column of deduped `key=value` strings (resource → scope → record) on logs tables, with a bloom filter over the Parquet leaf (`attr_tokens.list.item` — the Iceberg→Arrow 3-level List encoding maps upstream's dotted property split onto exactly that ColumnPath; verified by footer assertion, not just source reading).

- Schema: `to_iceberg_schema_with_labels_and_attr_tokens`, collision-free nested field IDs.
- Writer: populated in `transform_logs_v1_to_iceberg`; always non-null (possibly empty) list; old tables drop the column via the existing coercion path.
- Querier: exact-equality attribute filters gain an ANDed `array_has(attr_tokens, 'key=value')` conjunct when the table has the column; regex/negation/ordered and token-less tables unchanged.

**Release note:** an older writer binary writing to an attr_tokens table would null-fill the column, and the ANDed conjunct would drop those rows from equality results — writer and querier ship together, but mixed-version fleets should upgrade writers first.

**Follow-up (not this PR):** DataFusion's row-group pruning doesn't yet consult blooms for `array_has`; the format-side groundwork is in, a pruning rule comes separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logs now include searchable attribute tokens collected from resource, scope, and record attributes.
  * Attribute equality filters can use these tokens for more efficient log searches.
* **Performance**
  * Added bloom-filter support for attribute tokens, improving filtering efficiency on stored logs.
* **Bug Fixes**
  * Attribute tokens are deduplicated and consistently handled when attributes are nested, unstructured, or absent.
  * Equality filtering now works consistently across supported attribute formats without affecting other operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->