### PR TITLE
fix(common): exclude pyroscope on Windows to unblock release build

### DIFF
--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -35,7 +35,6 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-opentelemetry.workspace = true
 opentelemetry-appender-tracing.workspace = true
-pyroscope.workspace = true
 once_cell.workspace = true
 tokio.workspace = true
 
@@ -70,6 +69,13 @@ sysinfo.workspace = true
 # Prometheus remote write support
 snap.workspace = true
 prost.workspace = true
+
+# Continuous profiling: the Pyroscope agent's pprof-rs/jemalloc backends are
+# only supported on Linux/macOS (they bind to pthreads and pprof-rs), so the
+# dependency is excluded on Windows. `profiling::init_profiling` compiles to a
+# no-op stub there — see src/common/src/self_monitoring/profiling.rs.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+pyroscope.workspace = true
 
 [dev-dependencies]
 testcontainers-modules.workspace = true

--- a/src/common/src/self_monitoring/profiling.rs
+++ b/src/common/src/self_monitoring/profiling.rs
@@ -9,128 +9,174 @@
 //!
 //! Both are opt-in at runtime via the `[profiling]` config section and add
 //! nothing when disabled.
+//!
+//! The Pyroscope agent's backends bind to pthreads and pprof-rs and only
+//! support Linux/macOS, so on Windows this module compiles to a no-op stub
+//! (see [`init_profiling`]) and the `pyroscope` dependency is dropped
+//! entirely — see `src/common/Cargo.toml`.
 
-use anyhow::{Context, Result};
-use pyroscope::PyroscopeAgent;
-use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
-use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
+#[cfg(not(target_os = "windows"))]
+pub use platform::{ProfilingHandle, init_profiling};
 
-use crate::config::Configuration;
+#[cfg(target_os = "windows")]
+pub use stub::{ProfilingHandle, init_profiling};
 
-/// Spy name reported to the Pyroscope server.
-const SPY_NAME: &str = "pyroscope-rs";
+#[cfg(not(target_os = "windows"))]
+mod platform {
+    use anyhow::{Context, Result};
+    use pyroscope::PyroscopeAgent;
+    use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
+    use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 
-/// Handle to running profiling agents; stop via [`ProfilingHandle::shutdown`].
-pub struct ProfilingHandle {
-    agents: Vec<PyroscopeAgent<PyroscopeAgentRunning>>,
-}
+    use crate::config::Configuration;
 
-impl ProfilingHandle {
-    /// Stop the profiling agent(s), flushing any pending profile data.
-    pub fn shutdown(self) {
-        for agent in self.agents {
-            match agent.stop() {
-                Ok(stopped) => stopped.shutdown(),
-                Err(e) => tracing::warn!(error = %e, "Failed to stop Pyroscope agent"),
+    /// Spy name reported to the Pyroscope server.
+    const SPY_NAME: &str = "pyroscope-rs";
+
+    /// Handle to running profiling agents; stop via [`ProfilingHandle::shutdown`].
+    pub struct ProfilingHandle {
+        agents: Vec<PyroscopeAgent<PyroscopeAgentRunning>>,
+    }
+
+    impl ProfilingHandle {
+        /// Stop the profiling agent(s), flushing any pending profile data.
+        pub fn shutdown(self) {
+            for agent in self.agents {
+                match agent.stop() {
+                    Ok(stopped) => stopped.shutdown(),
+                    Err(e) => tracing::warn!(error = %e, "Failed to stop Pyroscope agent"),
+                }
             }
         }
     }
-}
 
-/// Start continuous profiling when `[profiling] enabled = true`.
-///
-/// Returns `Ok(None)` when disabled. CPU profiling starts unconditionally
-/// when enabled; memory profiling additionally requires
-/// `memory_profiling = true` **and** the `jemalloc-profiling` build feature
-/// (a warning is logged when configured without the feature).
-pub fn init_profiling(
-    config: &Configuration,
-    service_name: &str,
-) -> Result<Option<ProfilingHandle>> {
-    if !config.profiling.enabled {
-        return Ok(None);
-    }
+    /// Start continuous profiling when `[profiling] enabled = true`.
+    ///
+    /// Returns `Ok(None)` when disabled. CPU profiling starts unconditionally
+    /// when enabled; memory profiling additionally requires
+    /// `memory_profiling = true` **and** the `jemalloc-profiling` build feature
+    /// (a warning is logged when configured without the feature).
+    pub fn init_profiling(
+        config: &Configuration,
+        service_name: &str,
+    ) -> Result<Option<ProfilingHandle>> {
+        if !config.profiling.enabled {
+            return Ok(None);
+        }
 
-    let profiling = &config.profiling;
-    let mut agents = Vec::new();
+        let profiling = &config.profiling;
+        let mut agents = Vec::new();
 
-    let cpu_agent = PyroscopeAgentBuilder::new(
-        profiling.pyroscope_url.as_str(),
-        service_name,
-        profiling.cpu_sample_rate,
-        SPY_NAME,
-        env!("CARGO_PKG_VERSION"),
-        pprof_backend(
-            PprofConfig {
-                sample_rate: profiling.cpu_sample_rate,
-            },
-            BackendConfig::default(),
-        ),
-    )
-    .tags(vec![
-        ("service.name", service_name),
-        ("deployment.environment", "self-monitoring"),
-    ])
-    .build()
-    .context("Failed to build Pyroscope CPU agent")?
-    .start()
-    .context("Failed to start Pyroscope CPU agent")?;
-    agents.push(cpu_agent);
-
-    tracing::info!(
-        pyroscope_url = %profiling.pyroscope_url,
-        sample_rate = profiling.cpu_sample_rate,
-        "Continuous CPU profiling started"
-    );
-
-    #[cfg(feature = "jemalloc-profiling")]
-    if profiling.memory_profiling {
-        let app_name = format!("{service_name}.memory");
-        let memory_agent_result = PyroscopeAgentBuilder::new(
+        let cpu_agent = PyroscopeAgentBuilder::new(
             profiling.pyroscope_url.as_str(),
-            app_name.as_str(),
+            service_name,
             profiling.cpu_sample_rate,
             SPY_NAME,
             env!("CARGO_PKG_VERSION"),
-            pyroscope::backend::jemalloc::jemalloc_backend(),
+            pprof_backend(
+                PprofConfig {
+                    sample_rate: profiling.cpu_sample_rate,
+                },
+                BackendConfig::default(),
+            ),
         )
         .tags(vec![
             ("service.name", service_name),
             ("deployment.environment", "self-monitoring"),
         ])
         .build()
-        .context("Failed to build Pyroscope jemalloc agent")
-        .and_then(|agent| {
-            agent
-                .start()
-                .context("Failed to start Pyroscope jemalloc agent")
-        });
-        match memory_agent_result {
-            Ok(memory_agent) => {
-                agents.push(memory_agent);
-                tracing::info!("Continuous heap profiling started (jemalloc)");
-            }
-            Err(e) => {
-                // Cleanly stop the already-running CPU agent before bailing.
-                ProfilingHandle { agents }.shutdown();
-                return Err(e);
+        .context("Failed to build Pyroscope CPU agent")?
+        .start()
+        .context("Failed to start Pyroscope CPU agent")?;
+        agents.push(cpu_agent);
+
+        tracing::info!(
+            pyroscope_url = %profiling.pyroscope_url,
+            sample_rate = profiling.cpu_sample_rate,
+            "Continuous CPU profiling started"
+        );
+
+        #[cfg(feature = "jemalloc-profiling")]
+        if profiling.memory_profiling {
+            let app_name = format!("{service_name}.memory");
+            let memory_agent_result = PyroscopeAgentBuilder::new(
+                profiling.pyroscope_url.as_str(),
+                app_name.as_str(),
+                profiling.cpu_sample_rate,
+                SPY_NAME,
+                env!("CARGO_PKG_VERSION"),
+                pyroscope::backend::jemalloc::jemalloc_backend(),
+            )
+            .tags(vec![
+                ("service.name", service_name),
+                ("deployment.environment", "self-monitoring"),
+            ])
+            .build()
+            .context("Failed to build Pyroscope jemalloc agent")
+            .and_then(|agent| {
+                agent
+                    .start()
+                    .context("Failed to start Pyroscope jemalloc agent")
+            });
+            match memory_agent_result {
+                Ok(memory_agent) => {
+                    agents.push(memory_agent);
+                    tracing::info!("Continuous heap profiling started (jemalloc)");
+                }
+                Err(e) => {
+                    // Cleanly stop the already-running CPU agent before bailing.
+                    ProfilingHandle { agents }.shutdown();
+                    return Err(e);
+                }
             }
         }
+        #[cfg(not(feature = "jemalloc-profiling"))]
+        if profiling.memory_profiling {
+            tracing::warn!(
+                "memory_profiling is enabled but this binary was built without the \
+                 jemalloc-profiling feature; heap profiling is unavailable"
+            );
+        }
+
+        Ok(Some(ProfilingHandle { agents }))
     }
-    #[cfg(not(feature = "jemalloc-profiling"))]
-    if profiling.memory_profiling {
-        tracing::warn!(
-            "memory_profiling is enabled but this binary was built without the \
-             jemalloc-profiling feature; heap profiling is unavailable"
-        );
+}
+
+#[cfg(target_os = "windows")]
+mod stub {
+    use anyhow::Result;
+
+    use crate::config::Configuration;
+
+    /// No-op profiling handle on platforms without Pyroscope agent support.
+    pub struct ProfilingHandle;
+
+    impl ProfilingHandle {
+        /// No-op: profiling is never started on this platform.
+        pub fn shutdown(self) {}
     }
 
-    Ok(Some(ProfilingHandle { agents }))
+    /// Continuous profiling is unsupported on Windows (the Pyroscope agent's
+    /// backends require pthreads/pprof-rs), so this always returns `Ok(None)`.
+    /// A warning is logged if `[profiling] enabled = true`.
+    pub fn init_profiling(
+        config: &Configuration,
+        _service_name: &str,
+    ) -> Result<Option<ProfilingHandle>> {
+        if config.profiling.enabled {
+            tracing::warn!(
+                "Continuous profiling is not supported on Windows; the [profiling] \
+                 section is ignored"
+            );
+        }
+        Ok(None)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::init_profiling;
+    use crate::config::Configuration;
 
     #[test]
     fn disabled_returns_none() {


### PR DESCRIPTION
## Problem

The **Windows release binary** job (`x86_64-pc-windows-msvc`) fails to compile the `pyroscope` crate (v2.1.1, `backend-pprof-rs` feature), which the recently-merged self-profiling feature added as an **unconditional** dependency of `common`. The Pyroscope agent's backends are Linux/macOS-only:

```
error: feature `backend-pprof-rs` is only supported on Linux/macOS x86_64/aarch64
error[E0425]: cannot find type `pthread_t` in crate `libc`
error[E0425]: cannot find function `pthread_self` in crate `libc`
error: could not compile `pyroscope` (lib) due to 5 previous errors
```

This breaks every Windows build on `main` (e.g. run [30575951153](https://github.com/cedricziel/signaldb/actions/runs/30575951153)). Linux (musl) and macOS jobs are unaffected.

## Fix

- **`src/common/Cargo.toml`** — move `pyroscope` into `[target.'cfg(not(target_os = "windows"))'.dependencies]` so it is dropped entirely on Windows.
- **`src/common/src/self_monitoring/profiling.rs`** — split into a real `platform` module (non-Windows, behavior unchanged) and a Windows `stub` module where `init_profiling` returns `Ok(None)` and logs a warning if `[profiling]` is enabled.

The public API (`ProfilingHandle`, `init_profiling`) is identical on all targets, so the five `main.rs` callers need no changes.

## Verification

- `cargo metadata --filter-platform x86_64-pc-windows-msvc` → `pyroscope` absent from the graph, no feature-reference error (the `jemalloc-profiling` feature reference resolves cleanly on Windows).
- `cargo check -p common` passes on host.
- `profiling::tests` pass; `cargo fmt --check` and workspace clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility by disabling unsupported continuous profiling integrations on Windows.
  * Added a warning when profiling is enabled on Windows, while allowing the application to continue operating normally.
  * Preserved CPU and optional memory profiling behavior on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->