### PR TITLE
chore(release): track signaldb-ui with release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -17,5 +17,6 @@
   "src/prometheus-api": "0.1.1",
   "src/pyroscope-api": "0.1.1",
   "src/signaldb-api": "0.1.1",
-  "src/signaldb-sdk": "0.1.1"
+  "src/signaldb-sdk": "0.1.1",
+  "src/ui": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -853,6 +853,57 @@
           "section": "Continuous Integration"
         }
       ]
+    },
+    "src/ui": {
+      "release-type": "node",
+      "include-component-in-tag": true,
+      "component": "signaldb-ui",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "style",
+          "section": "Styles"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "test",
+          "section": "Tests"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration"
+        }
+      ]
     }
   },
   "separate-pull-requests": false,


### PR DESCRIPTION
src/ui was the only workspace member not tracked by release-please — no changelog and no version bumps for `feat(ui)`/`fix(ui)` commits (e.g. #794 would go unversioned). This adds it as a node package mirroring the Grafana plugin's settings: component `signaldb-ui`, `include-component-in-tag`, starting from the current `0.1.0` in the manifest.

Noticed while making the UI job a required CI check for `main`.