### PR TITLE
fix(release): install mold for the gnu release builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,6 +37,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     strategy:
+      # One target's failure must not cancel the other release archives.
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -70,9 +72,11 @@ jobs:
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
+        # mold + clang: .cargo/config.toml links x86_64-unknown-linux-gnu
+        # with clang and -fuse-ld=mold
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler mold clang
 
       - name: Install system dependencies (macOS)
         if: matrix.os == 'macos-latest'
@@ -674,6 +678,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install mold linker (Linux AMD64)
+        # The repo-level .cargo/config.toml links x86_64-unknown-linux-gnu
+        # with clang and -fuse-ld=mold, and it applies to the backend
+        # workspace too; the plugin's own CI installs mold the same way.
+        if: matrix.target.os == 'linux' && matrix.target.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold clang
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The v0.2.0 release run ([30532889528](https://github.com/cedricziel/signaldb/actions/runs/30532889528)) failed two jobs with `clang: error: invalid linker name in argument '-fuse-ld=mold'`:

- **Build Release Binaries (linux-gnu)** — and its default fail-fast **cancelled** the healthy macOS/Windows legs, so `Upload Release Assets` was skipped entirely
- **Build Grafana Plugin Backend (linux-amd64)** — so plugin packaging was skipped too

Root cause (latent, predates #792): `.cargo/config.toml` links `x86_64-unknown-linux-gnu` with `clang` + `-fuse-ld=mold`. ci.yml and the plugin's own CI install mold; the release workflow's two build jobs never did.

## Changes

- Install `mold clang` in `build-release`'s Ubuntu deps and in the plugin backend's linux-amd64 leg (mirrors ci.yml / grafana-plugin-ci-reusable.yml)
- `fail-fast: false` on the `build-release` matrix so one target's failure can't cancel the other archives

Everything new from #792 succeeded in that run: all 12 per-service/monolithic images, both musl archive jobs, and the UI build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build reliability by allowing target builds to continue independently when one fails.
  * Added required linker and compiler tooling for Linux release and plugin builds.
  * Improved consistency across Linux amd64 build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->