### PR TITLE
feat(common): add user, tenant membership, and session catalog tables

### DIFF
--- a/.claude/skills/service-discovery/SKILL.md
+++ b/.claude/skills/service-discovery/SKILL.md
@@ -58,7 +58,8 @@ CREATE TABLE ingesters (
 ```
 
 The same catalog also holds multi-tenancy tables (`tenants`, `api_keys`,
-`datasets`), `compactor_leases`, and the advisory `attribute_stats` table
+`datasets`), user-identity tables (`users`, `tenant_memberships`,
+`user_sessions`; users-tenant-membership ADR), `compactor_leases`, and the advisory `attribute_stats` table
 (epic #737: per-attribute-key presence/cardinality from the compactor's
 analyzer plus query-demand counters flushed by the querier, and a promote_streak hysteresis column for the auto-promotion decision pass).
 

--- a/docs/architecture/service-discovery.md
+++ b/docs/architecture/service-discovery.md
@@ -62,7 +62,9 @@ CREATE TABLE shard_owners (
 ```
 
 The same catalog database also holds the multi-tenancy tables (`tenants`,
-`api_keys`, `datasets`), the `compactor_leases` table, and the advisory
+`api_keys`, `datasets`), the user-identity tables (`users`,
+`tenant_memberships`, `user_sessions` — see the users-tenant-membership
+ADR), the `compactor_leases` table, and the advisory
 `attribute_stats` table (per-attribute-key presence and cardinality written
 by the compactor's analyzer, plus query-demand hit counters flushed
 periodically by the querier, and a `promote_streak` hysteresis column for

--- a/src/common/src/catalog.rs
+++ b/src/common/src/catalog.rs
@@ -13,6 +13,13 @@ fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, sqlx::Error> {
         .map_err(|e| sqlx::Error::Decode(Box::new(e)))
 }
 
+/// Canonicalize an email address for identity comparison: trim whitespace
+/// and lowercase, so the `users.email` UNIQUE constraint applies to the
+/// canonical form identically on SQLite and PostgreSQL.
+fn canonicalize_email(email: &str) -> String {
+    email.trim().to_lowercase()
+}
+
 /// Catalog provides an interface to the catalog database (PostgreSQL or SQLite).
 #[derive(Clone)]
 pub enum Catalog {
@@ -159,6 +166,61 @@ impl Catalog {
                     .execute(pool)
                     .await?;
 
+                // User accounts, tenant memberships, and login sessions
+                let create_users = r#"
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT NOT NULL UNIQUE,
+                    display_name TEXT,
+                    password_hash TEXT NOT NULL,
+                    is_instance_admin INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    disabled_at TEXT
+                )"#;
+                query(create_users).execute(pool).await?;
+
+                let create_tenant_memberships = r#"
+                CREATE TABLE IF NOT EXISTS tenant_memberships (
+                    user_id TEXT NOT NULL,
+                    tenant_id TEXT NOT NULL,
+                    role TEXT NOT NULL CHECK(role IN ('admin', 'member', 'viewer')),
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (user_id, tenant_id),
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
+                )"#;
+                query(create_tenant_memberships).execute(pool).await?;
+
+                let create_user_sessions = r#"
+                CREATE TABLE IF NOT EXISTS user_sessions (
+                    id TEXT PRIMARY KEY,
+                    token_hash TEXT NOT NULL UNIQUE,
+                    user_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    expires_at TEXT NOT NULL,
+                    revoked_at TEXT,
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )"#;
+                query(create_user_sessions).execute(pool).await?;
+
+                // Indexes for user/membership/session tables
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_tenant_memberships_tenant ON tenant_memberships(tenant_id)",
+                )
+                .execute(pool)
+                .await?;
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_user_sessions_user ON user_sessions(user_id)",
+                )
+                .execute(pool)
+                .await?;
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_user_sessions_hash ON user_sessions(token_hash) WHERE revoked_at IS NULL",
+                )
+                .execute(pool)
+                .await?;
+
                 // Compactor lease table — prevents duplicate work when multiple compactor
                 // instances run simultaneously. One row per (tenant, dataset, table, partition).
                 let create_compactor_leases = r#"
@@ -279,6 +341,58 @@ impl Catalog {
                 query("CREATE INDEX IF NOT EXISTS idx_datasets_tenant ON datasets(tenant_id)")
                     .execute(pool)
                     .await?;
+
+                // User accounts, tenant memberships, and login sessions
+                let create_users = r#"
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT NOT NULL UNIQUE,
+                    display_name TEXT,
+                    password_hash TEXT NOT NULL,
+                    is_instance_admin BOOLEAN NOT NULL DEFAULT FALSE,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    disabled_at TIMESTAMPTZ
+                )"#;
+                query(create_users).execute(pool).await?;
+
+                let create_tenant_memberships = r#"
+                CREATE TABLE IF NOT EXISTS tenant_memberships (
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+                    role TEXT NOT NULL CHECK(role IN ('admin', 'member', 'viewer')),
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (user_id, tenant_id)
+                )"#;
+                query(create_tenant_memberships).execute(pool).await?;
+
+                let create_user_sessions = r#"
+                CREATE TABLE IF NOT EXISTS user_sessions (
+                    id TEXT PRIMARY KEY,
+                    token_hash TEXT NOT NULL UNIQUE,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    expires_at TIMESTAMPTZ NOT NULL,
+                    revoked_at TIMESTAMPTZ
+                )"#;
+                query(create_user_sessions).execute(pool).await?;
+
+                // Indexes for user/membership/session tables
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_tenant_memberships_tenant ON tenant_memberships(tenant_id)",
+                )
+                .execute(pool)
+                .await?;
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_user_sessions_user ON user_sessions(user_id)",
+                )
+                .execute(pool)
+                .await?;
+                query(
+                    "CREATE INDEX IF NOT EXISTS idx_user_sessions_hash ON user_sessions(token_hash) WHERE revoked_at IS NULL",
+                )
+                .execute(pool)
+                .await?;
 
                 // Compactor lease table — prevents duplicate work when multiple compactor
                 // instances run simultaneously. One row per (tenant, dataset, table, partition).
@@ -896,6 +1010,162 @@ pub struct DatasetRecord {
     pub tenant_id: String,
     pub name: String,
     pub created_at: DateTime<Utc>,
+}
+
+/// Role a user holds within a tenant.
+///
+/// Stored as lowercase TEXT in the `tenant_memberships` table, matching
+/// the `CHECK(role IN ('admin', 'member', 'viewer'))` constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MembershipRole {
+    Admin,
+    Member,
+    Viewer,
+}
+
+impl MembershipRole {
+    /// The lowercase string form stored in the database.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MembershipRole::Admin => "admin",
+            MembershipRole::Member => "member",
+            MembershipRole::Viewer => "viewer",
+        }
+    }
+}
+
+impl std::fmt::Display for MembershipRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for MembershipRole {
+    type Err = sqlx::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "admin" => Ok(MembershipRole::Admin),
+            "member" => Ok(MembershipRole::Member),
+            "viewer" => Ok(MembershipRole::Viewer),
+            other => Err(sqlx::Error::Decode(
+                format!("invalid membership role: {other}").into(),
+            )),
+        }
+    }
+}
+
+/// User account record from database
+#[derive(Debug, Clone)]
+pub struct UserRecord {
+    pub id: String,
+    pub email: String,
+    pub display_name: Option<String>,
+    pub password_hash: String,
+    pub is_instance_admin: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+/// Tenant membership record from database
+#[derive(Debug, Clone)]
+pub struct TenantMembershipRecord {
+    pub user_id: String,
+    pub tenant_id: String,
+    pub role: MembershipRole,
+    pub created_at: DateTime<Utc>,
+}
+
+/// User session record from database (token stored as hash only)
+#[derive(Debug, Clone)]
+pub struct UserSessionRecord {
+    pub id: String,
+    pub token_hash: String,
+    pub user_id: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Map a SQLite row (RFC3339 text timestamps) to a `UserRecord`.
+fn user_from_sqlite_row(r: &sqlx::sqlite::SqliteRow) -> Result<UserRecord, sqlx::Error> {
+    let disabled_at: Option<String> = r.get("disabled_at");
+    Ok(UserRecord {
+        id: r.get("id"),
+        email: r.get("email"),
+        display_name: r.get("display_name"),
+        password_hash: r.get("password_hash"),
+        is_instance_admin: r.get("is_instance_admin"),
+        created_at: parse_rfc3339(r.get("created_at"))?,
+        updated_at: parse_rfc3339(r.get("updated_at"))?,
+        disabled_at: disabled_at.map(|s| parse_rfc3339(&s)).transpose()?,
+    })
+}
+
+/// Map a PostgreSQL row (native TIMESTAMPTZ) to a `UserRecord`.
+fn user_from_pg_row(r: &sqlx::postgres::PgRow) -> UserRecord {
+    UserRecord {
+        id: r.get("id"),
+        email: r.get("email"),
+        display_name: r.get("display_name"),
+        password_hash: r.get("password_hash"),
+        is_instance_admin: r.get("is_instance_admin"),
+        created_at: r.get("created_at"),
+        updated_at: r.get("updated_at"),
+        disabled_at: r.get("disabled_at"),
+    }
+}
+
+/// Map a SQLite row to a `TenantMembershipRecord`.
+fn membership_from_sqlite_row(
+    r: &sqlx::sqlite::SqliteRow,
+) -> Result<TenantMembershipRecord, sqlx::Error> {
+    let role: String = r.get("role");
+    Ok(TenantMembershipRecord {
+        user_id: r.get("user_id"),
+        tenant_id: r.get("tenant_id"),
+        role: role.parse()?,
+        created_at: parse_rfc3339(r.get("created_at"))?,
+    })
+}
+
+/// Map a PostgreSQL row to a `TenantMembershipRecord`.
+fn membership_from_pg_row(
+    r: &sqlx::postgres::PgRow,
+) -> Result<TenantMembershipRecord, sqlx::Error> {
+    let role: String = r.get("role");
+    Ok(TenantMembershipRecord {
+        user_id: r.get("user_id"),
+        tenant_id: r.get("tenant_id"),
+        role: role.parse()?,
+        created_at: r.get("created_at"),
+    })
+}
+
+/// Map a SQLite row to a `UserSessionRecord`.
+fn session_from_sqlite_row(r: &sqlx::sqlite::SqliteRow) -> Result<UserSessionRecord, sqlx::Error> {
+    let revoked_at: Option<String> = r.get("revoked_at");
+    Ok(UserSessionRecord {
+        id: r.get("id"),
+        token_hash: r.get("token_hash"),
+        user_id: r.get("user_id"),
+        created_at: parse_rfc3339(r.get("created_at"))?,
+        expires_at: parse_rfc3339(r.get("expires_at"))?,
+        revoked_at: revoked_at.map(|s| parse_rfc3339(&s)).transpose()?,
+    })
+}
+
+/// Map a PostgreSQL row to a `UserSessionRecord`.
+fn session_from_pg_row(r: &sqlx::postgres::PgRow) -> UserSessionRecord {
+    UserSessionRecord {
+        id: r.get("id"),
+        token_hash: r.get("token_hash"),
+        user_id: r.get("user_id"),
+        created_at: r.get("created_at"),
+        expires_at: r.get("expires_at"),
+        revoked_at: r.get("revoked_at"),
+    }
 }
 
 /// A per-attribute-key statistics row (epic #737, #733): scan-side
@@ -1702,6 +1972,474 @@ impl Catalog {
     }
 }
 
+/// User, tenant-membership, and session catalog methods
+impl Catalog {
+    /// Create a new user account with a random UUID id.
+    ///
+    /// `password_hash` is the already-hashed PHC string; hashing is the
+    /// caller's responsibility. The email is canonicalized (trimmed and
+    /// lowercased) before storage so the UNIQUE constraint applies to the
+    /// canonical form on both backends. Fails if the email is already taken.
+    pub async fn create_user(
+        &self,
+        email: &str,
+        display_name: Option<&str>,
+        password_hash: &str,
+        is_instance_admin: bool,
+    ) -> Result<UserRecord, sqlx::Error> {
+        let user_id = Uuid::new_v4().to_string();
+        let email = canonicalize_email(email);
+        let now = Utc::now();
+
+        match self {
+            Catalog::Sqlite(pool) => {
+                let now_str = now.to_rfc3339();
+                let stmt = r#"
+                INSERT INTO users (id, email, display_name, password_hash, is_instance_admin, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                "#;
+                query(stmt)
+                    .bind(&user_id)
+                    .bind(&email)
+                    .bind(display_name)
+                    .bind(password_hash)
+                    .bind(is_instance_admin)
+                    .bind(&now_str)
+                    .bind(&now_str)
+                    .execute(pool)
+                    .await?;
+            }
+            Catalog::Postgres(pool) => {
+                let stmt = r#"
+                INSERT INTO users (id, email, display_name, password_hash, is_instance_admin, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                "#;
+                query(stmt)
+                    .bind(&user_id)
+                    .bind(&email)
+                    .bind(display_name)
+                    .bind(password_hash)
+                    .bind(is_instance_admin)
+                    .bind(now)
+                    .bind(now)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+
+        Ok(UserRecord {
+            id: user_id,
+            email,
+            display_name: display_name.map(str::to_string),
+            password_hash: password_hash.to_string(),
+            is_instance_admin,
+            created_at: now,
+            updated_at: now,
+            disabled_at: None,
+        })
+    }
+
+    /// Get a user by ID
+    pub async fn get_user(&self, user_id: &str) -> Result<Option<UserRecord>, sqlx::Error> {
+        let columns = "id, email, display_name, password_hash, is_instance_admin, created_at, updated_at, disabled_at";
+        match self {
+            Catalog::Sqlite(pool) => {
+                let row = query(&format!("SELECT {columns} FROM users WHERE id = ?"))
+                    .bind(user_id)
+                    .fetch_optional(pool)
+                    .await?;
+                row.map(|r| user_from_sqlite_row(&r)).transpose()
+            }
+            Catalog::Postgres(pool) => {
+                let row = query(&format!("SELECT {columns} FROM users WHERE id = $1"))
+                    .bind(user_id)
+                    .fetch_optional(pool)
+                    .await?;
+                Ok(row.map(|r| user_from_pg_row(&r)))
+            }
+        }
+    }
+
+    /// Get a user by email.
+    ///
+    /// The lookup email is canonicalized (trimmed and lowercased) to match
+    /// the form stored by [`Catalog::create_user`].
+    pub async fn get_user_by_email(&self, email: &str) -> Result<Option<UserRecord>, sqlx::Error> {
+        let email = canonicalize_email(email);
+        let columns = "id, email, display_name, password_hash, is_instance_admin, created_at, updated_at, disabled_at";
+        match self {
+            Catalog::Sqlite(pool) => {
+                let row = query(&format!("SELECT {columns} FROM users WHERE email = ?"))
+                    .bind(&email)
+                    .fetch_optional(pool)
+                    .await?;
+                row.map(|r| user_from_sqlite_row(&r)).transpose()
+            }
+            Catalog::Postgres(pool) => {
+                let row = query(&format!("SELECT {columns} FROM users WHERE email = $1"))
+                    .bind(&email)
+                    .fetch_optional(pool)
+                    .await?;
+                Ok(row.map(|r| user_from_pg_row(&r)))
+            }
+        }
+    }
+
+    /// List all users, ordered by email
+    pub async fn list_users(&self) -> Result<Vec<UserRecord>, sqlx::Error> {
+        let columns = "id, email, display_name, password_hash, is_instance_admin, created_at, updated_at, disabled_at";
+        match self {
+            Catalog::Sqlite(pool) => {
+                let rows = query(&format!("SELECT {columns} FROM users ORDER BY email"))
+                    .fetch_all(pool)
+                    .await?;
+                rows.iter().map(user_from_sqlite_row).collect()
+            }
+            Catalog::Postgres(pool) => {
+                let rows = query(&format!("SELECT {columns} FROM users ORDER BY email"))
+                    .fetch_all(pool)
+                    .await?;
+                Ok(rows.iter().map(user_from_pg_row).collect())
+            }
+        }
+    }
+
+    /// Disable or re-enable a user account.
+    ///
+    /// Sets `disabled_at` to now when `disabled` is true, clears it when
+    /// false, and bumps `updated_at` either way. Returns
+    /// `sqlx::Error::RowNotFound` if the user does not exist.
+    pub async fn set_user_disabled(
+        &self,
+        user_id: &str,
+        disabled: bool,
+    ) -> Result<(), sqlx::Error> {
+        let now = Utc::now();
+        let rows_affected = match self {
+            Catalog::Sqlite(pool) => {
+                let disabled_at = disabled.then(|| now.to_rfc3339());
+                query("UPDATE users SET disabled_at = ?, updated_at = ? WHERE id = ?")
+                    .bind(disabled_at)
+                    .bind(now.to_rfc3339())
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?
+                    .rows_affected()
+            }
+            Catalog::Postgres(pool) => {
+                let disabled_at = disabled.then_some(now);
+                query("UPDATE users SET disabled_at = $1, updated_at = $2 WHERE id = $3")
+                    .bind(disabled_at)
+                    .bind(now)
+                    .bind(user_id)
+                    .execute(pool)
+                    .await?
+                    .rows_affected()
+            }
+        };
+        if rows_affected == 0 {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(())
+    }
+
+    /// Add a user to a tenant, or update their role if already a member
+    pub async fn upsert_tenant_membership(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+        role: MembershipRole,
+    ) -> Result<(), sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let now = Utc::now().to_rfc3339();
+                let stmt = r#"
+                INSERT INTO tenant_memberships (user_id, tenant_id, role, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (user_id, tenant_id) DO UPDATE SET role = excluded.role
+                "#;
+                query(stmt)
+                    .bind(user_id)
+                    .bind(tenant_id)
+                    .bind(role.as_str())
+                    .bind(&now)
+                    .execute(pool)
+                    .await?;
+            }
+            Catalog::Postgres(pool) => {
+                let stmt = r#"
+                INSERT INTO tenant_memberships (user_id, tenant_id, role)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (user_id, tenant_id) DO UPDATE SET role = EXCLUDED.role
+                "#;
+                query(stmt)
+                    .bind(user_id)
+                    .bind(tenant_id)
+                    .bind(role.as_str())
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Remove a user from a tenant (idempotent)
+    pub async fn remove_tenant_membership(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<(), sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                query("DELETE FROM tenant_memberships WHERE user_id = ? AND tenant_id = ?")
+                    .bind(user_id)
+                    .bind(tenant_id)
+                    .execute(pool)
+                    .await?;
+            }
+            Catalog::Postgres(pool) => {
+                query("DELETE FROM tenant_memberships WHERE user_id = $1 AND tenant_id = $2")
+                    .bind(user_id)
+                    .bind(tenant_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get a single membership for a (user, tenant) pair
+    pub async fn get_tenant_membership(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<Option<TenantMembershipRecord>, sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let row = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE user_id = ? AND tenant_id = ?",
+                )
+                .bind(user_id)
+                .bind(tenant_id)
+                .fetch_optional(pool)
+                .await?;
+                row.map(|r| membership_from_sqlite_row(&r)).transpose()
+            }
+            Catalog::Postgres(pool) => {
+                let row = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE user_id = $1 AND tenant_id = $2",
+                )
+                .bind(user_id)
+                .bind(tenant_id)
+                .fetch_optional(pool)
+                .await?;
+                row.map(|r| membership_from_pg_row(&r)).transpose()
+            }
+        }
+    }
+
+    /// List all tenant memberships for a user
+    pub async fn list_memberships_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<TenantMembershipRecord>, sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let rows = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE user_id = ? ORDER BY tenant_id",
+                )
+                .bind(user_id)
+                .fetch_all(pool)
+                .await?;
+                rows.iter().map(membership_from_sqlite_row).collect()
+            }
+            Catalog::Postgres(pool) => {
+                let rows = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE user_id = $1 ORDER BY tenant_id",
+                )
+                .bind(user_id)
+                .fetch_all(pool)
+                .await?;
+                rows.iter().map(membership_from_pg_row).collect()
+            }
+        }
+    }
+
+    /// List all user memberships for a tenant
+    pub async fn list_members_for_tenant(
+        &self,
+        tenant_id: &str,
+    ) -> Result<Vec<TenantMembershipRecord>, sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let rows = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE tenant_id = ? ORDER BY user_id",
+                )
+                .bind(tenant_id)
+                .fetch_all(pool)
+                .await?;
+                rows.iter().map(membership_from_sqlite_row).collect()
+            }
+            Catalog::Postgres(pool) => {
+                let rows = query(
+                    "SELECT user_id, tenant_id, role, created_at FROM tenant_memberships WHERE tenant_id = $1 ORDER BY user_id",
+                )
+                .bind(tenant_id)
+                .fetch_all(pool)
+                .await?;
+                rows.iter().map(membership_from_pg_row).collect()
+            }
+        }
+    }
+
+    /// Create a login session for a user with a random UUID id.
+    ///
+    /// `token_hash` is the hash of the session token; the plaintext token
+    /// is never stored.
+    pub async fn create_user_session(
+        &self,
+        user_id: &str,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<UserSessionRecord, sqlx::Error> {
+        let session_id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        match self {
+            Catalog::Sqlite(pool) => {
+                let stmt = r#"
+                INSERT INTO user_sessions (id, token_hash, user_id, created_at, expires_at)
+                VALUES (?, ?, ?, ?, ?)
+                "#;
+                query(stmt)
+                    .bind(&session_id)
+                    .bind(token_hash)
+                    .bind(user_id)
+                    .bind(now.to_rfc3339())
+                    .bind(expires_at.to_rfc3339())
+                    .execute(pool)
+                    .await?;
+            }
+            Catalog::Postgres(pool) => {
+                let stmt = r#"
+                INSERT INTO user_sessions (id, token_hash, user_id, created_at, expires_at)
+                VALUES ($1, $2, $3, $4, $5)
+                "#;
+                query(stmt)
+                    .bind(&session_id)
+                    .bind(token_hash)
+                    .bind(user_id)
+                    .bind(now)
+                    .bind(expires_at)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+
+        Ok(UserSessionRecord {
+            id: session_id,
+            token_hash: token_hash.to_string(),
+            user_id: user_id.to_string(),
+            created_at: now,
+            expires_at,
+            revoked_at: None,
+        })
+    }
+
+    /// Look up a session by token hash, returning it only if it is neither
+    /// revoked nor expired, and its user account is not disabled.
+    pub async fn get_valid_session(
+        &self,
+        token_hash: &str,
+    ) -> Result<Option<UserSessionRecord>, sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                // expires_at is stored as chrono RFC3339 text (UTC, +00:00
+                // offset), so lexicographic comparison against another
+                // RFC3339 UTC timestamp is chronologically correct. The
+                // join on users cuts off sessions of disabled accounts
+                // immediately.
+                let row = query(
+                    r#"
+                    SELECT s.id, s.token_hash, s.user_id, s.created_at, s.expires_at, s.revoked_at
+                    FROM user_sessions s
+                    JOIN users u ON u.id = s.user_id
+                    WHERE s.token_hash = ?
+                      AND s.revoked_at IS NULL
+                      AND s.expires_at > ?
+                      AND u.disabled_at IS NULL
+                    "#,
+                )
+                .bind(token_hash)
+                .bind(Utc::now().to_rfc3339())
+                .fetch_optional(pool)
+                .await?;
+                row.map(|r| session_from_sqlite_row(&r)).transpose()
+            }
+            Catalog::Postgres(pool) => {
+                let row = query(
+                    r#"
+                    SELECT s.id, s.token_hash, s.user_id, s.created_at, s.expires_at, s.revoked_at
+                    FROM user_sessions s
+                    JOIN users u ON u.id = s.user_id
+                    WHERE s.token_hash = $1
+                      AND s.revoked_at IS NULL
+                      AND s.expires_at > NOW()
+                      AND u.disabled_at IS NULL
+                    "#,
+                )
+                .bind(token_hash)
+                .fetch_optional(pool)
+                .await?;
+                Ok(row.map(|r| session_from_pg_row(&r)))
+            }
+        }
+    }
+
+    /// Revoke a session by ID
+    pub async fn revoke_session(&self, session_id: &str) -> Result<(), sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let now = Utc::now().to_rfc3339();
+                query("UPDATE user_sessions SET revoked_at = ? WHERE id = ?")
+                    .bind(&now)
+                    .bind(session_id)
+                    .execute(pool)
+                    .await?;
+            }
+            Catalog::Postgres(pool) => {
+                query("UPDATE user_sessions SET revoked_at = NOW() WHERE id = $1")
+                    .bind(session_id)
+                    .execute(pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete all sessions whose expiry has passed.
+    ///
+    /// Returns the number of rows removed. Safe to run concurrently — the
+    /// DELETE is idempotent.
+    pub async fn delete_expired_sessions(&self) -> Result<u64, sqlx::Error> {
+        match self {
+            Catalog::Sqlite(pool) => {
+                let result = query("DELETE FROM user_sessions WHERE expires_at < ?")
+                    .bind(Utc::now().to_rfc3339())
+                    .execute(pool)
+                    .await?;
+                Ok(result.rows_affected())
+            }
+            Catalog::Postgres(pool) => {
+                let result = query("DELETE FROM user_sessions WHERE expires_at < NOW()")
+                    .execute(pool)
+                    .await?;
+                Ok(result.rows_affected())
+            }
+        }
+    }
+}
+
 // ── Compactor lease management ────────────────────────────────────────────────
 
 /// A lease record from the `compactor_leases` table.
@@ -2320,5 +3058,447 @@ mod multi_tenancy_tests {
 
         let datasets = catalog.get_datasets("nonexistent").await.unwrap();
         assert!(datasets.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod user_membership_tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn membership_role_round_trips_through_lowercase_strings() {
+        for (role, s) in [
+            (MembershipRole::Admin, "admin"),
+            (MembershipRole::Member, "member"),
+            (MembershipRole::Viewer, "viewer"),
+        ] {
+            assert_eq!(role.to_string(), s);
+            assert_eq!(s.parse::<MembershipRole>().unwrap(), role);
+        }
+        assert!("Owner".parse::<MembershipRole>().is_err());
+    }
+
+    #[tokio::test]
+    async fn create_user_returns_record_retrievable_by_id_and_email() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        let created = catalog
+            .create_user("alice@example.com", Some("Alice"), "phc-hash-1", true)
+            .await
+            .unwrap();
+        assert_eq!(created.email, "alice@example.com");
+        assert_eq!(created.display_name, Some("Alice".to_string()));
+        assert_eq!(created.password_hash, "phc-hash-1");
+        assert!(created.is_instance_admin);
+        assert!(created.disabled_at.is_none());
+
+        let by_id = catalog.get_user(&created.id).await.unwrap().unwrap();
+        assert_eq!(by_id.id, created.id);
+        assert_eq!(by_id.email, "alice@example.com");
+        assert!(by_id.is_instance_admin);
+
+        let by_email = catalog
+            .get_user_by_email("alice@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_email.id, created.id);
+    }
+
+    #[tokio::test]
+    async fn get_user_returns_none_for_unknown_id_and_email() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        assert!(catalog.get_user("missing").await.unwrap().is_none());
+        assert!(
+            catalog
+                .get_user_by_email("nobody@example.com")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn create_user_with_duplicate_email_returns_error() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        catalog
+            .create_user("dup@example.com", None, "hash-a", false)
+            .await
+            .unwrap();
+        let result = catalog
+            .create_user("dup@example.com", None, "hash-b", false)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn user_email_identity_is_case_insensitive() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        let created = catalog
+            .create_user("Alice@Example.com", None, "hash-a", false)
+            .await
+            .unwrap();
+        // Stored in canonical (lowercase) form
+        assert_eq!(created.email, "alice@example.com");
+
+        // Same address in different case hits the UNIQUE constraint
+        let duplicate = catalog
+            .create_user("alice@example.com", None, "hash-b", false)
+            .await;
+        assert!(duplicate.is_err());
+
+        // Lookup canonicalizes too
+        let found = catalog
+            .get_user_by_email("ALICE@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, created.id);
+    }
+
+    #[tokio::test]
+    async fn list_users_returns_all_created_users() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        catalog
+            .create_user("b@example.com", None, "hash-b", false)
+            .await
+            .unwrap();
+        catalog
+            .create_user("a@example.com", None, "hash-a", false)
+            .await
+            .unwrap();
+
+        let users = catalog.list_users().await.unwrap();
+        assert_eq!(users.len(), 2);
+        // Ordered by email
+        assert_eq!(users[0].email, "a@example.com");
+        assert_eq!(users[1].email, "b@example.com");
+    }
+
+    #[tokio::test]
+    async fn set_user_disabled_sets_and_clears_disabled_at() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        let user = catalog
+            .create_user("flip@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        catalog.set_user_disabled(&user.id, true).await.unwrap();
+        let disabled = catalog.get_user(&user.id).await.unwrap().unwrap();
+        assert!(disabled.disabled_at.is_some());
+        assert!(disabled.updated_at >= user.updated_at);
+
+        catalog.set_user_disabled(&user.id, false).await.unwrap();
+        let enabled = catalog.get_user(&user.id).await.unwrap().unwrap();
+        assert!(enabled.disabled_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_user_disabled_returns_row_not_found_for_unknown_user() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+
+        let result = catalog.set_user_disabled("missing", true).await;
+        assert!(matches!(result, Err(sqlx::Error::RowNotFound)));
+    }
+
+    async fn setup_user_and_tenants(catalog: &Catalog) -> String {
+        catalog
+            .upsert_tenant("acme", "Acme Corp", None, "config")
+            .await
+            .unwrap();
+        catalog
+            .upsert_tenant("globex", "Globex", None, "config")
+            .await
+            .unwrap();
+        let user = catalog
+            .create_user("member@example.com", None, "hash", false)
+            .await
+            .unwrap();
+        user.id
+    }
+
+    #[tokio::test]
+    async fn upsert_tenant_membership_inserts_then_updates_role() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user_id = setup_user_and_tenants(&catalog).await;
+
+        catalog
+            .upsert_tenant_membership(&user_id, "acme", MembershipRole::Viewer)
+            .await
+            .unwrap();
+        let membership = catalog
+            .get_tenant_membership(&user_id, "acme")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(membership.role, MembershipRole::Viewer);
+        assert_eq!(membership.user_id, user_id);
+        assert_eq!(membership.tenant_id, "acme");
+
+        // Upserting again changes the role without duplicating the row
+        catalog
+            .upsert_tenant_membership(&user_id, "acme", MembershipRole::Admin)
+            .await
+            .unwrap();
+        let updated = catalog
+            .get_tenant_membership(&user_id, "acme")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.role, MembershipRole::Admin);
+        assert_eq!(
+            catalog.list_members_for_tenant("acme").await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_tenant_membership_deletes_row() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user_id = setup_user_and_tenants(&catalog).await;
+
+        catalog
+            .upsert_tenant_membership(&user_id, "acme", MembershipRole::Member)
+            .await
+            .unwrap();
+        catalog
+            .remove_tenant_membership(&user_id, "acme")
+            .await
+            .unwrap();
+        assert!(
+            catalog
+                .get_tenant_membership(&user_id, "acme")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_lists_work_in_both_directions() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user_id = setup_user_and_tenants(&catalog).await;
+        let other = catalog
+            .create_user("other@example.com", None, "hash2", false)
+            .await
+            .unwrap();
+
+        catalog
+            .upsert_tenant_membership(&user_id, "acme", MembershipRole::Admin)
+            .await
+            .unwrap();
+        catalog
+            .upsert_tenant_membership(&user_id, "globex", MembershipRole::Viewer)
+            .await
+            .unwrap();
+        catalog
+            .upsert_tenant_membership(&other.id, "acme", MembershipRole::Member)
+            .await
+            .unwrap();
+
+        let for_user = catalog.list_memberships_for_user(&user_id).await.unwrap();
+        assert_eq!(for_user.len(), 2);
+        let tenant_ids: Vec<&str> = for_user.iter().map(|m| m.tenant_id.as_str()).collect();
+        assert_eq!(tenant_ids, vec!["acme", "globex"]);
+
+        let for_tenant = catalog.list_members_for_tenant("acme").await.unwrap();
+        assert_eq!(for_tenant.len(), 2);
+        assert!(for_tenant.iter().any(|m| m.user_id == user_id));
+        assert!(for_tenant.iter().any(|m| m.user_id == other.id));
+
+        assert!(
+            catalog
+                .list_memberships_for_user("missing")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_insert_fails_for_nonexistent_tenant() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("orphan@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        // sqlx enables PRAGMA foreign_keys by default for SQLite, so the
+        // FK to tenants(id) is enforced.
+        let result = catalog
+            .upsert_tenant_membership(&user.id, "no-such-tenant", MembershipRole::Member)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_user_session_and_get_valid_session_roundtrip() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("session@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        let expires_at = Utc::now() + Duration::hours(1);
+        let session = catalog
+            .create_user_session(&user.id, "token-hash-1", expires_at)
+            .await
+            .unwrap();
+        assert_eq!(session.user_id, user.id);
+        assert_eq!(session.token_hash, "token-hash-1");
+        assert!(session.revoked_at.is_none());
+
+        let valid = catalog
+            .get_valid_session("token-hash-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(valid.id, session.id);
+        assert_eq!(valid.user_id, user.id);
+
+        assert!(
+            catalog
+                .get_valid_session("unknown-hash")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn revoked_session_is_not_returned_by_get_valid_session() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("revoke@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        let session = catalog
+            .create_user_session(
+                &user.id,
+                "token-hash-revoke",
+                Utc::now() + Duration::hours(1),
+            )
+            .await
+            .unwrap();
+        catalog.revoke_session(&session.id).await.unwrap();
+
+        assert!(
+            catalog
+                .get_valid_session("token-hash-revoke")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_user_sessions_are_not_returned_until_reenabled() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("locked@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        catalog
+            .create_user_session(
+                &user.id,
+                "token-hash-locked",
+                Utc::now() + Duration::hours(1),
+            )
+            .await
+            .unwrap();
+        assert!(
+            catalog
+                .get_valid_session("token-hash-locked")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Disabling the user cuts off the session immediately
+        catalog.set_user_disabled(&user.id, true).await.unwrap();
+        assert!(
+            catalog
+                .get_valid_session("token-hash-locked")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Re-enabling restores access for the still-valid session
+        catalog.set_user_disabled(&user.id, false).await.unwrap();
+        assert!(
+            catalog
+                .get_valid_session("token-hash-locked")
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_session_is_not_returned_by_get_valid_session() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("expired@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        catalog
+            .create_user_session(
+                &user.id,
+                "token-hash-expired",
+                Utc::now() - Duration::hours(1),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            catalog
+                .get_valid_session("token-hash-expired")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_expired_sessions_removes_only_expired_rows() {
+        let catalog = Catalog::new("sqlite::memory:").await.unwrap();
+        let user = catalog
+            .create_user("cleanup@example.com", None, "hash", false)
+            .await
+            .unwrap();
+
+        catalog
+            .create_user_session(&user.id, "hash-old", Utc::now() - Duration::hours(2))
+            .await
+            .unwrap();
+        catalog
+            .create_user_session(&user.id, "hash-current", Utc::now() + Duration::hours(2))
+            .await
+            .unwrap();
+
+        let removed = catalog.delete_expired_sessions().await.unwrap();
+        assert_eq!(removed, 1);
+
+        // The live session survives cleanup
+        assert!(
+            catalog
+                .get_valid_session("hash-current")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Nothing left to remove on a second pass
+        assert_eq!(catalog.delete_expired_sessions().await.unwrap(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Catalog-layer foundation for the users/tenant-membership feature (ADR: `docs/architecture/decisions/users-tenant-membership.md`, #788). Adds three tables to both catalog backends (SQLite + PostgreSQL), following the existing inline-DDL and record/CRUD patterns in `catalog.rs`:

- **`users`** — id, unique email, display name, PHC password hash, `is_instance_admin`, timestamps, `disabled_at`
- **`tenant_memberships`** — (user_id, tenant_id) PK, `role` constrained to `admin|member|viewer`, FK cascade to `users`/`tenants`
- **`user_sessions`** — token hash (unique, partial index on unrevoked rows mirroring `idx_api_keys_hash`), FK cascade, `expires_at`/`revoked_at`

New types: `UserRecord`, `TenantMembershipRecord`, `UserSessionRecord`, `MembershipRole` (Display/FromStr). 14 new `Catalog` methods covering user CRUD, membership upsert/removal/listing (both directions), and session create/validate/revoke/expire-cleanup.

Two behaviors from the ADR review are built in from the start:
- **Case-insensitive email identity**: emails are canonicalized (trim + lowercase) in `create_user` and `get_user_by_email`, so uniqueness applies to the canonical form identically on both backends.
- **Disabled users are cut off immediately**: `get_valid_session` joins `users` and filters `disabled_at IS NULL`, invalidating a disabled user's sessions at the next request without per-session revocation.

Also updates the service-discovery docs' catalog schema section, which enumerates tables sharing the catalog database.

## Testing

- 17 new tests (`sqlite::memory:`): user CRUD, duplicate-email rejection incl. case variants, disable/enable, membership role upsert + both-direction listings, FK enforcement, session validity/revocation/expiry, disabled-user session cutoff and restore
- `cargo test -p common`: 308 lib tests passed + catalog/iceberg/schema integration suites green (4 pre-existing testcontainers tests fail without Docker — identical on `origin/main`)
- `cargo fmt --check` and `cargo clippy -p common --all-targets --all-features -- -D warnings` clean

Companion PR: #789 (password hashing + session token utilities) — disjoint files, no ordering requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WovKW4GC3WipTb4CgJbbNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WovKW4GC3WipTb4CgJbbNV)_