### PR TITLE
feat(compactor): demote unqueried label columns at rewrite

### DIFF
--- a/docs/operations/compactor/phase3-operations.md
+++ b/docs/operations/compactor/phase3-operations.md
@@ -711,7 +711,7 @@ A schema-evolution failure is logged as a warning and the compaction continues u
 - `Failed to evolve schema for attribute promotion; continuing compaction without it` (warn) — the flip failed; the rewrite proceeded without new columns.
 - The usual `Rewrote table data into compacted files` line covers the backfilled rewrite — there is no separate backfill log line, and no promotion-specific Prometheus metric yet.
 
-Demotion candidates appear in the decision line but are not acted on (follow-up work). Pinned `[schema.materialized_labels]` entries are never demoted.
+Demotion candidates are dropped at rewrite (schema commit without the column, after the promote half; the rewrite then omits it — attribute data stays in the map tier). Pinned `[schema.materialized_labels]` entries are never demoted. Note: demand counters are cumulative today, so a once-queried key is not demoted until a demand-decay window lands (follow-up).
 
 ## Additional Resources
 

--- a/docs/operations/compactor/phase3-troubleshooting.md
+++ b/docs/operations/compactor/phase3-troubleshooting.md
@@ -812,7 +812,7 @@ DEBUG compactor::orphan::detector: Skipping recent file (within grace period) pa
 
 **How to stop promotions:** set `[compactor.attr_promotion].dry_run = true` (decisions are still logged, nothing changes) or `enabled = false` (no decision pass at all). Columns already added stay in place; they are nullable and harmless to queries.
 
-**Removing a promoted column:** demotion is decided and logged (`demote` in the decision line) but not yet acted on — dropping columns is follow-up work.
+**Removing a promoted column:** demotion is acted on at rewrite: unpinned promoted columns with no recorded query demand are dropped from the schema at the next compaction cycle (the data remains queryable through the attributes map). To force-keep a column, pin it in `[schema.materialized_labels]`.
 
 ## Additional Resources
 

--- a/src/common/src/iceberg/evolution.rs
+++ b/src/common/src/iceberg/evolution.rs
@@ -115,9 +115,13 @@ pub async fn add_label_columns(
 
     // Build the evolved schema: current fields plus one optional string
     // field per new key, ids continuing after the true maximum across the
-    // whole schema tree.
+    // whole schema tree AND the metadata's `last_column_id` — a column
+    // dropped by [`remove_label_columns`] no longer appears in the current
+    // schema, but its id must never be reused (old data files still map
+    // it to the old column's values).
+    let metadata = table.metadata();
     let mut fields: Vec<StructField> = current.fields().iter().cloned().collect();
-    let mut next_id = max_field_id(current) + 1;
+    let mut next_id = max_field_id(current).max(metadata.last_column_id) + 1;
     for (key, column) in &new_columns {
         fields.push(StructField {
             id: next_id,
@@ -132,7 +136,6 @@ pub async fn add_label_columns(
     }
     let last_column_id = next_id - 1;
 
-    let metadata = table.metadata();
     let new_schema_id = metadata
         .schemas
         .keys()
@@ -181,6 +184,114 @@ pub async fn add_label_columns(
         schema_id = *verified.schema_id(),
         columns = ?new_columns.iter().map(|(_, c)| c.as_str()).collect::<Vec<_>>(),
         "Added materialized label columns via schema evolution"
+    );
+
+    Ok(verified.clone())
+}
+
+/// Remove the materialized `label_<key>` columns of the given attribute
+/// keys from the table's current schema and make the pruned schema
+/// current (the demotion half of #734).
+///
+/// Idempotent: keys whose materialized column (see
+/// [`materialized_column_name`]) is already absent are skipped, and when
+/// nothing remains to drop the current schema is returned without a
+/// commit. Only `label_<key>` columns can ever be named — the key ->
+/// column encoding always carries the `label_` prefix, so base columns
+/// are unreachable by construction. Field ids of dropped columns are
+/// never reused: the metadata's `last_column_id` is left untouched
+/// (`AddSchema` with `last_column_id: None`) and [`add_label_columns`]
+/// allocates past it.
+///
+/// The change is committed as `AddSchema` + `SetCurrentSchema` through
+/// [`Catalog::update_table`], then the table is reloaded and the pruned
+/// schema verified, mirroring [`add_label_columns`]. The attribute values
+/// themselves stay in the map-typed attributes column — dropping the
+/// label column loses nothing; queries fall back to map matching.
+///
+/// Returns the verified current schema (without the dropped columns).
+pub async fn remove_label_columns(
+    catalog: Arc<dyn Catalog>,
+    identifier: &Identifier,
+    keys: &[String],
+) -> Result<Schema> {
+    let table = load_table(&catalog, identifier).await?;
+    let current = table
+        .current_schema()
+        .map_err(|e| anyhow::anyhow!("Failed to resolve current schema of {identifier}: {e}"))?;
+
+    // Resolve keys to column names, keeping only columns that exist and
+    // collapsing duplicates (two keys can encode to the same column).
+    let mut drop_columns: Vec<String> = Vec::new();
+    for key in keys {
+        let column = materialized_column_name(key);
+        if current.fields().iter().any(|f| f.name == column) && !drop_columns.contains(&column) {
+            drop_columns.push(column);
+        }
+    }
+    if drop_columns.is_empty() {
+        return Ok(current.clone());
+    }
+
+    // Build the pruned schema: current fields minus the dropped columns,
+    // ids untouched, new schema id one past the highest existing one.
+    let fields: Vec<StructField> = current
+        .fields()
+        .iter()
+        .filter(|f| !drop_columns.contains(&f.name))
+        .cloned()
+        .collect();
+    let metadata = table.metadata();
+    let new_schema_id = metadata
+        .schemas
+        .keys()
+        .max()
+        .copied()
+        .unwrap_or(*current.schema_id())
+        + 1;
+    let pruned = Schema::from_struct_type(StructType::new(fields), new_schema_id, None);
+
+    catalog
+        .clone()
+        .update_table(CommitTable {
+            identifier: identifier.clone(),
+            requirements: vec![],
+            updates: vec![
+                TableUpdate::AddSchema {
+                    schema: pruned,
+                    // Keep `last_column_id` as is: dropped ids must never
+                    // be handed out again.
+                    last_column_id: None,
+                },
+                TableUpdate::SetCurrentSchema {
+                    schema_id: new_schema_id,
+                },
+            ],
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to commit schema demotion for {identifier}: {e}"))?;
+
+    // Post-commit verification: reload and confirm the pruned schema is
+    // current and every named column is gone.
+    let reloaded = load_table(&catalog, identifier)
+        .await
+        .context("Failed to reload table for post-demotion verification")?;
+    let verified = reloaded.current_schema().map_err(|e| {
+        anyhow::anyhow!("Failed to resolve current schema after demotion of {identifier}: {e}")
+    })?;
+    for column in &drop_columns {
+        anyhow::ensure!(
+            !verified.fields().iter().any(|f| &f.name == column),
+            "Schema demotion of {identifier} did not take effect: column {column} still present \
+             in current schema; a concurrent commit likely won the race"
+        );
+    }
+
+    tracing::info!(
+        table = %identifier,
+        schema_id = *verified.schema_id(),
+        columns = ?drop_columns,
+        "Removed materialized label columns via schema evolution"
     );
 
     Ok(verified.clone())
@@ -376,6 +487,96 @@ mod tests {
                 .count(),
             1
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn removes_label_columns_and_flips_current_schema() -> anyhow::Result<()> {
+        let manager = CatalogManager::new_in_memory().await?;
+        let catalog = manager.catalog();
+        let identifier = create_test_table(&catalog, "events").await?;
+
+        add_label_columns(
+            catalog.clone(),
+            &identifier,
+            &["env".to_string(), "pod".to_string()],
+        )
+        .await?;
+        let schema =
+            remove_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+
+        assert!(field(&schema, "label_env").is_none(), "label_env dropped");
+        assert!(field(&schema, "label_pod").is_some(), "label_pod kept");
+        assert!(field(&schema, "attributes").is_some(), "map column kept");
+
+        // The pruned schema is current in the catalog and the column id
+        // budget did not regress.
+        let table = load_table(&catalog, &identifier).await?;
+        assert_eq!(table.metadata().current_schema_id, 2);
+        assert_eq!(table.metadata().schemas.len(), 3);
+        assert_eq!(table.metadata().last_column_id, 7);
+        assert!(field(table.current_schema()?, "label_env").is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remove_rerun_is_idempotent_and_commits_nothing() -> anyhow::Result<()> {
+        let manager = CatalogManager::new_in_memory().await?;
+        let catalog = manager.catalog();
+        let identifier = create_test_table(&catalog, "events").await?;
+
+        add_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+        let first =
+            remove_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+        let second =
+            remove_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+        assert_eq!(first, second, "re-run must return the same schema");
+
+        let table = load_table(&catalog, &identifier).await?;
+        assert_eq!(
+            table.metadata().schemas.len(),
+            3,
+            "idempotent re-run must not add another schema"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remove_of_absent_columns_is_a_no_op() -> anyhow::Result<()> {
+        let manager = CatalogManager::new_in_memory().await?;
+        let catalog = manager.catalog();
+        let identifier = create_test_table(&catalog, "events").await?;
+
+        // No label columns exist yet: nothing to remove, no commit. The
+        // key -> column encoding also means base columns can never be
+        // named for removal ("body" maps to "label_body").
+        let schema = remove_label_columns(
+            catalog.clone(),
+            &identifier,
+            &["env".to_string(), "body".to_string()],
+        )
+        .await?;
+        assert!(field(&schema, "body").is_some());
+
+        let table = load_table(&catalog, &identifier).await?;
+        assert_eq!(table.metadata().schemas.len(), 1, "no commit happened");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn readd_after_remove_assigns_a_fresh_field_id() -> anyhow::Result<()> {
+        let manager = CatalogManager::new_in_memory().await?;
+        let catalog = manager.catalog();
+        let identifier = create_test_table(&catalog, "events").await?;
+
+        add_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+        remove_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+        let schema = add_label_columns(catalog.clone(), &identifier, &["env".to_string()]).await?;
+
+        // Iceberg field ids must never be reused: the re-added column gets
+        // a new id past the previous maximum (6 was the original).
+        let env = field(&schema, "label_env").expect("label_env re-added");
+        assert_eq!(env.id, 7);
         Ok(())
     }
 

--- a/src/compactor/src/rewriter.rs
+++ b/src/compactor/src/rewriter.rs
@@ -23,9 +23,13 @@ struct PromotionOutcome {
     /// `(attribute key, label column)` pairs whose columns should be
     /// recomputed from the attribute sources during this rewrite.
     backfill: Vec<(String, String)>,
-    /// Whether the table's schema was evolved (new label columns added)
-    /// and must be reloaded before writing.
+    /// Whether the table's schema was evolved (label columns added or
+    /// dropped) and must be reloaded before writing.
     evolved: bool,
+    /// `label_<key>` columns dropped by the demotion half: the rewrite
+    /// must project them out of the merged batches, since the read
+    /// happened under the pre-demotion schema.
+    dropped_columns: Vec<String>,
 }
 
 /// Result of rewriting a table's data files.
@@ -155,6 +159,18 @@ impl ParquetRewriter {
             table
         };
 
+        // Drop demoted label columns from the merged batches: the read
+        // happened under the pre-demotion schema, so the batches still
+        // carry the columns the demotion just removed. The attribute
+        // values themselves stay in the map attributes column, so nothing
+        // is lost.
+        let merged_batches = if promotion.dropped_columns.is_empty() {
+            merged_batches
+        } else {
+            Self::drop_columns(merged_batches, &promotion.dropped_columns)
+                .context("Failed to drop demoted label columns from rewrite batches")?
+        };
+
         // Recompute the materialized label columns from the attribute
         // sources. Since every live row is rewritten, pre-existing rows
         // get their values backfilled by construction.
@@ -223,12 +239,15 @@ impl ParquetRewriter {
     ///
     /// With `dry_run = false` the pass also *acts* on the decision: it
     /// evolves the table schema (adds the promoted `label_<key>` columns
-    /// via the metadata-only AddSchema/SetCurrentSchema commit) and
-    /// returns the backfill plan for this rewrite. The two commits per
-    /// table — schema flip here, file replace after the rewrite — are
-    /// safe in that order: writer and querier read the schema live and
-    /// null-fill the new columns until the rewrite lands. Demotion
-    /// (dropping columns) is a later pass and is only ever logged.
+    /// and drops the demoted ones via the metadata-only
+    /// AddSchema/SetCurrentSchema commits) and returns the backfill plan
+    /// for this rewrite. The two commits per table — schema flip here,
+    /// file replace after the rewrite — are safe in that order: writer
+    /// and querier read the schema live, null-fill new columns until the
+    /// rewrite lands, and fall back to map/JSON matching for dropped
+    /// ones (label routing is derived from the table schema per query).
+    /// Pinned `[schema.materialized_labels]` keys are never demoted —
+    /// the decision engine excludes them.
     async fn run_promotion_pass(
         &self,
         catalog: &common::catalog::Catalog,
@@ -319,25 +338,87 @@ impl ParquetRewriter {
             }
         }
 
+        // Demotion (#734 P3): drop the long-unqueried auto-promoted
+        // columns before the rewrite so the new files stop carrying
+        // them. Like promotion, a failure is logged and the compaction
+        // continues — at worst the column lives until the next cycle.
+        let mut demoted: Vec<String> = Vec::new();
+        if !decision.demote.is_empty() {
+            match common::iceberg::evolution::remove_label_columns(
+                self.catalog_manager.catalog(),
+                table.identifier(),
+                &decision.demote,
+            )
+            .await
+            {
+                Ok(_) => {
+                    outcome.evolved = true;
+                    demoted = decision.demote;
+                    outcome.dropped_columns = demoted
+                        .iter()
+                        .map(|key| materialized_column_name(key))
+                        .collect();
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        table = %table_name,
+                        keys = ?decision.demote,
+                        "Failed to evolve schema for attribute demotion; continuing compaction without it"
+                    );
+                }
+            }
+        }
+
         // Backfill plan: the freshly promoted keys plus every label column
         // whose source key is still known (already-materialized keys from
-        // the stats, and the pinned allowlist). Recomputing existing
-        // columns heals rows the writer left null during the transition
-        // window. Deduplicated by column name — the key -> column encoding
-        // is lossy.
+        // the stats, and the pinned allowlist), minus what was just
+        // demoted. Recomputing existing columns heals rows the writer
+        // left null during the transition window. Deduplicated by column
+        // name — the key -> column encoding is lossy.
         let mut seen_columns = HashSet::new();
         let promoted: &[String] = if outcome.evolved {
             &decision.promote
         } else {
             &[]
         };
-        for key in promoted.iter().chain(materialized.iter()).chain(pinned) {
+        for key in promoted
+            .iter()
+            .chain(materialized.iter())
+            .chain(pinned)
+            .filter(|key| !demoted.contains(key))
+        {
             let column = materialized_column_name(key);
             if seen_columns.insert(column.clone()) {
                 outcome.backfill.push((key.clone(), column));
             }
         }
         outcome
+    }
+
+    /// Project the named columns out of every batch (missing columns are
+    /// ignored). Used to strip demoted label columns that were read under
+    /// the pre-demotion schema.
+    fn drop_columns(batches: Vec<RecordBatch>, columns: &[String]) -> Result<Vec<RecordBatch>> {
+        batches
+            .into_iter()
+            .map(|batch| {
+                let keep: Vec<usize> = batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, field)| !columns.contains(field.name()))
+                    .map(|(idx, _)| idx)
+                    .collect();
+                if keep.len() == batch.num_columns() {
+                    return Ok(batch);
+                }
+                batch
+                    .project(&keep)
+                    .context("Failed to project batch without demoted columns")
+            })
+            .collect()
     }
 
     /// Load a table with fresh metadata by its Iceberg identifier.

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -123,6 +123,10 @@ path = "tests/compactor/multi_instance.rs"
 name = "attr_promotion_rewrite"
 path = "tests/compactor/attr_promotion_rewrite.rs"
 
+[[test]]
+name = "attr_demotion_rewrite"
+path = "tests/compactor/attr_demotion_rewrite.rs"
+
 [package.metadata.cargo-machete]
 # These dependencies are used in integration tests under tests/ directory
 ignored = ["acceptor", "anyhow", "arrow-flight", "compactor", "datafusion", "futures", "iceberg-rust", "log", "opentelemetry-proto", "querier", "router", "tokio", "tokio-stream", "tonic", "writer"]

--- a/tests-integration/tests/compactor/attr_demotion_rewrite.rs
+++ b/tests-integration/tests/compactor/attr_demotion_rewrite.rs
@@ -1,0 +1,449 @@
+//! Rewrite-coupled attribute demotion (epic #737, #734 P3)
+//!
+//! End-to-end test of the active (non-dry-run) demotion path: a table
+//! that already carries a materialized `label_env` column but has zero
+//! recorded query demand for `env` runs through a compaction, which must
+//! drop the column via schema evolution (AddSchema + SetCurrentSchema)
+//! before the rewrite so the new files stop carrying it — while the
+//! attribute values stay queryable through the map-typed attributes
+//! column. A pinned `[schema.materialized_labels]` entry must never be
+//! demoted, and with `dry_run = true` the same setup must change nothing.
+
+use anyhow::Result;
+use common::catalog_manager::CatalogManager;
+use compactor::executor::{CompactionExecutor, CompactionStatus, ExecutorConfig};
+use compactor::metrics::CompactionMetrics;
+use compactor::planner::{CompactionCandidate, PartitionStats};
+use datafusion::arrow::array::{
+    Array as _, MapBuilder, MapFieldNames, RecordBatch, StringArray, StringBuilder,
+    TimestampMicrosecondArray,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef, TimeUnit};
+use datafusion::prelude::SessionContext;
+use futures::stream;
+use iceberg_rust::arrow::write::write_parquet_partitioned;
+use iceberg_rust::catalog::create::CreateTableBuilder;
+use iceberg_rust::catalog::identifier::Identifier;
+use iceberg_rust::catalog::tabular::Tabular;
+use iceberg_rust::spec::partition::PartitionSpec;
+use iceberg_rust::spec::schema::Schema as IcebergSchema;
+use iceberg_rust::spec::types::{MapType, PrimitiveType, StructField, StructType, Type};
+use iceberg_rust::table::Table;
+use std::sync::Arc;
+
+const TENANT: &str = "t1";
+const DATASET: &str = "d1";
+const TABLE: &str = "logs";
+
+fn string_field(id: i32, name: &str) -> StructField {
+    StructField {
+        id,
+        name: name.to_string(),
+        required: false,
+        field_type: Type::Primitive(PrimitiveType::String),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    }
+}
+
+/// A logs-shaped table that already carries a materialized `label_env`
+/// column (id 8, after the map's nested key/value ids 6 and 7), as a
+/// previous auto-promotion would have left it.
+fn table_schema() -> IcebergSchema {
+    let timestamp = StructField {
+        id: 1,
+        name: "timestamp".to_string(),
+        required: true,
+        field_type: Type::Primitive(PrimitiveType::Timestamp),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    };
+    let attributes = StructField {
+        id: 5,
+        name: "log_attributes".to_string(),
+        required: false,
+        field_type: Type::Map(MapType {
+            key_id: 6,
+            key: Box::new(Type::Primitive(PrimitiveType::String)),
+            value_id: 7,
+            value_required: false,
+            value: Box::new(Type::Primitive(PrimitiveType::String)),
+        }),
+        doc: None,
+        initial_default: None,
+        write_default: None,
+    };
+    IcebergSchema::from_struct_type(
+        StructType::new(vec![
+            timestamp,
+            string_field(2, "service_name"),
+            string_field(3, "severity_text"),
+            string_field(4, "body"),
+            attributes,
+            string_field(8, "label_env"),
+        ]),
+        0,
+        None,
+    )
+}
+
+async fn load_table(catalog_manager: &CatalogManager, identifier: &Identifier) -> Result<Table> {
+    match catalog_manager.catalog().load_tabular(identifier).await? {
+        Tabular::Table(table) => Ok(table),
+        _ => anyhow::bail!("expected a table"),
+    }
+}
+
+/// One test row: (timestamp, service, body, attributes, label_env value).
+type TestRow<'a> = (
+    i64,
+    &'a str,
+    &'a str,
+    &'a [(&'a str, &'a str)],
+    Option<&'a str>,
+);
+
+/// Write one data file with the given rows.
+async fn write_file(
+    catalog_manager: &CatalogManager,
+    identifier: &Identifier,
+    rows: &[TestRow<'_>],
+) -> Result<()> {
+    let mut table = load_table(catalog_manager, identifier).await?;
+
+    // Derive the Arrow schema from the table so the map entry/key/value
+    // field names line up with what the table declares.
+    let arrow_schema: SchemaRef = Arc::new(
+        table
+            .current_schema()?
+            .fields()
+            .try_into()
+            .map_err(|e: iceberg_rust::spec::error::Error| anyhow::anyhow!("to arrow: {e}"))?,
+    );
+    let attr_field = arrow_schema.field_with_name("log_attributes")?;
+    let DataType::Map(entry_field, _) = attr_field.data_type() else {
+        anyhow::bail!("log_attributes should convert to an Arrow Map");
+    };
+    let DataType::Struct(kv_fields) = entry_field.data_type() else {
+        anyhow::bail!("map entries should be a struct");
+    };
+    let field_names = MapFieldNames {
+        entry: entry_field.name().clone(),
+        key: kv_fields[0].name().clone(),
+        value: kv_fields[1].name().clone(),
+    };
+
+    let mut attrs = MapBuilder::new(
+        Some(field_names),
+        StringBuilder::new(),
+        StringBuilder::new(),
+    );
+    let mut timestamps = Vec::new();
+    let mut services = Vec::new();
+    let mut severities = Vec::new();
+    let mut bodies = Vec::new();
+    let mut labels = Vec::new();
+    for (ts, service, body, kvs, label_env) in rows {
+        timestamps.push(*ts);
+        services.push(Some(*service));
+        severities.push(Some("INFO"));
+        bodies.push(Some(*body));
+        labels.push(*label_env);
+        for (k, v) in *kvs {
+            attrs.keys().append_value(k);
+            attrs.values().append_value(v);
+        }
+        attrs.append(true)?;
+    }
+    let attrs = attrs.finish();
+    let ts = TimestampMicrosecondArray::from(timestamps);
+
+    let batch_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+        Field::new("service_name", DataType::Utf8, true),
+        Field::new("severity_text", DataType::Utf8, true),
+        Field::new("body", DataType::Utf8, true),
+        Field::new("log_attributes", attrs.data_type().clone(), true),
+        Field::new("label_env", DataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        batch_schema,
+        vec![
+            Arc::new(ts),
+            Arc::new(StringArray::from(services)),
+            Arc::new(StringArray::from(severities)),
+            Arc::new(StringArray::from(bodies)),
+            Arc::new(attrs),
+            Arc::new(StringArray::from(labels)),
+        ],
+    )?;
+
+    let files = write_parquet_partitioned(&table, stream::iter(vec![Ok(batch)]), None).await?;
+    table
+        .new_transaction(None)
+        .append_data(files)
+        .commit()
+        .await?;
+    Ok(())
+}
+
+/// Build the environment: an in-memory catalog with the promotion pass
+/// configured, a logs table that already carries `label_env`, two small
+/// files whose rows have `env`/`pod` attributes plus materialized
+/// `label_env` values — and NO query demand recorded for anything, so
+/// `env` is a demotion candidate. `pinned` puts `env` on the logs
+/// `[schema.materialized_labels]` allowlist.
+async fn setup(
+    dry_run: bool,
+    pinned: bool,
+) -> Result<(
+    Arc<CatalogManager>,
+    Arc<common::catalog::Catalog>,
+    Identifier,
+)> {
+    let mut config = common::testing::TestConfigBuilder::new()
+        .in_memory()
+        .with_tenant(TENANT, DATASET)
+        .build();
+    config.compactor.attr_promotion = common::config::AttrPromotionConfig {
+        enabled: true,
+        dry_run,
+        max_labels_per_table: 8,
+        min_presence: 0.01,
+        min_query_hits: 1,
+        promote_streak: 1,
+        max_promotions_per_cycle: 4,
+    };
+    if pinned {
+        config.schema.materialized_labels.logs = vec!["env".to_string()];
+    }
+    let catalog_manager = Arc::new(CatalogManager::new(config).await?);
+
+    let namespace = catalog_manager.build_namespace(TENANT, DATASET)?;
+    catalog_manager
+        .catalog()
+        .create_namespace(&namespace, None)
+        .await?;
+    let identifier = catalog_manager.build_table_identifier(TENANT, DATASET, TABLE);
+    let create = CreateTableBuilder::default()
+        .with_name(TABLE.to_string())
+        .with_schema(table_schema())
+        .with_partition_spec(PartitionSpec::default())
+        .with_location(catalog_manager.build_table_location(TENANT, DATASET, TABLE))
+        .create()
+        .map_err(|e| anyhow::anyhow!("create table build: {e}"))?;
+    catalog_manager
+        .catalog()
+        .create_table(identifier.clone(), create)
+        .await?;
+
+    // Two files -> the executor has something to compact. Every row
+    // carries at least one attribute (see the promotion test for the
+    // empty-map read-back quirk). `env` appears in 3 of 4 rows and its
+    // label column is populated.
+    write_file(
+        &catalog_manager,
+        &identifier,
+        &[
+            (
+                1_000_000,
+                "api",
+                "hello prod",
+                &[("env", "prod"), ("pod", "api-1")],
+                Some("prod"),
+            ),
+            (
+                2_000_000,
+                "api",
+                "hello staging",
+                &[("env", "staging")],
+                Some("staging"),
+            ),
+        ],
+    )
+    .await?;
+    write_file(
+        &catalog_manager,
+        &identifier,
+        &[
+            (3_000_000, "web", "no env here", &[("pod", "web-1")], None),
+            (
+                4_000_000,
+                "web",
+                "hello prod again",
+                &[("env", "prod")],
+                Some("prod"),
+            ),
+        ],
+    )
+    .await?;
+
+    // No query demand for any key: the scan-side stats persisted during
+    // the compaction give `env` query_hits = 0, making the materialized
+    // column a demotion candidate.
+    let service_catalog = Arc::new(common::catalog::Catalog::new_in_memory().await?);
+
+    Ok((catalog_manager, service_catalog, identifier))
+}
+
+async fn run_compaction(
+    catalog_manager: Arc<CatalogManager>,
+    service_catalog: Arc<common::catalog::Catalog>,
+) -> Result<()> {
+    let executor = CompactionExecutor::new(
+        catalog_manager,
+        ExecutorConfig::default(),
+        CompactionMetrics::new(),
+    )
+    .with_service_catalog(service_catalog);
+    let candidate = CompactionCandidate {
+        tenant_id: TENANT.to_string(),
+        dataset_id: DATASET.to_string(),
+        table_name: TABLE.to_string(),
+        partition_id: "all".to_string(),
+        stats: PartitionStats {
+            file_count: 2,
+            total_size_bytes: 4096,
+            avg_file_size_bytes: 2048,
+        },
+    };
+    let result = executor.execute_candidate(candidate).await?;
+    anyhow::ensure!(
+        result.status == CompactionStatus::Success,
+        "compaction must succeed: {:?}",
+        result.error
+    );
+    Ok(())
+}
+
+async fn count_rows(ctx: &SessionContext, sql: &str) -> Result<usize> {
+    let rows = ctx.sql(sql).await?.collect().await?;
+    Ok(rows.iter().map(|b| b.num_rows()).sum())
+}
+
+fn register(table: Table, ctx: &SessionContext) -> Result<()> {
+    let provider = Arc::new(datafusion_iceberg::DataFusionTable::new(
+        Tabular::Table(table),
+        None,
+        None,
+        None,
+    )) as Arc<dyn datafusion::datasource::TableProvider>;
+    ctx.register_table("logs", provider)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn active_demotion_drops_unqueried_column_and_keeps_data_queryable() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let (catalog_manager, service_catalog, identifier) = setup(false, false).await?;
+
+    run_compaction(catalog_manager.clone(), service_catalog).await?;
+
+    // Schema pruned: `label_env` is gone, the base columns survive.
+    let table = load_table(&catalog_manager, &identifier).await?;
+    let schema = table.current_schema()?;
+    assert!(
+        !schema.fields().iter().any(|f| f.name == "label_env"),
+        "unqueried materialized column must be demoted"
+    );
+    assert!(
+        schema.fields().iter().any(|f| f.name == "log_attributes"),
+        "attributes map must survive the demotion"
+    );
+    assert_eq!(table.metadata().current_schema_id, 1);
+    assert_eq!(table.metadata().schemas.len(), 2);
+
+    // The rewritten files no longer carry the column, and the data is
+    // still fully queryable through the attributes map — demotion loses
+    // nothing.
+    let ctx = SessionContext::new();
+    register(table, &ctx)?;
+    assert_eq!(count_rows(&ctx, "SELECT body FROM logs").await?, 4);
+    assert_eq!(
+        count_rows(
+            &ctx,
+            "SELECT body FROM logs WHERE log_attributes['env'] = 'prod'"
+        )
+        .await?,
+        2,
+        "attribute values must stay queryable via the map after demotion"
+    );
+    assert_eq!(
+        count_rows(
+            &ctx,
+            "SELECT body FROM logs WHERE log_attributes['env'] = 'staging'"
+        )
+        .await?,
+        1
+    );
+    assert!(
+        ctx.sql("SELECT label_env FROM logs").await.is_err(),
+        "the demoted column must not be projectable any more"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pinned_label_is_never_demoted_even_with_zero_demand() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let (catalog_manager, service_catalog, identifier) = setup(false, true).await?;
+
+    run_compaction(catalog_manager.clone(), service_catalog).await?;
+
+    // `env` is pinned via [schema.materialized_labels]: no demotion, no
+    // schema churn.
+    let table = load_table(&catalog_manager, &identifier).await?;
+    let schema = table.current_schema()?;
+    assert!(
+        schema.fields().iter().any(|f| f.name == "label_env"),
+        "pinned label must never be demoted"
+    );
+    assert_eq!(table.metadata().schemas.len(), 1, "no schema was committed");
+
+    // Still queryable through the materialized column.
+    let ctx = SessionContext::new();
+    register(table, &ctx)?;
+    assert_eq!(count_rows(&ctx, "SELECT body FROM logs").await?, 4);
+    assert_eq!(
+        count_rows(&ctx, "SELECT body FROM logs WHERE label_env = 'prod'").await?,
+        2
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn dry_run_demotion_changes_nothing() -> Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let (catalog_manager, service_catalog, identifier) = setup(true, false).await?;
+
+    run_compaction(catalog_manager.clone(), service_catalog).await?;
+
+    // Schema untouched: the column survives and no schema was committed.
+    let table = load_table(&catalog_manager, &identifier).await?;
+    let schema = table.current_schema()?;
+    assert!(
+        schema.fields().iter().any(|f| f.name == "label_env"),
+        "dry run must not demote"
+    );
+    assert_eq!(table.metadata().schemas.len(), 1);
+
+    // Compaction itself still worked and preserved the data, column
+    // included.
+    let ctx = SessionContext::new();
+    register(table, &ctx)?;
+    assert_eq!(count_rows(&ctx, "SELECT body FROM logs").await?, 4);
+    assert_eq!(
+        count_rows(&ctx, "SELECT body FROM logs WHERE label_env = 'prod'").await?,
+        2
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Part 3 of #734, stacked on #784. Completes the promote/demote symmetry.

- `common::iceberg::evolution::remove_label_columns`: next schema minus the named `label_<key>` columns, `AddSchema` (with `last_column_id` preserved so field ids never regress) + `SetCurrentSchema`, reload-verified, idempotent.
- **Hardening found via TDD:** `add_label_columns` would have reused a dropped column's field id after a remove→re-add cycle (Iceberg forbids id reuse; it mis-maps old files). It now allocates past `max(max_field_id, last_column_id)` — regression test `readd_after_remove_assigns_a_fresh_field_id`.
- Rewriter: demote half runs after the promote half (each an independent metadata commit, then the single file-replace commit); demoted columns are projected out of the merged batches (`RecordBatch::project`), since the read happens under the pre-demotion schema.
- Pinned `[schema.materialized_labels]` entries are never demoted; `dry_run=true` remains log-only. Attribute data stays in the map tier — nothing is lost, the querier falls back automatically.

**Documented limitation:** demand counters are cumulative, so a once-queried key is never demoted until a demand-decay window lands at the stats layer (follow-up, noted in ops docs).

Tests: evolution 9 (4 new), compactor 115, `attr_demotion_rewrite` 3 new (drop + still-queryable-via-map, pinned survives, dry-run no-op), `attr_promotion_rewrite` 2 unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compaction now removes unpinned, unused materialized label columns during rewrite.
  - Removed columns are excluded from rewritten data while base attributes remain queryable.
  - Re-adding a previously removed label column receives a fresh field identifier.
  - Pinned materialized labels remain protected from demotion.
  - Dry-run compaction leaves schemas and materialized columns unchanged.

- **Documentation**
  - Updated operator and troubleshooting guides to describe enforced demotion and cumulative demand tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->