### PR TITLE
feat(compactor): act on attribute promotion decisions at rewrite

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -296,7 +296,7 @@ for the UI's tenant selector.
 - Distributed leases (`compactor_leases` catalog table) prevent concurrent compaction of the same partition
 - Flight admin interface exposes only `do_action` commands (`compact_now`, `compact_status`, `compact_dry_run`) and `list_actions`; all other Flight RPCs return `unimplemented`
 - Retention enforcement and orphan-file cleanup, configured via `[compactor.retention]` and `[compactor.orphan_cleanup]`
-- Advisory attribute-stats pass on every rewrite: logs per-key presence / approximate cardinality, persists the statistics to the catalog's `attribute_stats` table, and — when `[compactor.attr_promotion]` is enabled — logs a dry-run promotion/demotion decision (demand × presence under a schema-width budget with streak hysteresis; epic #737 Layer 4)
+- Advisory attribute-stats pass on every rewrite: logs per-key presence / approximate cardinality, persists the statistics to the catalog's `attribute_stats` table, and — when `[compactor.attr_promotion]` is enabled — computes a promotion/demotion decision (demand × presence under a schema-width budget with streak hysteresis; epic #737 Layer 4). With `dry_run = false` (default is `true`, log-only) promotions are acted on at rewrite: the table schema is evolved to add the `label_<key>` columns, then the rewrite backfills them from the attributes map and commits via the normal replace path
 - Enabled by default (retention enforcement included, 30d per signal); disable with `[compactor].enabled = false`
 
 ## Multi-Tenancy and Authentication

--- a/docs/operations/compactor/phase3-configuration.md
+++ b/docs/operations/compactor/phase3-configuration.md
@@ -16,6 +16,7 @@ Complete reference for configuring SignalDB Compactor Phase 3: Retention Enforce
 - [Configuration Overview](#configuration-overview)
 - [Retention Configuration](#retention-configuration)
 - [Orphan Cleanup Configuration](#orphan-cleanup-configuration)
+- [Attribute Promotion Configuration](#attribute-promotion-configuration)
 - [Environment Variables](#environment-variables)
 - [Configuration Examples](#configuration-examples)
 - [Validation Rules](#validation-rules)
@@ -358,6 +359,42 @@ max_live_files_threshold = 500000
 # max_snapshot_age_hours = 24     # Only last 24h snapshots
 ```
 
+## Attribute Promotion Configuration
+
+### `[compactor.attr_promotion]`
+
+Attribute auto-promotion (epic #737) turns frequently queried attribute keys into materialized `label_<key>` columns at compaction time. Every rewrite already runs a read-only attribute-statistics pass; when this section is enabled, a decision pass scores the persisted statistics (query demand x row presence) against guardrails and — with `dry_run = false` — acts on the result during the same rewrite.
+
+```toml
+[compactor.attr_promotion]
+enabled = true
+dry_run = true    # observe decisions first; set false to act on them
+max_labels_per_table = 32
+min_presence = 0.005
+min_query_hits = 1
+promote_streak = 3
+max_promotions_per_cycle = 4
+```
+
+| Setting                    | Type    | Default | Description                                                                                                                       |
+| -------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                  | boolean | `false` | Run the promotion decision pass on each rewrite                                                                                   |
+| `dry_run`                  | boolean | `true`  | Log decisions only; never change schemas or data                                                                                  |
+| `max_labels_per_table`     | integer | `32`    | Schema-width budget: maximum materialized `label_<key>` columns per table, pinned `[schema.materialized_labels]` entries included |
+| `min_presence`             | float   | `0.005` | Minimum fraction of rows a key must appear in to be promotable                                                                    |
+| `min_query_hits`           | integer | `1`     | Minimum accumulated query-demand hits for a key to be promotable                                                                  |
+| `promote_streak`           | integer | `3`     | Consecutive over-threshold cycles before promotion (hysteresis)                                                                   |
+| `max_promotions_per_cycle` | integer | `4`     | Maximum promotions per rewrite cycle                                                                                              |
+
+**`dry_run` semantics:**
+
+- `dry_run = true` (default): the pass only logs an `Attribute promotion decision` line per table. No schema or data changes.
+- `dry_run = false`: the compactor **acts** on promote decisions at the next rewrite of each table. It evolves the table schema (adds the promoted columns through a metadata-only commit), backfills the column values from the attributes map while rewriting the files, and commits the rewrite through the normal replace path. See the [operations guide](phase3-operations.md#attribute-promotion) for the observable sequence.
+
+The guardrails live in the decision engine and apply in both modes: machine-generated keys (embedded UUIDs, long hex or digit runs) are never promoted, keys whose distinct-value tracking hit the analyzer cap are rejected, a key must qualify for `promote_streak` consecutive cycles, and the schema-width budget caps the total number of label columns. Pinned `[schema.materialized_labels]` entries are never demoted or otherwise touched. Demotion (dropping unqueried auto-promoted columns) is decided and logged but not yet acted on.
+
+**Recommendation:** run with `dry_run = true` for several compaction cycles and review the `Attribute promotion decision` log lines. Flip to `false` only once the keys they announce are ones you want as columns.
+
 ## Environment Variables
 
 All scalar configuration can be overridden via environment variables.
@@ -605,4 +642,4 @@ Invalid retention configuration for tenant 'acme': Invalid retention period for 
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
 
-> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). When `[compactor.attr_promotion]` is enabled, a dry-run decision pass scores those statistics (demand × presence under a schema-width budget, with cardinality and generated-key guardrails plus streak hysteresis) and logs an `Attribute promotion decision` line. It requires no configuration and changes no table data.
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). This statistics pass requires no configuration and changes no table data. The promotion decision pass built on those statistics is configured via [`[compactor.attr_promotion]`](#attribute-promotion-configuration).

--- a/docs/operations/compactor/phase3-operations.md
+++ b/docs/operations/compactor/phase3-operations.md
@@ -19,6 +19,7 @@ This guide covers day-to-day operations for SignalDB Compactor Phase 3: Retentio
 - [Common Operations](#common-operations)
 - [Emergency Procedures](#emergency-procedures)
 - [Performance Tuning](#performance-tuning)
+- [Attribute Promotion](#attribute-promotion)
 
 ## Overview
 
@@ -694,10 +695,28 @@ export AWS_S3_USE_ACCELERATE_ENDPOINT=true
 
 ---
 
+## Attribute Promotion
+
+With [`[compactor.attr_promotion]`](phase3-configuration.md#attribute-promotion-configuration) enabled and `dry_run = false`, the compactor promotes qualifying attribute keys to materialized `label_<key>` columns as part of a normal compaction rewrite. Each acted-on promotion makes two commits per table:
+
+1. **Schema flip** (before the rewrite): a metadata-only `AddSchema` + `SetCurrentSchema` commit adds the promoted columns. No data files change; readers null-fill the new columns until the rewrite lands.
+2. **Rewrite/replace** (the normal compaction commit): every live row is rewritten with the label values backfilled from its attributes (resource, then scope, then record attributes). Existing label columns are recomputed too, healing rows the writer left null during the transition window.
+
+A schema-evolution failure is logged as a warning and the compaction continues under the old schema — promotion never fails a rewrite.
+
+**What operators see in the logs:**
+
+- `Attribute promotion decision` (info) — per table: `dry_run`, `promote`, `demote`, and `building` (keys still accumulating their hysteresis streak).
+- `Added materialized label columns via schema evolution` (info) — the schema flip landed; lists the table, new schema id, and columns.
+- `Failed to evolve schema for attribute promotion; continuing compaction without it` (warn) — the flip failed; the rewrite proceeded without new columns.
+- The usual `Rewrote table data into compacted files` line covers the backfilled rewrite — there is no separate backfill log line, and no promotion-specific Prometheus metric yet.
+
+Demotion candidates appear in the decision line but are not acted on (follow-up work). Pinned `[schema.materialized_labels]` entries are never demoted.
+
 ## Additional Resources
 
 - [Phase 3 Configuration Reference](phase3-configuration.md)
 - [Phase 3 Troubleshooting Guide](phase3-troubleshooting.md)
 - [Compactor README](../../../src/compactor/README.md)
 
-> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). When `[compactor.attr_promotion]` is enabled, a dry-run decision pass scores those statistics (demand × presence under a schema-width budget, with cardinality and generated-key guardrails plus streak hysteresis) and logs an `Attribute promotion decision` line. It requires no configuration and changes no table data.
+> Note: every compaction rewrite also runs a read-only attribute-statistics pass that logs per-key presence, approximate cardinality, and advisory materialization candidates (`Attribute-stats analyzer` log line), and persists the per-key statistics to the service catalog's `attribute_stats` table (joined there with query-demand counters flushed by the querier). This statistics pass requires no configuration and changes no table data; the promotion pass built on it is covered in [Attribute Promotion](#attribute-promotion).

--- a/docs/operations/compactor/phase3-troubleshooting.md
+++ b/docs/operations/compactor/phase3-troubleshooting.md
@@ -19,6 +19,7 @@ Comprehensive troubleshooting guide for SignalDB Compactor Phase 3: Retention En
 - [Data Integrity Issues](#data-integrity-issues)
 - [Debug Procedures](#debug-procedures)
 - [Common Error Messages](#common-error-messages)
+- [Attribute Promotion](#attribute-promotion)
 
 ## Quick Diagnosis
 
@@ -803,6 +804,16 @@ DEBUG compactor::orphan::detector: Skipping recent file (within grace period) pa
 
 **Solution:** Nothing to fix. The file becomes eligible after the grace period elapses.
 
+## Attribute Promotion
+
+**A `label_<key>` column appeared that is not in `[schema.materialized_labels]`:** attribute auto-promotion added it. With `[compactor.attr_promotion].dry_run = false`, the compactor promotes frequently queried attribute keys to columns at rewrite (see the [operations guide](phase3-operations.md#attribute-promotion)).
+
+**How to tell a promotion happened:** look for `Added materialized label columns via schema evolution` in the compactor logs (table, schema id, columns), or compare the table's current schema against your pinned config. The preceding `Attribute promotion decision` line shows why the key qualified.
+
+**How to stop promotions:** set `[compactor.attr_promotion].dry_run = true` (decisions are still logged, nothing changes) or `enabled = false` (no decision pass at all). Columns already added stay in place; they are nullable and harmless to queries.
+
+**Removing a promoted column:** demotion is decided and logged (`demote` in the decision line) but not yet acted on — dropping columns is follow-up work.
+
 ## Additional Resources
 
 - [Phase 3 Operations Guide](phase3-operations.md)
@@ -820,4 +831,4 @@ If you encounter issues not covered in this guide:
 4. **Configuration:** Share `signaldb.toml` (redact sensitive values)
 5. **Open Issue:** https://github.com/cedricziel/signaldb/issues with above information
 
-> The `Attribute-stats analyzer` log line on each rewrite is advisory only (epic #737); it never blocks or alters compaction. Its statistics are persisted to the catalog's `attribute_stats` table; a `Failed to persist attribute scan stats` warning means the catalog write failed and is safe to ignore for compaction correctness. The dry-run `Attribute promotion decision` line (when `[compactor.attr_promotion]` is enabled) is likewise advisory.
+> The `Attribute-stats analyzer` log line on each rewrite is advisory only (epic #737); it never blocks or alters compaction. Its statistics are persisted to the catalog's `attribute_stats` table; a `Failed to persist attribute scan stats` warning means the catalog write failed and is safe to ignore for compaction correctness. The `Attribute promotion decision` line (when `[compactor.attr_promotion]` is enabled) is advisory while `dry_run = true`; with `dry_run = false` the compactor acts on it — see [Attribute Promotion](#attribute-promotion).

--- a/src/compactor/src/attr_promotion.rs
+++ b/src/compactor/src/attr_promotion.rs
@@ -23,9 +23,13 @@
 //! - **Pinned labels** (from `[schema.materialized_labels]`) are never
 //!   demoted.
 
+use anyhow::{Context, Result};
 use common::catalog::AttributeStatsRecord;
 use common::config::AttrPromotionConfig;
 use common::schema::materialized_column_name;
+use datafusion::arrow::array::{ArrayRef, RecordBatch, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use std::sync::Arc;
 
 /// The outcome of a promotion pass over one table's statistics.
 #[derive(Debug, Default, PartialEq)]
@@ -177,9 +181,107 @@ pub fn materialized_keys_of(
         .collect()
 }
 
+/// Attribute source columns for the backfill, in the writer's value
+/// precedence order: resource, then scope, then the record-level column
+/// (only one of the record-level names exists per table).
+const BACKFILL_SOURCE_COLUMNS: &[&str] = &[
+    "resource_attributes",
+    "scope_attributes",
+    "span_attributes",
+    "log_attributes",
+    "attributes",
+    "profile_attributes",
+];
+
+/// Recompute the materialized `label_<column>` value columns of the given
+/// batches from their attribute source columns.
+///
+/// `pairs` maps attribute keys to their target column names (deduplicated
+/// by column — see [`materialized_column_name`]). Existing Utf8 columns
+/// are overwritten in place (healing rows the writer left null, e.g. data
+/// ingested after an auto-promotion); missing columns are appended in
+/// `pairs` order, matching the evolved schema which appends promoted
+/// columns at the end. Values follow the writer's source precedence
+/// (resource → scope → record attributes) and rows without the key stay
+/// null — old rows are backfilled by construction since every row is
+/// rewritten.
+pub(crate) fn backfill_label_columns(
+    batches: Vec<RecordBatch>,
+    pairs: &[(String, String)],
+) -> Result<Vec<RecordBatch>> {
+    if pairs.is_empty() {
+        return Ok(batches);
+    }
+    batches
+        .into_iter()
+        .map(|batch| backfill_batch(batch, pairs))
+        .collect()
+}
+
+/// One attribute source column parsed into per-row key/value documents.
+type AttrDocuments = Vec<Option<Vec<(String, String)>>>;
+
+fn backfill_batch(batch: RecordBatch, pairs: &[(String, String)]) -> Result<RecordBatch> {
+    let num_rows = batch.num_rows();
+
+    // Parse each attribute source column present in the batch once, in
+    // precedence order.
+    let sources: Vec<AttrDocuments> = BACKFILL_SOURCE_COLUMNS
+        .iter()
+        .filter_map(|column| batch.column_by_name(column))
+        .map(|array| crate::attr_stats::attr_documents(array.as_ref()))
+        .filter(|docs| docs.len() == num_rows)
+        .collect();
+
+    let mut fields: Vec<Field> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.as_ref().clone())
+        .collect();
+    let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
+
+    for (key, column) in pairs {
+        let values: StringArray = (0..num_rows)
+            .map(|row| {
+                sources.iter().find_map(|docs| {
+                    docs[row]
+                        .as_ref()
+                        .and_then(|doc| doc.iter().find(|(k, _)| k == key))
+                        .map(|(_, v)| v.clone())
+                })
+            })
+            .collect();
+        match fields.iter().position(|f| f.name() == column) {
+            Some(idx) if fields[idx].data_type() == &DataType::Utf8 => {
+                if !fields[idx].is_nullable() {
+                    fields[idx] = fields[idx].clone().with_nullable(true);
+                }
+                columns[idx] = Arc::new(values);
+            }
+            Some(_) => {
+                tracing::warn!(
+                    column = %column,
+                    attr_key = %key,
+                    "Materialized label column has a non-string type; skipping backfill"
+                );
+            }
+            None => {
+                fields.push(Field::new(column, DataType::Utf8, true));
+                columns.push(Arc::new(values));
+            }
+        }
+    }
+
+    let schema = Arc::new(Schema::new(fields));
+    RecordBatch::try_new(schema, columns)
+        .context("Failed to rebuild batch with backfilled label columns")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::arrow::array::Array;
 
     fn record(key: &str, present: i64, total: i64, hits: i64, streak: i64) -> AttributeStatsRecord {
         AttributeStatsRecord {
@@ -275,6 +377,84 @@ mod tests {
         assert!(looks_generated("session_12345678"));
         assert!(!looks_generated("http.method"));
         assert!(!looks_generated("k8s.pod.name"));
+    }
+
+    fn json_utf8_batch() -> RecordBatch {
+        // Two source columns: resource attrs win over record attrs.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("body", DataType::Utf8, true),
+            Field::new("resource_attributes", DataType::Utf8, true),
+            Field::new("log_attributes", DataType::Utf8, true),
+            Field::new("label_env", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("a"), Some("b"), Some("c")])),
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"env":"prod"}"#),
+                    None,
+                    Some("{}"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"env":"record-level","pod":"api-1"}"#),
+                    Some(r#"{"env":"staging"}"#),
+                    Some("{}"),
+                ])),
+                // Existing column with writer-left nulls to be healed.
+                Arc::new(StringArray::from(vec![None::<&str>, None, None])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+    }
+
+    #[test]
+    fn backfill_overwrites_existing_column_with_source_precedence() {
+        let pairs = vec![("env".to_string(), "label_env".to_string())];
+        let out = backfill_label_columns(vec![json_utf8_batch()], &pairs).unwrap();
+        assert_eq!(out.len(), 1);
+        let env = string_column(&out[0], "label_env");
+        // Row 0: resource wins over the record-level value.
+        assert_eq!(env.value(0), "prod");
+        // Row 1: only the record-level source carries the key.
+        assert_eq!(env.value(1), "staging");
+        // Row 2: key absent everywhere -> null.
+        assert!(env.is_null(2));
+        // Column count unchanged: the existing column was replaced.
+        assert_eq!(out[0].num_columns(), 4);
+    }
+
+    #[test]
+    fn backfill_appends_missing_columns_in_pair_order() {
+        let pairs = vec![
+            ("pod".to_string(), "label_pod".to_string()),
+            ("env".to_string(), "label_env".to_string()),
+        ];
+        let out = backfill_label_columns(vec![json_utf8_batch()], &pairs).unwrap();
+        let batch = &out[0];
+        // `label_pod` is new and appended before the (replaced) `label_env`.
+        assert_eq!(batch.num_columns(), 5);
+        assert_eq!(batch.schema().field(4).name(), "label_pod");
+        let pod = string_column(batch, "label_pod");
+        assert_eq!(pod.value(0), "api-1");
+        assert!(pod.is_null(1));
+        assert!(pod.is_null(2));
+    }
+
+    #[test]
+    fn backfill_without_pairs_is_a_no_op() {
+        let batch = json_utf8_batch();
+        let out = backfill_label_columns(vec![batch.clone()], &[]).unwrap();
+        assert_eq!(out[0], batch);
     }
 
     #[test]

--- a/src/compactor/src/attr_stats.rs
+++ b/src/compactor/src/attr_stats.rs
@@ -140,8 +140,9 @@ pub fn log_promotion_candidates(
 
 /// Iterate an attribute column's per-row documents as key/value pairs,
 /// handling both storage forms: `Map<Utf8, Utf8>` (new tables) and Utf8
-/// columns holding flat JSON objects (legacy tables).
-fn attr_documents(array: &dyn Array) -> Vec<Option<Vec<(String, String)>>> {
+/// columns holding flat JSON objects (legacy tables). Also used by the
+/// rewrite-coupled promotion backfill in [`crate::attr_promotion`].
+pub(crate) fn attr_documents(array: &dyn Array) -> Vec<Option<Vec<(String, String)>>> {
     if let Some(map) = array.as_any().downcast_ref::<MapArray>() {
         return (0..map.len())
             .map(|i| {

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -7,11 +7,26 @@
 
 use anyhow::{Context, Result};
 use common::CatalogManager;
+use common::schema::materialized_column_name;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::prelude::*;
+use iceberg_rust::catalog::identifier::Identifier;
 use iceberg_rust::spec::manifest::DataFile;
 use iceberg_rust::table::Table;
+use std::collections::HashSet;
 use std::sync::Arc;
+
+/// What the promotion pass decided to do to this rewrite (epic #737,
+/// #734). Empty/default when promotion is disabled or dry-run.
+#[derive(Debug, Default)]
+struct PromotionOutcome {
+    /// `(attribute key, label column)` pairs whose columns should be
+    /// recomputed from the attribute sources during this rewrite.
+    backfill: Vec<(String, String)>,
+    /// Whether the table's schema was evolved (new label columns added)
+    /// and must be reloaded before writing.
+    evolved: bool,
+}
 
 /// Result of rewriting a table's data files.
 pub struct RewriteOutcome {
@@ -106,6 +121,7 @@ impl ParquetRewriter {
         // candidates; changes nothing.
         let (attr_stats, scanned) = crate::attr_stats::analyze_batches(&merged_batches);
         crate::attr_stats::log_promotion_candidates(&table_name, &attr_stats, scanned);
+        let mut promotion = PromotionOutcome::default();
         if let Some(catalog) = &self.service_catalog {
             // The identifier namespace is [tenant_slug, dataset_slug].
             let ns = table.identifier().namespace();
@@ -119,10 +135,44 @@ impl ParquetRewriter {
                     scanned,
                 )
                 .await;
-                self.run_promotion_pass(catalog, tenant, dataset, &table_name, table)
+                promotion = self
+                    .run_promotion_pass(catalog, tenant, dataset, &table_name, table)
                     .await;
             }
         }
+
+        // When the promotion pass evolved the schema (new label columns),
+        // the write must happen under the reloaded table so the new files
+        // are written with the evolved schema.
+        let reloaded_table;
+        let write_table: &Table = if promotion.evolved {
+            reloaded_table = self
+                .load_fresh_by_identifier(table.identifier())
+                .await
+                .context("Failed to reload table after schema evolution")?;
+            &reloaded_table
+        } else {
+            table
+        };
+
+        // Recompute the materialized label columns from the attribute
+        // sources. Since every live row is rewritten, pre-existing rows
+        // get their values backfilled by construction.
+        let merged_batches = if promotion.backfill.is_empty() {
+            merged_batches
+        } else {
+            let schema_columns: HashSet<String> = write_table
+                .current_schema()
+                .map(|schema| schema.fields().iter().map(|f| f.name.clone()).collect())
+                .unwrap_or_default();
+            let pairs: Vec<(String, String)> = promotion
+                .backfill
+                .into_iter()
+                .filter(|(_, column)| schema_columns.contains(column))
+                .collect();
+            crate::attr_promotion::backfill_label_columns(merged_batches, &pairs)
+                .context("Failed to backfill materialized label columns")?
+        };
 
         // Chunk batches toward the target file size so the writer produces
         // reasonably sized files.
@@ -135,7 +185,7 @@ impl ParquetRewriter {
         );
 
         let new_files =
-            iceberg_rust::arrow::write::write_parquet_partitioned(table, batch_stream, None)
+            iceberg_rust::arrow::write::write_parquet_partitioned(write_table, batch_stream, None)
                 .await
                 .context("Failed to write compacted Parquet files")?;
 
@@ -167,11 +217,18 @@ impl ParquetRewriter {
         }))
     }
 
-    /// Advisory auto-promotion pass (epic #737, #734): score the freshly
-    /// persisted statistics against the configured guardrails, log the
+    /// Auto-promotion pass (epic #737, #734): score the freshly persisted
+    /// statistics against the configured guardrails, log the
     /// promotion/demotion decision, and persist the hysteresis streaks.
-    /// Dry-run only for now — the rewrite-coupled schema change is the
-    /// follow-up half.
+    ///
+    /// With `dry_run = false` the pass also *acts* on the decision: it
+    /// evolves the table schema (adds the promoted `label_<key>` columns
+    /// via the metadata-only AddSchema/SetCurrentSchema commit) and
+    /// returns the backfill plan for this rewrite. The two commits per
+    /// table — schema flip here, file replace after the rewrite — are
+    /// safe in that order: writer and querier read the schema live and
+    /// null-fill the new columns until the rewrite lands. Demotion
+    /// (dropping columns) is a later pass and is only ever logged.
     async fn run_promotion_pass(
         &self,
         catalog: &common::catalog::Catalog,
@@ -179,18 +236,19 @@ impl ParquetRewriter {
         dataset: &str,
         table_name: &str,
         table: &Table,
-    ) {
+    ) -> PromotionOutcome {
+        let mut outcome = PromotionOutcome::default();
         let config = self.catalog_manager.config();
         let promotion = &config.compactor.attr_promotion;
         if !promotion.enabled {
-            return;
+            return outcome;
         }
         let signal = crate::attr_stats::signal_of_table(table_name);
         let stats = match catalog.get_attribute_stats(tenant, dataset, signal).await {
             Ok(stats) => stats,
             Err(e) => {
                 tracing::warn!(error = %e, table = %table_name, "Failed to load attribute stats for promotion pass");
-                return;
+                return outcome;
             }
         };
         // The table's current label_<key> columns and the pinned allowlist.
@@ -225,6 +283,74 @@ impl ParquetRewriter {
             {
                 tracing::warn!(error = %e, attr_key = %key, "Failed to persist promotion streak");
             }
+        }
+
+        // Act on the decision when the pass is out of dry-run: evolve the
+        // schema before the rewrite so the new files carry the promoted
+        // columns. An evolution failure is logged and the compaction
+        // continues under the old schema — promotion must never fail a
+        // rewrite.
+        if promotion.dry_run {
+            return outcome;
+        }
+        if !decision.promote.is_empty() {
+            match common::iceberg::evolution::add_label_columns(
+                self.catalog_manager.catalog(),
+                table.identifier(),
+                &decision.promote,
+            )
+            .await
+            {
+                Ok(_) => {
+                    outcome.evolved = true;
+                    // TODO(#731): set bloom-filter table properties for the
+                    // newly promoted label columns once the
+                    // `bloom_filter_properties_for_labels` helper lands in
+                    // common.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        table = %table_name,
+                        keys = ?decision.promote,
+                        "Failed to evolve schema for attribute promotion; continuing compaction without it"
+                    );
+                }
+            }
+        }
+
+        // Backfill plan: the freshly promoted keys plus every label column
+        // whose source key is still known (already-materialized keys from
+        // the stats, and the pinned allowlist). Recomputing existing
+        // columns heals rows the writer left null during the transition
+        // window. Deduplicated by column name — the key -> column encoding
+        // is lossy.
+        let mut seen_columns = HashSet::new();
+        let promoted: &[String] = if outcome.evolved {
+            &decision.promote
+        } else {
+            &[]
+        };
+        for key in promoted.iter().chain(materialized.iter()).chain(pinned) {
+            let column = materialized_column_name(key);
+            if seen_columns.insert(column.clone()) {
+                outcome.backfill.push((key.clone(), column));
+            }
+        }
+        outcome
+    }
+
+    /// Load a table with fresh metadata by its Iceberg identifier.
+    async fn load_fresh_by_identifier(&self, identifier: &Identifier) -> Result<Table> {
+        let tabular = self
+            .catalog_manager
+            .catalog()
+            .load_tabular(identifier)
+            .await
+            .with_context(|| format!("Failed to load table {identifier} with fresh metadata"))?;
+        match tabular {
+            iceberg_rust::catalog::tabular::Tabular::Table(table) => Ok(table),
+            _ => Err(anyhow::anyhow!("Expected table but got view: {identifier}")),
         }
     }
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -119,6 +119,10 @@ path = "tests/compactor/retention_failure_scenarios.rs"
 name = "multi_instance"
 path = "tests/compactor/multi_instance.rs"
 
+[[test]]
+name = "attr_promotion_rewrite"
+path = "tests/compactor/attr_promotion_rewrite.rs"
+
 [package.metadata.cargo-machete]
 # These dependencies are used in integration tests under tests/ directory
 ignored = ["acceptor", "anyhow", "arrow-flight", "compactor", "datafusion", "futures", "iceberg-rust", "log", "opentelemetry-proto", "querier", "router", "tokio", "tokio-stream", "tonic", "writer"]

--- a/tests-integration/tests/compactor/attr_promotion_rewrite.rs
+++ b/tests-integration/tests/compactor/attr_promotion_rewrite.rs
@@ -1,0 +1,392 @@
+//! Rewrite-coupled attribute auto-promotion (epic #737, #734)
+//!
+//! End-to-end test of the active (non-dry-run) promotion path: a table
+//! with map-typed attributes and query demand for one key runs through a
+//! compaction, which must evolve the schema (add the `label_<key>`
+//! column via AddSchema + SetCurrentSchema), backfill the column for the
+//! pre-existing rows during the rewrite, and leave the data queryable.
+//! With `dry_run = true` the same setup must change nothing.
+
+use anyhow::Result;
+use common::catalog_manager::CatalogManager;
+use compactor::executor::{CompactionExecutor, CompactionStatus, ExecutorConfig};
+use compactor::metrics::CompactionMetrics;
+use compactor::planner::{CompactionCandidate, PartitionStats};
+use datafusion::arrow::array::{
+    Array as _, MapBuilder, MapFieldNames, RecordBatch, StringArray, StringBuilder,
+    TimestampMicrosecondArray,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef, TimeUnit};
+use datafusion::prelude::SessionContext;
+use futures::stream;
+use iceberg_rust::arrow::write::write_parquet_partitioned;
+use iceberg_rust::catalog::create::CreateTableBuilder;
+use iceberg_rust::catalog::identifier::Identifier;
+use iceberg_rust::catalog::tabular::Tabular;
+use iceberg_rust::spec::partition::PartitionSpec;
+use iceberg_rust::spec::schema::Schema as IcebergSchema;
+use iceberg_rust::spec::types::{MapType, PrimitiveType, StructField, StructType, Type};
+use iceberg_rust::table::Table;
+use std::sync::Arc;
+
+const TENANT: &str = "t1";
+const DATASET: &str = "d1";
+const TABLE: &str = "logs";
+
+fn string_field(id: i32, name: &str) -> StructField {
+    StructField {
+        id,
+        name: name.to_string(),
+        required: false,
+        field_type: Type::Primitive(PrimitiveType::String),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    }
+}
+
+/// A small logs-shaped table: the real sort columns (timestamp,
+/// service_name, severity_text) plus a map-typed `log_attributes` column
+/// whose nested key/value ids (6, 7) are allocated after the top-level
+/// ids, as the production schema parser does.
+fn table_schema() -> IcebergSchema {
+    let timestamp = StructField {
+        id: 1,
+        name: "timestamp".to_string(),
+        required: true,
+        field_type: Type::Primitive(PrimitiveType::Timestamp),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    };
+    let attributes = StructField {
+        id: 5,
+        name: "log_attributes".to_string(),
+        required: false,
+        field_type: Type::Map(MapType {
+            key_id: 6,
+            key: Box::new(Type::Primitive(PrimitiveType::String)),
+            value_id: 7,
+            value_required: false,
+            value: Box::new(Type::Primitive(PrimitiveType::String)),
+        }),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    };
+    IcebergSchema::from_struct_type(
+        StructType::new(vec![
+            timestamp,
+            string_field(2, "service_name"),
+            string_field(3, "severity_text"),
+            string_field(4, "body"),
+            attributes,
+        ]),
+        0,
+        None,
+    )
+}
+
+async fn load_table(catalog_manager: &CatalogManager, identifier: &Identifier) -> Result<Table> {
+    match catalog_manager.catalog().load_tabular(identifier).await? {
+        Tabular::Table(table) => Ok(table),
+        _ => anyhow::bail!("expected a table"),
+    }
+}
+
+/// One test row: (timestamp, service, body, attributes as key/value pairs).
+type TestRow<'a> = (i64, &'a str, &'a str, &'a [(&'a str, &'a str)]);
+
+/// Write one data file with the given rows.
+async fn write_file(
+    catalog_manager: &CatalogManager,
+    identifier: &Identifier,
+    rows: &[TestRow<'_>],
+) -> Result<()> {
+    let mut table = load_table(catalog_manager, identifier).await?;
+
+    // Derive the Arrow schema from the table so the map entry/key/value
+    // field names line up with what the table declares.
+    let arrow_schema: SchemaRef = Arc::new(
+        table
+            .current_schema()?
+            .fields()
+            .try_into()
+            .map_err(|e: iceberg_rust::spec::error::Error| anyhow::anyhow!("to arrow: {e}"))?,
+    );
+    let attr_field = arrow_schema.field_with_name("log_attributes")?;
+    let DataType::Map(entry_field, _) = attr_field.data_type() else {
+        anyhow::bail!("log_attributes should convert to an Arrow Map");
+    };
+    let DataType::Struct(kv_fields) = entry_field.data_type() else {
+        anyhow::bail!("map entries should be a struct");
+    };
+    let field_names = MapFieldNames {
+        entry: entry_field.name().clone(),
+        key: kv_fields[0].name().clone(),
+        value: kv_fields[1].name().clone(),
+    };
+
+    let mut attrs = MapBuilder::new(
+        Some(field_names),
+        StringBuilder::new(),
+        StringBuilder::new(),
+    );
+    let mut timestamps = Vec::new();
+    let mut services = Vec::new();
+    let mut severities = Vec::new();
+    let mut bodies = Vec::new();
+    for (ts, service, body, kvs) in rows {
+        timestamps.push(*ts);
+        services.push(Some(*service));
+        severities.push(Some("INFO"));
+        bodies.push(Some(*body));
+        for (k, v) in *kvs {
+            attrs.keys().append_value(k);
+            attrs.values().append_value(v);
+        }
+        attrs.append(true)?;
+    }
+    let attrs = attrs.finish();
+    let ts = TimestampMicrosecondArray::from(timestamps);
+
+    let batch_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+        Field::new("service_name", DataType::Utf8, true),
+        Field::new("severity_text", DataType::Utf8, true),
+        Field::new("body", DataType::Utf8, true),
+        Field::new("log_attributes", attrs.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        batch_schema,
+        vec![
+            Arc::new(ts),
+            Arc::new(StringArray::from(services)),
+            Arc::new(StringArray::from(severities)),
+            Arc::new(StringArray::from(bodies)),
+            Arc::new(attrs),
+        ],
+    )?;
+
+    let files = write_parquet_partitioned(&table, stream::iter(vec![Ok(batch)]), None).await?;
+    table
+        .new_transaction(None)
+        .append_data(files)
+        .commit()
+        .await?;
+    Ok(())
+}
+
+/// Build the environment: an in-memory catalog with the promotion pass
+/// configured (streak 1 so a single cycle promotes), a logs table with
+/// two small files whose rows carry `env`/`pod` attributes, and query
+/// demand recorded for `env` only.
+async fn setup(
+    dry_run: bool,
+) -> Result<(
+    Arc<CatalogManager>,
+    Arc<common::catalog::Catalog>,
+    Identifier,
+)> {
+    let mut config = common::testing::TestConfigBuilder::new()
+        .in_memory()
+        .with_tenant(TENANT, DATASET)
+        .build();
+    config.compactor.attr_promotion = common::config::AttrPromotionConfig {
+        enabled: true,
+        dry_run,
+        max_labels_per_table: 8,
+        min_presence: 0.01,
+        min_query_hits: 1,
+        promote_streak: 1,
+        max_promotions_per_cycle: 4,
+    };
+    let catalog_manager = Arc::new(CatalogManager::new(config).await?);
+
+    let namespace = catalog_manager.build_namespace(TENANT, DATASET)?;
+    catalog_manager
+        .catalog()
+        .create_namespace(&namespace, None)
+        .await?;
+    let identifier = catalog_manager.build_table_identifier(TENANT, DATASET, TABLE);
+    let create = CreateTableBuilder::default()
+        .with_name(TABLE.to_string())
+        .with_schema(table_schema())
+        .with_partition_spec(PartitionSpec::default())
+        .with_location(catalog_manager.build_table_location(TENANT, DATASET, TABLE))
+        .create()
+        .map_err(|e| anyhow::anyhow!("create table build: {e}"))?;
+    catalog_manager
+        .catalog()
+        .create_table(identifier.clone(), create)
+        .await?;
+
+    // Two files -> the executor has something to compact. `env` appears
+    // in 3 of 4 rows; `pod` in 2 (and has no query demand). Every row
+    // carries at least one attribute: a Parquet file written through
+    // `write_parquet_partitioned` with an empty-map row currently reads
+    // back with the whole map column empty (upstream iceberg-rust quirk,
+    // unrelated to promotion), which would skew the presence stats.
+    write_file(
+        &catalog_manager,
+        &identifier,
+        &[
+            (
+                1_000_000,
+                "api",
+                "hello prod",
+                &[("env", "prod"), ("pod", "api-1")],
+            ),
+            (2_000_000, "api", "hello staging", &[("env", "staging")]),
+        ],
+    )
+    .await?;
+    write_file(
+        &catalog_manager,
+        &identifier,
+        &[
+            (3_000_000, "web", "no env here", &[("pod", "web-1")]),
+            (4_000_000, "web", "hello prod again", &[("env", "prod")]),
+        ],
+    )
+    .await?;
+
+    // Query demand for `env` only. The promotion pass reads stats keyed
+    // by the identifier's namespace slugs (equal to the ids here).
+    let service_catalog = Arc::new(common::catalog::Catalog::new_in_memory().await?);
+    service_catalog
+        .add_attribute_query_hits(TENANT, DATASET, "logs", "env", 10)
+        .await?;
+
+    Ok((catalog_manager, service_catalog, identifier))
+}
+
+async fn run_compaction(
+    catalog_manager: Arc<CatalogManager>,
+    service_catalog: Arc<common::catalog::Catalog>,
+) -> Result<()> {
+    let executor = CompactionExecutor::new(
+        catalog_manager,
+        ExecutorConfig::default(),
+        CompactionMetrics::new(),
+    )
+    .with_service_catalog(service_catalog);
+    let candidate = CompactionCandidate {
+        tenant_id: TENANT.to_string(),
+        dataset_id: DATASET.to_string(),
+        table_name: TABLE.to_string(),
+        partition_id: "all".to_string(),
+        stats: PartitionStats {
+            file_count: 2,
+            total_size_bytes: 4096,
+            avg_file_size_bytes: 2048,
+        },
+    };
+    let result = executor.execute_candidate(candidate).await?;
+    anyhow::ensure!(
+        result.status == CompactionStatus::Success,
+        "compaction must succeed: {:?}",
+        result.error
+    );
+    Ok(())
+}
+
+async fn count_rows(ctx: &SessionContext, sql: &str) -> Result<usize> {
+    let rows = ctx.sql(sql).await?.collect().await?;
+    Ok(rows.iter().map(|b| b.num_rows()).sum())
+}
+
+#[tokio::test]
+async fn active_promotion_evolves_schema_and_backfills_on_rewrite() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let (catalog_manager, service_catalog, identifier) = setup(false).await?;
+
+    run_compaction(catalog_manager.clone(), service_catalog).await?;
+
+    // Schema evolved: `label_env` exists (and only it — `pod` had no
+    // query demand and must not be promoted).
+    let table = load_table(&catalog_manager, &identifier).await?;
+    let schema = table.current_schema()?;
+    assert!(
+        schema.fields().iter().any(|f| f.name == "label_env"),
+        "promoted column must exist in the current schema"
+    );
+    assert!(
+        !schema.fields().iter().any(|f| f.name == "label_pod"),
+        "unqueried key must not be promoted"
+    );
+    assert_eq!(table.metadata().current_schema_id, 1);
+    assert_eq!(table.metadata().schemas.len(), 2);
+
+    // The rewrite backfilled the column for the pre-existing rows and the
+    // data is queryable through the promoted column.
+    let provider = Arc::new(datafusion_iceberg::DataFusionTable::new(
+        Tabular::Table(table),
+        None,
+        None,
+        None,
+    )) as Arc<dyn datafusion::datasource::TableProvider>;
+    let ctx = SessionContext::new();
+    ctx.register_table("logs", provider)?;
+
+    assert_eq!(count_rows(&ctx, "SELECT body FROM logs").await?, 4);
+    assert_eq!(
+        count_rows(&ctx, "SELECT body FROM logs WHERE label_env = 'prod'").await?,
+        2,
+        "pre-existing rows must be backfilled from the attributes map"
+    );
+    assert_eq!(
+        count_rows(&ctx, "SELECT body FROM logs WHERE label_env = 'staging'").await?,
+        1
+    );
+    assert_eq!(
+        count_rows(&ctx, "SELECT body FROM logs WHERE label_env IS NULL").await?,
+        1,
+        "rows without the attribute stay null"
+    );
+    // The source attributes are still intact after the rewrite.
+    assert_eq!(
+        count_rows(
+            &ctx,
+            "SELECT body FROM logs WHERE log_attributes['env'] = 'prod'"
+        )
+        .await?,
+        2
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn dry_run_promotion_changes_nothing() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let (catalog_manager, service_catalog, identifier) = setup(true).await?;
+
+    run_compaction(catalog_manager.clone(), service_catalog).await?;
+
+    // Schema untouched: no label columns, no extra schema version.
+    let table = load_table(&catalog_manager, &identifier).await?;
+    let schema = table.current_schema()?;
+    assert!(
+        !schema.fields().iter().any(|f| f.name.starts_with("label_")),
+        "dry run must not evolve the schema"
+    );
+    assert_eq!(table.metadata().schemas.len(), 1);
+
+    // Compaction itself still worked and preserved the data.
+    let provider = Arc::new(datafusion_iceberg::DataFusionTable::new(
+        Tabular::Table(table),
+        None,
+        None,
+        None,
+    )) as Arc<dyn datafusion::datasource::TableProvider>;
+    let ctx = SessionContext::new();
+    ctx.register_table("logs", provider)?;
+    assert_eq!(count_rows(&ctx, "SELECT body FROM logs").await?, 4);
+
+    Ok(())
+}


### PR DESCRIPTION
Part 2 of #734, stacked on #783. Closes the loop from stats → decision → action: with `[compactor.attr_promotion].dry_run = false`, the compactor now materializes promoted attribute keys as real columns at rewrite time.

- Before rewriting a table, promote keys from `attr_promotion::decide()` via the #783 helper (`AddSchema` + `SetCurrentSchema`), then reload the table.
- The rewrite projection extracts `label_<key>` from the `attributes` map column — **backfill falls out for free** since the rewrite rewrites old rows anyway.
- Commit goes through the existing verified `IcebergCommitter` replace path (optimistic concurrency + post-commit reload check). Two-commit sequence (schema flip, then replace) — safe because writer/querier read schema live and null-fill.
- Guardrails (generated-key detection, caps, hysteresis, pinned manual entries) stay in the decision engine; this PR only acts on its output.
- `dry_run` remains the default: log-only, no behavior change for existing deployments.

Tests: `active_promotion_evolves_schema_and_backfills_on_rewrite` (schema evolved, old rows backfilled, queryable) and `dry_run_promotion_changes_nothing`; compactor suite 106 passed; schema-evolution regression green.