### PR TITLE
fix(release): close coverage gaps — crate tracking, microservices archives, per-service images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
   # happens in the build-musl-* jobs above.
   # Docker build for amd64 (runs on all events)
   docker-build-amd64:
-    name: Build Docker Image (amd64)
+    name: Build Docker Image (${{ matrix.service }}, amd64)
     runs-on: ubuntu-latest
     # test gates the image push: a commit with a red test suite must not
     # be published to ghcr, even though the binaries already built
@@ -420,6 +420,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - uses: actions/checkout@v7
 
@@ -440,11 +444,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The monolithic image keeps the bare repository name; per-service
+      # images live under ghcr.io/<repo>/<service>. Mirrors the release
+      # workflow's naming.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=ref,event=branch,suffix=-amd64
             type=ref,event=pr,suffix=-amd64
@@ -454,7 +470,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          target: monolithic
+          target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
           platforms: linux/amd64
@@ -464,7 +480,7 @@ jobs:
 
   # Docker build for arm64 (only on main branch, not PRs)
   docker-build-arm64:
-    name: Build Docker Image (arm64)
+    name: Build Docker Image (${{ matrix.service }}, arm64)
     runs-on: ubuntu-24.04-arm
     # test gates the image push; see docker-build-amd64
     needs: [build-musl-arm64, test]
@@ -472,6 +488,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - uses: actions/checkout@v7
 
@@ -491,11 +511,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the amd64 job for the image naming scheme.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=ref,event=branch,suffix=-arm64
 
@@ -504,7 +534,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          target: monolithic
+          target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
           platforms: linux/arm64
@@ -514,13 +544,17 @@ jobs:
 
   # Merge architecture-specific images into multi-arch manifest (main only)
   docker-manifest:
-    name: Create Multi-Arch Manifest
+    name: Create Multi-Arch Manifest (${{ matrix.service }})
     runs-on: ubuntu-latest
     needs: [docker-build-amd64, docker-build-arm64]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -529,11 +563,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the docker-build-amd64 job for the image naming scheme.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create and push manifest
         run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository }}:main \
-            ghcr.io/${{ github.repository }}:main-amd64 \
-            ghcr.io/${{ github.repository }}:main-arm64
+          docker buildx imagetools create -t ${{ steps.image.outputs.name }}:main \
+            ${{ steps.image.outputs.name }}:main-amd64 \
+            ${{ steps.image.outputs.name }}:main-arm64
 
   # Lightweight deployment test - only essential combinations
   deployment-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
             cargo build --release -p router --bin signaldb-router
             cargo build --release -p writer --bin signaldb-writer
             cargo build --release -p querier --bin signaldb-querier
+            cargo build --release -p compactor --bin signaldb-compactor
           fi
 
       - name: Test binary execution
@@ -266,6 +267,8 @@ jobs:
             ./target/release/signaldb-writer --version
             ./target/release/signaldb-querier --help
             ./target/release/signaldb-querier --version
+            ./target/release/signaldb-compactor --help
+            ./target/release/signaldb-compactor --version
           fi
 
       - name: Upload binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,37 @@ jobs:
           path: dist/
           retention-days: 7
 
+  # Explore UI dist for the container images, built once per run (with
+  # pnpm caching) instead of once per image build inside docker, where
+  # pnpm has no cache. Gated like the docker jobs that consume it.
+  build-ui:
+    name: Build UI dist
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build UI
+        run: pnpm --filter signaldb-ui build
+
+      - name: Upload UI dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-dist
+          path: src/ui/dist
+          retention-days: 7
+
   # Docker image build - copy-only images from prebuilt musl binaries,
   # split by architecture. No layer caching needed: the expensive compile
   # happens in the build-musl-* jobs above.
@@ -416,7 +447,7 @@ jobs:
     runs-on: ubuntu-latest
     # test gates the image push: a commit with a red test suite must not
     # be published to ghcr, even though the binaries already built
-    needs: [build-musl-amd64, test]
+    needs: [build-musl-amd64, build-ui, test]
     permissions:
       contents: read
       packages: write
@@ -432,6 +463,12 @@ jobs:
         with:
           name: musl-binaries-amd64
           path: dist/
+
+      - name: Download UI dist
+        uses: actions/download-artifact@v8
+        with:
+          name: ui-dist
+          path: ui-dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -473,6 +510,7 @@ jobs:
           target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
+            UI_BUILDER=prebuilt
           platforms: linux/amd64
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -483,7 +521,7 @@ jobs:
     name: Build Docker Image (${{ matrix.service }}, arm64)
     runs-on: ubuntu-24.04-arm
     # test gates the image push; see docker-build-amd64
-    needs: [build-musl-arm64, test]
+    needs: [build-musl-arm64, build-ui, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -500,6 +538,12 @@ jobs:
         with:
           name: musl-binaries-arm64
           path: dist/
+
+      - name: Download UI dist
+        uses: actions/download-artifact@v8
+        with:
+          name: ui-dist
+          path: ui-dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -537,6 +581,7 @@ jobs:
           target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
+            UI_BUILDER=prebuilt
           platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -453,7 +453,10 @@ jobs:
   upload-assets:
     name: Upload Release Assets
     runs-on: ubuntu-latest
-    needs: [release-please, build-release, docker-manifest]
+    # Deliberately not gated on the docker jobs: binary assets and image
+    # publishing are independent, and a transient registry failure must
+    # not block the tarballs from reaching the release.
+    needs: [release-please, build-release]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
 
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -269,10 +269,14 @@ jobs:
           retention-days: 7
 
   docker-build-amd64:
-    name: Build Docker Image (amd64)
+    name: Build Docker Image (${{ matrix.service }}, amd64)
     runs-on: ubuntu-latest
     needs: [release-please, build-musl-amd64]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - uses: actions/checkout@v7
 
@@ -292,11 +296,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The monolithic image keeps the bare repository name; per-service
+      # images live under ghcr.io/<repo>/<service>.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           # latest=false: metadata-action's latest=auto default would add a
           # plain (unsuffixed) latest tag here, letting a single-arch image
           # overwrite it; the manifest job owns the multi-arch latest tag.
@@ -305,12 +320,12 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-amd64
 
-      - name: Build and push monolithic image
+      - name: Build and push image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
-          target: monolithic
+          target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
           platforms: linux/amd64
@@ -319,10 +334,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   docker-build-arm64:
-    name: Build Docker Image (arm64)
+    name: Build Docker Image (${{ matrix.service }}, arm64)
     runs-on: ubuntu-24.04-arm
     needs: [release-please, build-musl-arm64]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - uses: actions/checkout@v7
 
@@ -342,23 +361,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the amd64 job for the image naming scheme.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           # latest=false: see the amd64 job; the manifest job owns latest.
           flavor: |
             latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }},suffix=-arm64
 
-      - name: Build and push monolithic image
+      - name: Build and push image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
-          target: monolithic
+          target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
           platforms: linux/arm64
@@ -367,10 +396,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   docker-manifest:
-    name: Create Multi-Arch Release Manifest
+    name: Create Multi-Arch Release Manifest (${{ matrix.service }})
     runs-on: ubuntu-latest
     needs: [release-please, docker-build-amd64, docker-build-arm64]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monolithic, acceptor, router, writer, querier, compactor]
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -379,11 +412,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # See the docker-build-amd64 job for the image naming scheme.
+      - name: Compute image name
+        id: image
+        run: |
+          if [ "${{ matrix.service }}" = "monolithic" ]; then
+            echo "name=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=ghcr.io/${{ github.repository }}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
@@ -394,8 +437,8 @@ jobs:
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             docker buildx imagetools create -t "$tag" \
-              "ghcr.io/${{ github.repository }}:${version}-amd64" \
-              "ghcr.io/${{ github.repository }}:${version}-arm64"
+              "${{ steps.image.outputs.name }}:${version}-amd64" \
+              "${{ steps.image.outputs.name }}:${version}-arm64"
           done <<< "${{ steps.meta.outputs.tags }}"
 
   upload-assets:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -326,10 +326,57 @@ jobs:
           path: archives/*.tar.gz
           retention-days: 7
 
+  # Explore UI dist, built once per release: the router and monolithic
+  # images copy it in (UI_BUILDER=prebuilt) instead of each compiling it
+  # inside docker, and it ships as a release asset for archive users, who
+  # point SIGNALDB_UI_DIR at the unpacked directory.
+  build-ui:
+    name: Build Explore UI
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build UI
+        run: pnpm --filter signaldb-ui build
+
+      - name: Upload UI dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-dist
+          path: src/ui/dist
+          retention-days: 7
+
+      - name: Package UI archive
+        run: |
+          mkdir -p archives/signaldb-ui
+          cp -R src/ui/dist/. archives/signaldb-ui/
+          tar czf archives/signaldb-ui.tar.gz -C archives signaldb-ui
+
+      - name: Upload UI archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-archive-ui
+          path: archives/*.tar.gz
+          retention-days: 7
+
   docker-build-amd64:
     name: Build Docker Image (${{ matrix.service }}, amd64)
     runs-on: ubuntu-latest
-    needs: [release-please, build-musl-amd64]
+    needs: [release-please, build-musl-amd64, build-ui]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     strategy:
       fail-fast: false
@@ -343,6 +390,12 @@ jobs:
         with:
           name: release-musl-binaries-amd64
           path: dist/
+
+      - name: Download UI dist
+        uses: actions/download-artifact@v8
+        with:
+          name: ui-dist
+          path: ui-dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -386,6 +439,7 @@ jobs:
           target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
+            UI_BUILDER=prebuilt
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -394,7 +448,7 @@ jobs:
   docker-build-arm64:
     name: Build Docker Image (${{ matrix.service }}, arm64)
     runs-on: ubuntu-24.04-arm
-    needs: [release-please, build-musl-arm64]
+    needs: [release-please, build-musl-arm64, build-ui]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     strategy:
       fail-fast: false
@@ -408,6 +462,12 @@ jobs:
         with:
           name: release-musl-binaries-arm64
           path: dist/
+
+      - name: Download UI dist
+        uses: actions/download-artifact@v8
+        with:
+          name: ui-dist
+          path: ui-dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -448,6 +508,7 @@ jobs:
           target: ${{ matrix.service }}
           build-args: |
             BUILDER=prebuilt
+            UI_BUILDER=prebuilt
           platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -505,7 +566,7 @@ jobs:
     # Deliberately not gated on the docker jobs: binary assets and image
     # publishing are independent, and a transient registry failure must
     # not block the tarballs from reaching the release.
-    needs: [release-please, build-release, build-musl-amd64, build-musl-arm64]
+    needs: [release-please, build-release, build-musl-amd64, build-musl-arm64, build-ui]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
 
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,16 @@ jobs:
         run: |
           choco install protoc
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
       - name: Build release binaries
+        # The release-${target} rust-cache is only refreshed on release
+        # runs, so it lags main by a whole release cycle; sccache backfills
+        # the compiler-level cache across that gap.
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         run: |
           cargo build --release --target ${{ matrix.target }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -214,6 +214,31 @@ jobs:
           path: dist/
           retention-days: 7
 
+      # The same static binaries double as Linux release archives; kept out
+      # of dist/ so the docker jobs' COPY doesn't pick up the tarballs.
+      - name: Package release archives
+        run: |
+          target=x86_64-unknown-linux-musl
+          mkdir -p archives/signaldb-monolithic-${target} \
+                   archives/signaldb-microservices-${target} \
+                   archives/signaldb-cli-${target}
+          cp dist/signaldb archives/signaldb-monolithic-${target}/
+          cp dist/signaldb-acceptor dist/signaldb-router dist/signaldb-writer \
+             dist/signaldb-querier dist/signaldb-compactor \
+             archives/signaldb-microservices-${target}/
+          cp dist/signaldb-cli archives/signaldb-cli-${target}/
+          cd archives
+          tar czf signaldb-monolithic-${target}.tar.gz signaldb-monolithic-${target}
+          tar czf signaldb-microservices-${target}.tar.gz signaldb-microservices-${target}
+          tar czf signaldb-cli-${target}.tar.gz signaldb-cli-${target}
+
+      - name: Upload release archives
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-archives-musl-amd64
+          path: archives/*.tar.gz
+          retention-days: 7
+
   build-musl-arm64:
     name: Build musl Binaries (arm64)
     runs-on: ubuntu-24.04-arm
@@ -275,6 +300,30 @@ jobs:
         with:
           name: release-musl-binaries-arm64
           path: dist/
+          retention-days: 7
+
+      # See the amd64 job; these provide the only Linux arm64 archives.
+      - name: Package release archives
+        run: |
+          target=aarch64-unknown-linux-musl
+          mkdir -p archives/signaldb-monolithic-${target} \
+                   archives/signaldb-microservices-${target} \
+                   archives/signaldb-cli-${target}
+          cp dist/signaldb archives/signaldb-monolithic-${target}/
+          cp dist/signaldb-acceptor dist/signaldb-router dist/signaldb-writer \
+             dist/signaldb-querier dist/signaldb-compactor \
+             archives/signaldb-microservices-${target}/
+          cp dist/signaldb-cli archives/signaldb-cli-${target}/
+          cd archives
+          tar czf signaldb-monolithic-${target}.tar.gz signaldb-monolithic-${target}
+          tar czf signaldb-microservices-${target}.tar.gz signaldb-microservices-${target}
+          tar czf signaldb-cli-${target}.tar.gz signaldb-cli-${target}
+
+      - name: Upload release archives
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-archives-musl-arm64
+          path: archives/*.tar.gz
           retention-days: 7
 
   docker-build-amd64:
@@ -456,7 +505,7 @@ jobs:
     # Deliberately not gated on the docker jobs: binary assets and image
     # publishing are independent, and a transient registry failure must
     # not block the tarballs from reaching the release.
-    needs: [release-please, build-release]
+    needs: [release-please, build-release, build-musl-amd64, build-musl-arm64]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
 
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -122,6 +122,8 @@ jobs:
           cp signaldb-acceptor${{ matrix.binary_suffix }} signaldb-microservices-${{ matrix.target }}/
           cp signaldb-router${{ matrix.binary_suffix }} signaldb-microservices-${{ matrix.target }}/
           cp signaldb-writer${{ matrix.binary_suffix }} signaldb-microservices-${{ matrix.target }}/
+          cp signaldb-querier${{ matrix.binary_suffix }} signaldb-microservices-${{ matrix.target }}/
+          cp signaldb-compactor${{ matrix.binary_suffix }} signaldb-microservices-${{ matrix.target }}/
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             7z a signaldb-microservices-${{ matrix.target }}.zip signaldb-microservices-${{ matrix.target }}/
           else

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,5 +11,11 @@
   "src/tempo-api": "0.1.0",
   "src/writer": "0.1.0",
   "src/signaldb-cli": "0.1.1",
-  "tests-integration": "0.1.1"
+  "tests-integration": "0.1.1",
+  "src/logql": "0.1.0",
+  "src/loki-api": "0.1.0",
+  "src/prometheus-api": "0.1.0",
+  "src/pyroscope-api": "0.1.0",
+  "src/signaldb-api": "0.1.0",
+  "src/signaldb-sdk": "0.1.0"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,16 @@
 #              docker compose and local builds
 #   prebuilt - copy static musl binaries staged in dist/ by CI, skipping
 #              the in-container compile entirely
+# The Explore UI has the same two paths, selected independently via
+# --build-arg UI_BUILDER=<source|prebuilt> (prebuilt copies a dist built by
+# CI and staged in ui-dist/, so one UI build serves every image).
 ARG BUILDER=source
+ARG UI_BUILDER=source
 
-# Explore UI builder - always built in-container (fast), consumed by the
-# router and monolithic runtime stages. A failing UI build fails the image
-# build; images never ship silently without their UI.
-FROM node:22-alpine AS ui-builder
+# Explore UI builder (source path) - consumed by the router and monolithic
+# runtime stages. A failing UI build fails the image build; images never
+# ship silently without their UI.
+FROM node:22-alpine AS ui-builder-source
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable
@@ -24,6 +28,14 @@ RUN pnpm install --frozen-lockfile --filter signaldb-ui
 
 COPY src/ui/ src/ui/
 RUN pnpm --filter signaldb-ui build
+
+# Explore UI builder (prebuilt path) - copy a dist/ staged in ui-dist/ by CI
+FROM alpine:3.24 AS ui-builder-prebuilt
+
+COPY ui-dist/ /build/src/ui/dist/
+
+# Selected UI builder; downstream stages copy from this alias
+FROM ui-builder-${UI_BUILDER} AS ui-builder
 
 # Builder stage - compile all services with musl for Alpine compatibility
 FROM rust:1.97-alpine AS builder-source

--- a/docs/operations/dokku.md
+++ b/docs/operations/dokku.md
@@ -43,7 +43,7 @@ dokku git:from-image signaldb ghcr.io/cedricziel/signaldb:<version>
 
 ## From source (git push)
 
-Dokku will build using the production `Dockerfile` with the `monolithic` target. The Dockerfile's default `BUILDER=source` path compiles everything inside the container (the `BUILDER=prebuilt` variant is only used by CI, which supplies pre-compiled musl binaries), so no extra build arguments are needed:
+Dokku will build using the production `Dockerfile` with the `monolithic` target. The Dockerfile's default `BUILDER=source` and `UI_BUILDER=source` paths compile the services and the Explore UI inside the container (the `prebuilt` variants of both are only used by CI, which supplies pre-compiled musl binaries and a pre-built UI dist), so no extra build arguments are needed:
 
 ```bash
 dokku apps:create signaldb

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -503,6 +503,356 @@
           "section": "Continuous Integration"
         }
       ]
+    },
+    "src/logql": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/loki-api": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/prometheus-api": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/pyroscope-api": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/signaldb-api": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/signaldb-cli": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
+    },
+    "src/signaldb-sdk": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
     }
   },
   "separate-pull-requests": false,


### PR DESCRIPTION
## Summary

A release-process audit found coverage gaps and caching blind spots; this PR closes them.

### 1. Seven workspace crates were invisible to release-please
`logql`, `loki-api`, `prometheus-api`, `pyroscope-api`, `signaldb-api`, `signaldb-cli`, and `signaldb-sdk` were not registered in `release-please-config.json`. Since release-please attributes commits by path, commits touching only those crates appeared in no changelog — and on their own never triggered a release PR, even though the next built binary would contain the change (e.g. the LogQL parity work in `src/logql`). They're now registered with the same settings as the other Rust packages, and the manifest is seeded at their current `Cargo.toml` versions (this also resolves the existing config/manifest drift around `src/signaldb-cli`).

### 2. Microservices release archives lacked the query path
`signaldb-microservices-*.tar.gz` only shipped the acceptor, router, and writer — no querier, no compactor. Both are now packaged. Mirrored in CI: the microservices `build-binaries` job now builds and smoke-tests `signaldb-compactor` too.

### 3. Per-service Docker images were never published
The Dockerfile's `acceptor`/`router`/`writer`/`querier`/`compactor` runtime stages were dead weight — only `monolithic` was ever pushed. Both the release workflow and CI now build all six targets via a service matrix (amd64 + arm64 + multi-arch manifests):

- `ghcr.io/cedricziel/signaldb` — monolithic (unchanged name)
- `ghcr.io/cedricziel/signaldb/<service>` — per-service images

Builds stay copy-only from the prebuilt musl binaries (`BUILDER=prebuilt`), so the extra matrix legs cost seconds each.

### 4. Linux musl release archives (first arm64 assets)
The static musl binaries were already built per-arch for the images but never reached the release. They're now packaged as `signaldb-{monolithic,microservices,cli}-{x86_64,aarch64}-unknown-linux-musl.tar.gz` — the first Linux arm64 release assets, and fully static amd64 ones.

### 5. Explore UI: built once, shipped as an asset
Previously each release compiled the UI four times inside docker (router + monolithic × two arches, no pnpm cache), and tarball users got no UI at all (the router serves from `SIGNALDB_UI_DIR`, which only the image populated). The Dockerfile now supports `UI_BUILDER=prebuilt` mirroring the binaries' prebuilt pattern; a `build-ui` job (release workflow + CI) builds the dist once with pnpm caching, feeds every image, and publishes `signaldb-ui.tar.gz` as a release asset. Local/compose builds keep the in-container default.

### 6. Caching + resilience fixes
- `build-release` was the only Rust build job without sccache, and its `release-*` rust-cache only refreshes on release runs (Windows had no warm cache at all). sccache added.
- `upload-assets` no longer depends on the docker jobs — a transient registry failure can't block the binary tarballs anymore.

## Notes for after merge

- **GHCR visibility**: the first push creates the five new `signaldb/<service>` packages as *private*; flip them to public in the package settings if they should match the monolithic image.
- **Branch protection**: the docker job names changed (e.g. `Build Docker Image (amd64)` → `Build Docker Image (monolithic, amd64)`); update any required-status-check rules that reference the old names.
- The next release-please PR will create first tags/changelogs for the seven newly tracked crates.