### PR TITLE
feat(ui): group-first traces view with selectable dimensions, RED columns, and drill-in

### DIFF
--- a/docs/users/explore-ui.md
+++ b/docs/users/explore-ui.md
@@ -22,8 +22,13 @@ visible in the UI is equally queryable from Grafana.
 - **Logs** — filter chips compiled to LogQL (with an "edit as text" escape
   hatch), a per-level volume histogram, a virtualized log list with
   per-attribute filter/exclude actions, a fields sidebar, and live tail.
-- **Traces** — recent-trace search and open-by-ID, a waterfall with span
-  details, and error highlighting.
+- **Traces** — a group-first view: recent traces arrive grouped by root
+  span name (or by service, any observed root-span/resource attribute, or
+  two dimensions combined via "Then by"), with per-group trace count,
+  request rate, error rate, p50/p95 latency, and last-seen columns —
+  all sortable. Selecting a group lists just its traces; selecting a trace
+  opens a waterfall with span details and error highlighting. Open-by-ID
+  works from any level.
 - **Metrics** — a PromQL box charting range queries.
 - **Correlation** — log rows with a `trace_id` open the trace waterfall;
   the span panel links back to logs filtered by that trace.

--- a/src/ui/src/api/tempo.test.ts
+++ b/src/ui/src/api/tempo.test.ts
@@ -89,6 +89,38 @@ describe("tempoGetTrace", () => {
     });
   });
 
+  it("treats an all-zero parent span id as a root", async () => {
+    mockFetchOnce({
+      traceID: "abc",
+      rootServiceName: "gateway",
+      rootTraceName: "root-op",
+      startTimeUnixNano: "1000",
+      durationMs: 1,
+      spanSets: [
+        {
+          matched: 1,
+          spans: [
+            {
+              spanID: "s1",
+              parentSpanID: "0000000000000000",
+              startTimeUnixNano: "1000",
+              durationNanos: "2000",
+              attributes: {
+                "resource.env": {
+                  key: "resource.env",
+                  value: { stringValue: "prod" },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const trace = await tempoGetTrace("abc");
+    expect(trace.spans[0]?.parentSpanId).toBeNull();
+    expect(trace.rootAttributes).toEqual({ "resource.env": "prod" });
+  });
+
   it("throws a readable error on failure", async () => {
     mockFetchOnce({ error: "trace not found" }, 404);
     await expect(tempoGetTrace("missing")).rejects.toThrow(
@@ -124,8 +156,53 @@ describe("tempoSearch", () => {
         rootTraceName: "GET /cart",
         startNs: "5000",
         durationMs: 88,
+        rootAttributes: {},
       },
     ]);
+  });
+
+  it("extracts the root span's attributes from spanSets", async () => {
+    mockFetchOnce({
+      traces: [
+        {
+          traceID: "t1",
+          rootServiceName: "checkout",
+          rootTraceName: "GET /cart",
+          startTimeUnixNano: "5000",
+          durationMs: 88,
+          spanSets: [
+            {
+              matched: 2,
+              spans: [
+                {
+                  spanID: "child",
+                  parentSpanID: "root",
+                  startTimeUnixNano: "5100",
+                  durationNanos: "10",
+                  attributes: {
+                    ignored: { key: "ignored", value: { stringValue: "x" } },
+                  },
+                },
+                {
+                  spanID: "root",
+                  startTimeUnixNano: "5000",
+                  durationNanos: "88000000",
+                  attributes: {
+                    "resource.host.name": {
+                      key: "resource.host.name",
+                      value: { stringValue: "web-1" },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      metrics: {},
+    });
+    const out = await tempoSearch(RANGE, 25);
+    expect(out[0]?.rootAttributes).toEqual({ "resource.host.name": "web-1" });
   });
 
   it("tolerates an empty result", async () => {

--- a/src/ui/src/api/tempo.test.ts
+++ b/src/ui/src/api/tempo.test.ts
@@ -157,8 +157,39 @@ describe("tempoSearch", () => {
         startNs: "5000",
         durationMs: 88,
         rootAttributes: {},
+        rootError: false,
       },
     ]);
+  });
+
+  it("flags traces whose root span errored", async () => {
+    mockFetchOnce({
+      traces: [
+        {
+          traceID: "t1",
+          rootServiceName: "checkout",
+          rootTraceName: "GET /cart",
+          startTimeUnixNano: "5000",
+          durationMs: 88,
+          spanSets: [
+            {
+              matched: 1,
+              spans: [
+                {
+                  spanID: "root",
+                  startTimeUnixNano: "5000",
+                  durationNanos: "10",
+                  status: "error",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      metrics: {},
+    });
+    const out = await tempoSearch(RANGE, 25);
+    expect(out[0]?.rootError).toBe(true);
   });
 
   it("extracts the root span's attributes from spanSets", async () => {

--- a/src/ui/src/api/tempo.ts
+++ b/src/ui/src/api/tempo.ts
@@ -28,6 +28,8 @@ export interface TraceSummary {
    * grouping dimensions for the traces landing screen.
    */
   rootAttributes: Record<string, AttrValue>;
+  /** True when the root span's status is "error". */
+  rootError: boolean;
 }
 
 export interface TempoTrace extends TraceSummary {
@@ -88,14 +90,14 @@ function toSpan(w: WireSpan): TempoSpan {
   };
 }
 
-/** The root span's attributes: no parent wins, else the earliest span. */
-function rootAttributes(spans: TempoSpan[]): Record<string, AttrValue> {
-  const root =
+/** The root span: no parent wins, else the earliest span. */
+function rootSpan(spans: TempoSpan[]): TempoSpan | undefined {
+  return (
     spans.find((s) => s.parentSpanId === null) ??
     [...spans].sort((a, b) =>
       BigInt(a.startNs) < BigInt(b.startNs) ? -1 : 1,
-    )[0];
-  return root?.attributes ?? {};
+    )[0]
+  );
 }
 
 async function tempoFetch<T>(
@@ -130,13 +132,15 @@ export async function tempoGetTrace(
     params,
   );
   const spans = (wire.spanSets ?? []).flatMap((s) => s.spans.map(toSpan));
+  const root = rootSpan(spans);
   return {
     traceId: wire.traceID,
     rootServiceName: wire.rootServiceName,
     rootTraceName: wire.rootTraceName,
     startNs: wire.startTimeUnixNano,
     durationMs: wire.durationMs,
-    rootAttributes: rootAttributes(spans),
+    rootAttributes: root?.attributes ?? {},
+    rootError: root?.status === "error",
     spans,
   };
 }
@@ -151,14 +155,18 @@ export async function tempoSearch(
     limit: String(limit),
   });
   const wire = await tempoFetch<{ traces?: WireTrace[] }>("search", params);
-  return (wire.traces ?? []).map((t) => ({
-    traceId: t.traceID,
-    rootServiceName: t.rootServiceName,
-    rootTraceName: t.rootTraceName,
-    startNs: t.startTimeUnixNano,
-    durationMs: t.durationMs,
-    rootAttributes: rootAttributes(
+  return (wire.traces ?? []).map((t) => {
+    const root = rootSpan(
       (t.spanSets ?? []).flatMap((s) => s.spans.map(toSpan)),
-    ),
-  }));
+    );
+    return {
+      traceId: t.traceID,
+      rootServiceName: t.rootServiceName,
+      rootTraceName: t.rootTraceName,
+      startNs: t.startTimeUnixNano,
+      durationMs: t.durationMs,
+      rootAttributes: root?.attributes ?? {},
+      rootError: root?.status === "error",
+    };
+  });
 }

--- a/src/ui/src/api/tempo.ts
+++ b/src/ui/src/api/tempo.ts
@@ -23,6 +23,11 @@ export interface TraceSummary {
   rootTraceName: string;
   startNs: string;
   durationMs: number;
+  /**
+   * Root span attributes (resource attributes prefixed "resource."), the
+   * grouping dimensions for the traces landing screen.
+   */
+  rootAttributes: Record<string, AttrValue>;
 }
 
 export interface TempoTrace extends TraceSummary {
@@ -69,9 +74,11 @@ function toSpan(w: WireSpan): TempoSpan {
   for (const [key, attr] of Object.entries(w.attributes ?? {})) {
     attributes[key] = flattenAttrValue(attr.value);
   }
+  // OTLP encodes "no parent" as an all-zero span id.
+  const parent = w.parentSpanID?.replace(/0/g, "") ? w.parentSpanID : null;
   return {
     spanId: w.spanID,
-    parentSpanId: w.parentSpanID || null,
+    parentSpanId: parent,
     name: w.name ?? "",
     serviceName: w.serviceName ?? "",
     status: w.status ?? "unset",
@@ -79,6 +86,16 @@ function toSpan(w: WireSpan): TempoSpan {
     durNs: w.durationNanos,
     attributes,
   };
+}
+
+/** The root span's attributes: no parent wins, else the earliest span. */
+function rootAttributes(spans: TempoSpan[]): Record<string, AttrValue> {
+  const root =
+    spans.find((s) => s.parentSpanId === null) ??
+    [...spans].sort((a, b) =>
+      BigInt(a.startNs) < BigInt(b.startNs) ? -1 : 1,
+    )[0];
+  return root?.attributes ?? {};
 }
 
 async function tempoFetch<T>(
@@ -112,13 +129,15 @@ export async function tempoGetTrace(
     `traces/${encodeURIComponent(traceId)}`,
     params,
   );
+  const spans = (wire.spanSets ?? []).flatMap((s) => s.spans.map(toSpan));
   return {
     traceId: wire.traceID,
     rootServiceName: wire.rootServiceName,
     rootTraceName: wire.rootTraceName,
     startNs: wire.startTimeUnixNano,
     durationMs: wire.durationMs,
-    spans: (wire.spanSets ?? []).flatMap((s) => s.spans.map(toSpan)),
+    rootAttributes: rootAttributes(spans),
+    spans,
   };
 }
 
@@ -138,5 +157,8 @@ export async function tempoSearch(
     rootTraceName: t.rootTraceName,
     startNs: t.startTimeUnixNano,
     durationMs: t.durationMs,
+    rootAttributes: rootAttributes(
+      (t.spanSets ?? []).flatMap((s) => s.spans.map(toSpan)),
+    ),
   }));
 }

--- a/src/ui/src/features/traces/TracesView.test.tsx
+++ b/src/ui/src/features/traces/TracesView.test.tsx
@@ -9,15 +9,69 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function searchTrace(
+  traceID: string,
+  service: string,
+  name: string,
+  startNs: string,
+  durationMs: number,
+  env: string,
+) {
+  return {
+    traceID,
+    rootServiceName: service,
+    rootTraceName: name,
+    startTimeUnixNano: startNs,
+    durationMs,
+    spanSets: [
+      {
+        matched: 1,
+        spans: [
+          {
+            spanID: `${traceID}-root`,
+            startTimeUnixNano: startNs,
+            durationNanos: String(durationMs * 1e6),
+            name,
+            serviceName: service,
+            attributes: {
+              "resource.env": {
+                key: "resource.env",
+                value: { stringValue: env },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
 const SEARCH_BODY = {
   traces: [
-    {
-      traceID: "t1cafe",
-      rootServiceName: "gateway",
-      rootTraceName: "POST /api/checkout",
-      startTimeUnixNano: "1700000000000000000",
-      durationMs: 412,
-    },
+    searchTrace(
+      "t1cafe",
+      "gateway",
+      "POST /api/checkout",
+      "1700000000000000000",
+      412,
+      "prod",
+    ),
+    searchTrace(
+      "t2feed",
+      "gateway",
+      "POST /api/checkout",
+      "1700000060000000000",
+      88,
+      "staging",
+    ),
+    searchTrace(
+      "t3beef",
+      "auth",
+      "GET /login",
+      "1700000030000000000",
+      51,
+      "prod",
+    ),
   ],
   metrics: {},
 };
@@ -72,14 +126,50 @@ function renderView(state: Partial<ExploreState> = {}) {
   return update;
 }
 
-describe("TracesView search", () => {
-  it("lists traces and opens one on click", async () => {
+describe("TracesView group list", () => {
+  it("groups traces by root, largest group first", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView();
+    const rows = await screen.findAllByRole("row");
+    // Header row + one row per group, not per trace.
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toHaveTextContent("POST /api/checkout");
+    expect(rows[1]).toHaveTextContent("2");
+    expect(rows[2]).toHaveTextContent("GET /login");
+  });
+
+  it("dives into a group on click", async () => {
     stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
     const update = renderView();
     await userEvent.click(
       await screen.findByRole("button", { name: "POST /api/checkout" }),
     );
-    expect(update).toHaveBeenCalledWith({ trace: "t1cafe" });
+    expect(update).toHaveBeenCalledWith({ group: "POST /api/checkout" });
+  });
+
+  it("offers observed attributes as grouping dimensions", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView();
+    // Attribute options appear once results arrive.
+    await screen.findByRole("button", { name: "POST /api/checkout" });
+    await userEvent.selectOptions(
+      screen.getByLabelText("Group by"),
+      "resource.env",
+    );
+    expect(update).toHaveBeenCalledWith({
+      groupBy: "resource.env",
+      group: "",
+    });
+  });
+
+  it("groups by the selected attribute dimension", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView({ groupBy: "resource.env" });
+    const rows = await screen.findAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toHaveTextContent("prod");
+    expect(rows[1]).toHaveTextContent("2");
+    expect(rows[2]).toHaveTextContent("staging");
   });
 
   it("opens a trace by pasted id", async () => {
@@ -96,6 +186,50 @@ describe("TracesView search", () => {
     ]);
     renderView();
     expect(await screen.findByRole("alert")).toHaveTextContent(/500/);
+  });
+});
+
+describe("TracesView group detail", () => {
+  it("lists only the selected group's traces, newest first", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView({ group: "POST /api/checkout" });
+    const rows = await screen.findAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toHaveTextContent("t2feed");
+    expect(rows[2]).toHaveTextContent("t1cafe");
+    expect(screen.queryByText("t3beef")).not.toBeInTheDocument();
+  });
+
+  it("filters by the active dimension, not just span name", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView({ groupBy: "resource.env", group: "prod" });
+    const rows = await screen.findAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(screen.getByText("t1cafe")).toBeInTheDocument();
+    expect(screen.getByText("t3beef")).toBeInTheDocument();
+    expect(screen.queryByText("t2feed")).not.toBeInTheDocument();
+  });
+
+  it("opens a trace on click", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView({ group: "POST /api/checkout" });
+    await userEvent.click(await screen.findByText("t1cafe"));
+    expect(update).toHaveBeenCalledWith({ trace: "t1cafe" });
+  });
+
+  it("navigates back to the group list", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView({ group: "POST /api/checkout" });
+    await userEvent.click(
+      await screen.findByRole("button", { name: "← groups" }),
+    );
+    expect(update).toHaveBeenCalledWith({ group: "" });
+  });
+
+  it("notes when the group has no traces in range", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: { metrics: {} } }]);
+    renderView({ group: "POST /api/checkout" });
+    expect(await screen.findByText(/no traces/i)).toBeInTheDocument();
   });
 });
 

--- a/src/ui/src/features/traces/TracesView.test.tsx
+++ b/src/ui/src/features/traces/TracesView.test.tsx
@@ -217,6 +217,36 @@ describe("TracesView group list", () => {
     expect(rows[2]).toHaveTextContent("staging");
   });
 
+  it("sorts by a clicked column and flips on the second click", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView();
+    await screen.findByRole("button", { name: "POST /api/checkout" });
+    // String column: first click sorts ascending.
+    await userEvent.click(screen.getByRole("button", { name: "span.name" }));
+    let rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("GET /login");
+    expect(rows[1]?.closest("table")?.querySelector("[aria-sort]")).toBe(
+      rows[0]?.querySelector("th"),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "span.name" }));
+    rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("POST /api/checkout");
+  });
+
+  it("sorts metric columns descending first", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView();
+    await screen.findByRole("button", { name: "POST /api/checkout" });
+    // checkout has 50% errors, login none: desc keeps checkout on top,
+    // the flip to ascending puts login first.
+    await userEvent.click(screen.getByRole("button", { name: "Errors" }));
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent(
+      "POST /api/checkout",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Errors" }));
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("GET /login");
+  });
+
   it("opens a trace by pasted id", async () => {
     stubFetchRoutes([{ match: "/tempo/api/search", body: { metrics: {} } }]);
     const update = renderView();
@@ -292,6 +322,18 @@ describe("TracesView group detail", () => {
     stubFetchRoutes([{ match: "/tempo/api/search", body: { metrics: {} } }]);
     renderView({ group: "POST /api/checkout" });
     expect(await screen.findByText(/no traces/i)).toBeInTheDocument();
+  });
+
+  it("sorts the trace list by a clicked column", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView({ group: "POST /api/checkout" });
+    await screen.findByText("t1cafe");
+    // Newest first by default; duration sorts descending first.
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("t2feed");
+    await userEvent.click(screen.getByRole("button", { name: "Duration" }));
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("t1cafe");
+    await userEvent.click(screen.getByRole("button", { name: "Duration" }));
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("t2feed");
   });
 });
 

--- a/src/ui/src/features/traces/TracesView.test.tsx
+++ b/src/ui/src/features/traces/TracesView.test.tsx
@@ -16,6 +16,7 @@ function searchTrace(
   startNs: string,
   durationMs: number,
   env: string,
+  status = "ok",
 ) {
   return {
     traceID,
@@ -33,6 +34,7 @@ function searchTrace(
             durationNanos: String(durationMs * 1e6),
             name,
             serviceName: service,
+            status,
             attributes: {
               "resource.env": {
                 key: "resource.env",
@@ -55,6 +57,7 @@ const SEARCH_BODY = {
       "1700000000000000000",
       412,
       "prod",
+      "error",
     ),
     searchTrace(
       "t2feed",
@@ -138,6 +141,48 @@ describe("TracesView group list", () => {
     expect(rows[2]).toHaveTextContent("GET /login");
   });
 
+  it("shows rate, error rate, and latency percentiles per group", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView();
+    const rows = await screen.findAllByRole("row");
+    expect(rows[0]).toHaveTextContent("Rate");
+    expect(rows[0]).toHaveTextContent("Errors");
+    expect(rows[0]).toHaveTextContent("P50");
+    // Default range is 1h; 2 checkout traces, one of them errored.
+    expect(rows[1]).toHaveTextContent("2/h");
+    expect(rows[1]).toHaveTextContent("50%");
+    expect(rows[2]).toHaveTextContent("1/h");
+  });
+
+  it("adds a secondary dimension via the then-by picker", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView();
+    await screen.findByRole("button", { name: "POST /api/checkout" });
+    await userEvent.selectOptions(
+      screen.getByLabelText("Then by"),
+      "service.name",
+    );
+    expect(update).toHaveBeenCalledWith({
+      groupBy: "span.name,service.name",
+      group: "",
+    });
+  });
+
+  it("renders one column per dimension and drills in with a composite key", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    const update = renderView({ groupBy: "span.name,service.name" });
+    const rows = await screen.findAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toHaveTextContent("POST /api/checkout");
+    expect(rows[1]).toHaveTextContent("gateway");
+    await userEvent.click(
+      screen.getByRole("button", { name: "POST /api/checkout" }),
+    );
+    expect(update).toHaveBeenCalledWith({
+      group: "POST /api/checkout\u001fgateway",
+    });
+  });
+
   it("dives into a group on click", async () => {
     stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
     const update = renderView();
@@ -208,6 +253,23 @@ describe("TracesView group detail", () => {
     expect(screen.getByText("t1cafe")).toBeInTheDocument();
     expect(screen.getByText("t3beef")).toBeInTheDocument();
     expect(screen.queryByText("t2feed")).not.toBeInTheDocument();
+  });
+
+  it("filters by every dimension of a composite group", async () => {
+    stubFetchRoutes([{ match: "/tempo/api/search", body: SEARCH_BODY }]);
+    renderView({
+      groupBy: "span.name,service.name",
+      group: "POST /api/checkout\u001fgateway",
+    });
+    // Title shows the values joined for humans.
+    expect(
+      await screen.findByRole("heading", {
+        name: "POST /api/checkout · gateway",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("t1cafe")).toBeInTheDocument();
+    expect(screen.getByText("t2feed")).toBeInTheDocument();
+    expect(screen.queryByText("t3beef")).not.toBeInTheDocument();
   });
 
   it("opens a trace on click", async () => {

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -34,6 +34,83 @@ function plural(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? "" : "s"}`;
 }
 
+/* ---------- column sorting ---------- */
+
+type SortDir = "asc" | "desc";
+interface SortSpec {
+  key: string;
+  dir: SortDir;
+}
+
+function useSort(defaultKey: string, defaultDir: SortDir) {
+  const [sort, setSort] = useState<SortSpec>({
+    key: defaultKey,
+    dir: defaultDir,
+  });
+  const toggle = (key: string, firstDir: SortDir) =>
+    setSort((s) =>
+      s.key === key
+        ? { key, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: firstDir },
+    );
+  return [sort, toggle] as const;
+}
+
+type SortValue = string | number | bigint;
+
+function compareValues(a: SortValue, b: SortValue): number {
+  if (typeof a === "string" || typeof b === "string") {
+    return String(a).localeCompare(String(b));
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function sortRows<T>(
+  rows: T[],
+  sort: SortSpec,
+  value: (row: T, key: string) => SortValue,
+): T[] {
+  const sign = sort.dir === "asc" ? 1 : -1;
+  return [...rows].sort(
+    (a, b) => sign * compareValues(value(a, sort.key), value(b, sort.key)),
+  );
+}
+
+function SortTh({
+  label,
+  sortKey,
+  sort,
+  toggle,
+  numeric = false,
+  firstDir,
+}: {
+  label: string;
+  sortKey: string;
+  sort: SortSpec;
+  toggle: (key: string, firstDir: SortDir) => void;
+  /** Right-aligned metric column; sorts descending on first click. */
+  numeric?: boolean;
+  /** Overrides the first-click direction (e.g. timestamps: newest first). */
+  firstDir?: SortDir;
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <th
+      className={numeric ? "num" : undefined}
+      aria-sort={
+        active ? (sort.dir === "asc" ? "ascending" : "descending") : undefined
+      }
+    >
+      <button
+        className="th-sort"
+        onClick={() => toggle(sortKey, firstDir ?? (numeric ? "desc" : "asc"))}
+      >
+        {label}
+      </button>
+    </th>
+  );
+}
+
 export function TracesView({ state, update }: Props) {
   if (state.trace !== "") {
     return <TraceDetail state={state} update={update} />;
@@ -177,25 +254,75 @@ function GroupList({
   rangeSeconds: number;
   update: (patch: Partial<ExploreState>) => void;
 }) {
+  const [sort, toggle] = useSort("traces", "desc");
   if (traces.length === 0) {
     return <div className="traces-note">No traces in this time range.</div>;
   }
-  const groups = groupTraces(traces, dims);
+  const groups = sortRows(groupTraces(traces, dims), sort, groupSortValue);
   const showServices = !dims.includes("service.name");
   return (
     <table className="trace-table">
       <thead>
         <tr>
-          {dims.map((d) => (
-            <th key={d}>{d}</th>
+          {dims.map((d, i) => (
+            <SortTh
+              key={d}
+              label={d}
+              sortKey={`dim:${i}`}
+              sort={sort}
+              toggle={toggle}
+            />
           ))}
-          {showServices && <th>Services</th>}
-          <th className="num">Traces</th>
-          <th className="num">Rate</th>
-          <th className="num">Errors</th>
-          <th className="num">P50</th>
-          <th className="num">P95</th>
-          <th>Last seen</th>
+          {showServices && (
+            <SortTh
+              label="Services"
+              sortKey="services"
+              sort={sort}
+              toggle={toggle}
+            />
+          )}
+          <SortTh
+            label="Traces"
+            sortKey="traces"
+            sort={sort}
+            toggle={toggle}
+            numeric
+          />
+          <SortTh
+            label="Rate"
+            sortKey="rate"
+            sort={sort}
+            toggle={toggle}
+            numeric
+          />
+          <SortTh
+            label="Errors"
+            sortKey="errors"
+            sort={sort}
+            toggle={toggle}
+            numeric
+          />
+          <SortTh
+            label="P50"
+            sortKey="p50"
+            sort={sort}
+            toggle={toggle}
+            numeric
+          />
+          <SortTh
+            label="P95"
+            sortKey="p95"
+            sort={sort}
+            toggle={toggle}
+            numeric
+          />
+          <SortTh
+            label="Last seen"
+            sortKey="last"
+            sort={sort}
+            toggle={toggle}
+            firstDir="desc"
+          />
         </tr>
       </thead>
       <tbody>
@@ -231,6 +358,39 @@ function formatServices(g: TraceGroup): string {
     : g.services.join(", ");
 }
 
+function groupSortValue(g: TraceGroup, key: string): SortValue {
+  if (key.startsWith("dim:")) return g.values[Number(key.slice(4))] ?? "";
+  switch (key) {
+    case "services":
+      return g.services.join(", ");
+    case "errors":
+      return g.errorCount / g.traces.length;
+    case "p50":
+      return g.p50Ms;
+    case "p95":
+      return g.p95Ms;
+    case "last":
+      return BigInt(g.lastStartNs);
+    default:
+      return g.traces.length;
+  }
+}
+
+function traceSortValue(t: TraceSummary, key: string): SortValue {
+  switch (key) {
+    case "root":
+      return t.rootTraceName;
+    case "service":
+      return t.rootServiceName;
+    case "duration":
+      return t.durationMs;
+    case "id":
+      return t.traceId;
+    default:
+      return BigInt(t.startNs);
+  }
+}
+
 function GroupDetail({
   state,
   traces,
@@ -240,10 +400,13 @@ function GroupDetail({
   traces: TraceSummary[];
   update: (patch: Partial<ExploreState>) => void;
 }) {
+  const [sort, toggle] = useSort("time", "desc");
   const dims = parseGroupBy(state.groupBy);
-  const members = traces
-    .filter((t) => groupKey(t, dims) === state.group)
-    .sort((a, b) => (BigInt(a.startNs) < BigInt(b.startNs) ? 1 : -1));
+  const members = sortRows(
+    traces.filter((t) => groupKey(t, dims) === state.group),
+    sort,
+    traceSortValue,
+  );
   return (
     <>
       <div className="trace-head">
@@ -263,11 +426,33 @@ function GroupDetail({
         <table className="trace-table">
           <thead>
             <tr>
-              <th>Root</th>
-              <th>Service</th>
-              <th>Time</th>
-              <th className="num">Duration</th>
-              <th>Trace ID</th>
+              <SortTh label="Root" sortKey="root" sort={sort} toggle={toggle} />
+              <SortTh
+                label="Service"
+                sortKey="service"
+                sort={sort}
+                toggle={toggle}
+              />
+              <SortTh
+                label="Time"
+                sortKey="time"
+                sort={sort}
+                toggle={toggle}
+                firstDir="desc"
+              />
+              <SortTh
+                label="Duration"
+                sortKey="duration"
+                sort={sort}
+                toggle={toggle}
+                numeric
+              />
+              <SortTh
+                label="Trace ID"
+                sortKey="id"
+                sort={sort}
+                toggle={toggle}
+              />
             </tr>
           </thead>
           <tbody>

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -13,9 +13,12 @@ import {
   resolveRange,
 } from "../../lib/time";
 import {
+  formatRate,
   groupDimensions,
+  groupKey,
+  groupLabel,
   groupTraces,
-  groupValue,
+  parseGroupBy,
   type TraceGroup,
 } from "../../lib/traceGroups";
 import type { ExploreState } from "../../lib/urlState";
@@ -67,22 +70,11 @@ function TraceSearch({ state, update }: Props) {
           <button type="submit">Open</button>
         </form>
         {state.group === "" && (
-          <label className="group-by">
-            Group by
-            <select
-              aria-label="Group by"
-              value={state.groupBy}
-              onChange={(e) =>
-                update({ groupBy: e.currentTarget.value, group: "" })
-              }
-            >
-              {dimensionOptions(search.data ?? [], state.groupBy).map((d) => (
-                <option key={d} value={d}>
-                  {d}
-                </option>
-              ))}
-            </select>
-          </label>
+          <DimensionPickers
+            traces={search.data ?? []}
+            groupBy={state.groupBy}
+            update={update}
+          />
         )}
       </div>
 
@@ -96,7 +88,8 @@ function TraceSearch({ state, update }: Props) {
         (state.group === "" ? (
           <GroupList
             traces={search.data}
-            groupBy={state.groupBy}
+            dims={parseGroupBy(state.groupBy)}
+            rangeSeconds={rangeSeconds(state)}
             update={update}
           />
         ) : (
@@ -106,13 +99,12 @@ function TraceSearch({ state, update }: Props) {
   );
 }
 
-/** The picked dimension stays selectable even if absent from this range. */
-function dimensionOptions(traces: TraceSummary[], groupBy: string): string[] {
-  const dims = groupDimensions(traces);
-  return dims.includes(groupBy) ? dims : [...dims, groupBy].sort();
+function rangeSeconds(state: ExploreState): number {
+  const r = resolveRange(state.range, Date.now());
+  return Math.max(1, (r.toMs - r.fromMs) / 1000);
 }
 
-function GroupList({
+function DimensionPickers({
   traces,
   groupBy,
   update,
@@ -121,17 +113,86 @@ function GroupList({
   groupBy: string;
   update: (patch: Partial<ExploreState>) => void;
 }) {
+  const dims = parseGroupBy(groupBy);
+  const primary = dims[0] ?? "";
+  const secondary = dims[1] ?? "";
+  const setDims = (next: string[]) =>
+    update({ groupBy: next.filter((d) => d !== "").join(","), group: "" });
+  return (
+    <div className="group-pickers">
+      <label className="group-by">
+        Group by
+        <select
+          aria-label="Group by"
+          value={primary}
+          onChange={(e) => {
+            const v = e.currentTarget.value;
+            setDims([v, secondary === v ? "" : secondary]);
+          }}
+        >
+          {dimensionOptions(traces, primary).map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="group-by">
+        Then by
+        <select
+          aria-label="Then by"
+          value={secondary}
+          onChange={(e) => setDims([primary, e.currentTarget.value])}
+        >
+          <option value="">—</option>
+          {dimensionOptions(traces, secondary)
+            .filter((d) => d !== primary && d !== "")
+            .map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+/** The picked dimension stays selectable even if absent from this range. */
+function dimensionOptions(traces: TraceSummary[], picked: string): string[] {
+  const dims = groupDimensions(traces);
+  return picked === "" || dims.includes(picked)
+    ? dims
+    : [...dims, picked].sort();
+}
+
+function GroupList({
+  traces,
+  dims,
+  rangeSeconds,
+  update,
+}: {
+  traces: TraceSummary[];
+  dims: string[];
+  rangeSeconds: number;
+  update: (patch: Partial<ExploreState>) => void;
+}) {
   if (traces.length === 0) {
     return <div className="traces-note">No traces in this time range.</div>;
   }
-  const groups = groupTraces(traces, groupBy);
+  const groups = groupTraces(traces, dims);
+  const showServices = !dims.includes("service.name");
   return (
     <table className="trace-table">
       <thead>
         <tr>
-          <th>{groupBy}</th>
-          <th>Services</th>
+          {dims.map((d) => (
+            <th key={d}>{d}</th>
+          ))}
+          {showServices && <th>Services</th>}
           <th className="num">Traces</th>
+          <th className="num">Rate</th>
+          <th className="num">Errors</th>
           <th className="num">P50</th>
           <th className="num">P95</th>
           <th>Last seen</th>
@@ -139,12 +200,21 @@ function GroupList({
       </thead>
       <tbody>
         {groups.map((g) => (
-          <tr key={g.value} onClick={() => update({ group: g.value })}>
+          <tr key={g.key} onClick={() => update({ group: g.key })}>
             <td>
-              <button className="trace-open">{g.value}</button>
+              <button className="trace-open">{g.values[0]}</button>
             </td>
-            <td>{formatServices(g)}</td>
+            {g.values.slice(1).map((v, i) => (
+              <td key={dims[i + 1]}>{v}</td>
+            ))}
+            {showServices && <td>{formatServices(g)}</td>}
             <td className="num">{g.traces.length}</td>
+            <td className="num">{formatRate(g.traces.length, rangeSeconds)}</td>
+            <td className={`num${g.errorCount > 0 ? " err-rate" : ""}`}>
+              {g.errorCount > 0
+                ? `${Math.round((100 * g.errorCount) / g.traces.length)}%`
+                : "–"}
+            </td>
             <td className="num">{formatDurationMs(g.p50Ms)}</td>
             <td className="num">{formatDurationMs(g.p95Ms)}</td>
             <td>{formatTimestamp(nanosToMs(g.lastStartNs))}</td>
@@ -170,8 +240,9 @@ function GroupDetail({
   traces: TraceSummary[];
   update: (patch: Partial<ExploreState>) => void;
 }) {
+  const dims = parseGroupBy(state.groupBy);
   const members = traces
-    .filter((t) => groupValue(t, state.groupBy) === state.group)
+    .filter((t) => groupKey(t, dims) === state.group)
     .sort((a, b) => (BigInt(a.startNs) < BigInt(b.startNs) ? 1 : -1));
   return (
     <>
@@ -179,9 +250,9 @@ function GroupDetail({
         <button className="backbtn" onClick={() => update({ group: "" })}>
           ← groups
         </button>
-        <h3>{state.group}</h3>
+        <h3>{groupLabel(state.group)}</h3>
         <span className="tmeta">
-          {state.groupBy} · {plural(members.length, "trace")}
+          {dims.join(", ")} · {plural(members.length, "trace")}
         </span>
       </div>
       {members.length === 0 ? (

--- a/src/ui/src/features/traces/TracesView.tsx
+++ b/src/ui/src/features/traces/TracesView.tsx
@@ -1,12 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { tempoGetTrace, tempoSearch, type TempoSpan } from "../../api/tempo";
+import {
+  tempoGetTrace,
+  tempoSearch,
+  type TempoSpan,
+  type TraceSummary,
+} from "../../api/tempo";
 import {
   formatTimestamp,
   nanosToMs,
   rangeToParam,
   resolveRange,
 } from "../../lib/time";
+import {
+  groupDimensions,
+  groupTraces,
+  groupValue,
+  type TraceGroup,
+} from "../../lib/traceGroups";
 import type { ExploreState } from "../../lib/urlState";
 import { buildWaterfall, formatDurationMs } from "../../lib/waterfall";
 import "./traces.css";
@@ -37,23 +48,43 @@ function TraceSearch({ state, update }: Props) {
 
   return (
     <div className="traces-search">
-      <form
-        className="trace-id-form"
-        onSubmit={(e) => {
-          e.preventDefault();
-          const id = new FormData(e.currentTarget).get("traceId");
-          if (typeof id === "string" && id.trim() !== "") {
-            update({ trace: id.trim() });
-          }
-        }}
-      >
-        <input
-          name="traceId"
-          aria-label="Trace ID"
-          placeholder="Open trace by ID…"
-        />
-        <button type="submit">Open</button>
-      </form>
+      <div className="traces-toolbar">
+        <form
+          className="trace-id-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const id = new FormData(e.currentTarget).get("traceId");
+            if (typeof id === "string" && id.trim() !== "") {
+              update({ trace: id.trim() });
+            }
+          }}
+        >
+          <input
+            name="traceId"
+            aria-label="Trace ID"
+            placeholder="Open trace by ID…"
+          />
+          <button type="submit">Open</button>
+        </form>
+        {state.group === "" && (
+          <label className="group-by">
+            Group by
+            <select
+              aria-label="Group by"
+              value={state.groupBy}
+              onChange={(e) =>
+                update({ groupBy: e.currentTarget.value, group: "" })
+              }
+            >
+              {dimensionOptions(search.data ?? [], state.groupBy).map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
 
       {search.isError && (
         <div className="query-error" role="alert">
@@ -61,10 +92,103 @@ function TraceSearch({ state, update }: Props) {
         </div>
       )}
       {search.isPending && <div className="traces-note">Loading…</div>}
-      {search.data && search.data.length === 0 && (
-        <div className="traces-note">No traces in this time range.</div>
-      )}
-      {search.data && search.data.length > 0 && (
+      {search.data &&
+        (state.group === "" ? (
+          <GroupList
+            traces={search.data}
+            groupBy={state.groupBy}
+            update={update}
+          />
+        ) : (
+          <GroupDetail state={state} traces={search.data} update={update} />
+        ))}
+    </div>
+  );
+}
+
+/** The picked dimension stays selectable even if absent from this range. */
+function dimensionOptions(traces: TraceSummary[], groupBy: string): string[] {
+  const dims = groupDimensions(traces);
+  return dims.includes(groupBy) ? dims : [...dims, groupBy].sort();
+}
+
+function GroupList({
+  traces,
+  groupBy,
+  update,
+}: {
+  traces: TraceSummary[];
+  groupBy: string;
+  update: (patch: Partial<ExploreState>) => void;
+}) {
+  if (traces.length === 0) {
+    return <div className="traces-note">No traces in this time range.</div>;
+  }
+  const groups = groupTraces(traces, groupBy);
+  return (
+    <table className="trace-table">
+      <thead>
+        <tr>
+          <th>{groupBy}</th>
+          <th>Services</th>
+          <th className="num">Traces</th>
+          <th className="num">P50</th>
+          <th className="num">P95</th>
+          <th>Last seen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {groups.map((g) => (
+          <tr key={g.value} onClick={() => update({ group: g.value })}>
+            <td>
+              <button className="trace-open">{g.value}</button>
+            </td>
+            <td>{formatServices(g)}</td>
+            <td className="num">{g.traces.length}</td>
+            <td className="num">{formatDurationMs(g.p50Ms)}</td>
+            <td className="num">{formatDurationMs(g.p95Ms)}</td>
+            <td>{formatTimestamp(nanosToMs(g.lastStartNs))}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function formatServices(g: TraceGroup): string {
+  return g.services.length > 2
+    ? `${plural(g.services.length, "service")}`
+    : g.services.join(", ");
+}
+
+function GroupDetail({
+  state,
+  traces,
+  update,
+}: {
+  state: ExploreState;
+  traces: TraceSummary[];
+  update: (patch: Partial<ExploreState>) => void;
+}) {
+  const members = traces
+    .filter((t) => groupValue(t, state.groupBy) === state.group)
+    .sort((a, b) => (BigInt(a.startNs) < BigInt(b.startNs) ? 1 : -1));
+  return (
+    <>
+      <div className="trace-head">
+        <button className="backbtn" onClick={() => update({ group: "" })}>
+          ← groups
+        </button>
+        <h3>{state.group}</h3>
+        <span className="tmeta">
+          {state.groupBy} · {plural(members.length, "trace")}
+        </span>
+      </div>
+      {members.length === 0 ? (
+        <div className="traces-note">
+          No traces for this group in this time range.
+        </div>
+      ) : (
         <table className="trace-table">
           <thead>
             <tr>
@@ -76,7 +200,7 @@ function TraceSearch({ state, update }: Props) {
             </tr>
           </thead>
           <tbody>
-            {search.data.map((t) => (
+            {members.map((t) => (
               <tr key={t.traceId} onClick={() => update({ trace: t.traceId })}>
                 <td>
                   <button className="trace-open">{t.rootTraceName}</button>
@@ -90,7 +214,7 @@ function TraceSearch({ state, update }: Props) {
           </tbody>
         </table>
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/ui/src/features/traces/traces.css
+++ b/src/ui/src/features/traces/traces.css
@@ -5,11 +5,38 @@
   overflow: auto;
 }
 
-.trace-id-form {
+.traces-toolbar {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--border);
+}
+
+.trace-id-form {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+}
+
+.group-by {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.group-by select {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--text);
 }
 
 .trace-id-form input {

--- a/src/ui/src/features/traces/traces.css
+++ b/src/ui/src/features/traces/traces.css
@@ -20,6 +20,12 @@
   flex: 1;
 }
 
+.group-pickers {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
 .group-by {
   display: flex;
   align-items: center;
@@ -27,6 +33,11 @@
   font-size: 11px;
   color: var(--dim);
   white-space: nowrap;
+}
+
+.err-rate {
+  color: var(--err);
+  font-weight: 600;
 }
 
 .group-by select {

--- a/src/ui/src/features/traces/traces.css
+++ b/src/ui/src/features/traces/traces.css
@@ -97,6 +97,30 @@
   font-variant-numeric: tabular-nums;
 }
 
+.trace-table .th-sort {
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+}
+
+.trace-table .th-sort:hover {
+  color: var(--text);
+}
+
+.trace-table th[aria-sort] .th-sort {
+  color: var(--text);
+}
+
+.trace-table th[aria-sort="ascending"] .th-sort::after {
+  content: " ↑";
+}
+
+.trace-table th[aria-sort="descending"] .th-sort::after {
+  content: " ↓";
+}
+
 .trace-table td {
   padding: 6px 14px;
   border-bottom: 1px solid var(--border);

--- a/src/ui/src/lib/traceGroups.test.ts
+++ b/src/ui/src/lib/traceGroups.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 import type { TraceSummary } from "../api/tempo";
 import {
   DEFAULT_GROUP_BY,
+  formatRate,
   groupDimensions,
+  groupKey,
   groupTraces,
   groupValue,
   NOT_SET,
+  parseGroupBy,
 } from "./traceGroups";
 
 function trace(
@@ -15,6 +18,7 @@ function trace(
   startNs: string,
   durationMs: number,
   rootAttributes: TraceSummary["rootAttributes"] = {},
+  rootError = false,
 ): TraceSummary {
   return {
     traceId,
@@ -23,8 +27,24 @@ function trace(
     startNs,
     durationMs,
     rootAttributes,
+    rootError,
   };
 }
+
+describe("parseGroupBy", () => {
+  it("defaults to span.name", () => {
+    expect(parseGroupBy("")).toEqual(["span.name"]);
+    expect(parseGroupBy(DEFAULT_GROUP_BY)).toEqual(["span.name"]);
+  });
+
+  it("splits comma-separated dimensions and drops duplicates", () => {
+    expect(parseGroupBy("span.name,service.name")).toEqual([
+      "span.name",
+      "service.name",
+    ]);
+    expect(parseGroupBy("span.name,span.name,")).toEqual(["span.name"]);
+  });
+});
 
 describe("groupValue", () => {
   it("maps the built-in dimensions to root name and service", () => {
@@ -56,12 +76,36 @@ describe("groupTraces", () => {
         trace("b", "auth", "GET /login", "100", 50),
         trace("c", "gateway", "POST /checkout", "200", 100),
       ],
-      DEFAULT_GROUP_BY,
+      ["span.name"],
     );
-    expect(groups.map((g) => [g.value, g.traces.length])).toEqual([
-      ["POST /checkout", 2],
-      ["GET /login", 1],
+    expect(groups.map((g) => [g.values, g.traces.length])).toEqual([
+      [["POST /checkout"], 2],
+      [["GET /login"], 1],
     ]);
+  });
+
+  it("distinguishes same-named roots when also grouped by service", () => {
+    const traces = [
+      trace("a", "gateway", "GET /health", "1", 1),
+      trace("b", "auth", "GET /health", "2", 1),
+    ];
+    expect(groupTraces(traces, ["span.name"])).toHaveLength(1);
+    const two = groupTraces(traces, ["span.name", "service.name"]);
+    expect(two.map((g) => g.values)).toEqual(
+      [[["GET /health", "auth"]], [["GET /health", "gateway"]]].flat(),
+    );
+  });
+
+  it("counts errored traces per group", () => {
+    const groups = groupTraces(
+      [
+        trace("a", "gw", "op", "1", 1, {}, true),
+        trace("b", "gw", "op", "2", 1),
+        trace("c", "gw", "op", "3", 1),
+      ],
+      ["span.name"],
+    );
+    expect(groups[0]?.errorCount).toBe(1);
   });
 
   it("groups by an arbitrary attribute and lists each group's services", () => {
@@ -71,11 +115,11 @@ describe("groupTraces", () => {
         trace("b", "auth", "GET /login", "2", 10, { env: "prod" }),
         trace("c", "gateway", "POST /checkout", "3", 10, { env: "staging" }),
       ],
-      "env",
+      ["env"],
     );
-    expect(groups.map((g) => [g.value, g.traces.length])).toEqual([
-      ["prod", 2],
-      ["staging", 1],
+    expect(groups.map((g) => [g.values, g.traces.length])).toEqual([
+      [["prod"], 2],
+      [["staging"], 1],
     ]);
     expect(groups[0]?.services).toEqual(["auth", "gateway"]);
     expect(groups[1]?.services).toEqual(["gateway"]);
@@ -87,7 +131,7 @@ describe("groupTraces", () => {
         trace("old", "gateway", "POST /checkout", "9000000000", 100),
         trace("new", "gateway", "POST /checkout", "10000000000", 100),
       ],
-      DEFAULT_GROUP_BY,
+      ["span.name"],
     );
     expect(groups[0]?.traces.map((t) => t.traceId)).toEqual(["new", "old"]);
     expect(groups[0]?.lastStartNs).toBe("10000000000");
@@ -98,7 +142,7 @@ describe("groupTraces", () => {
       [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((d, i) =>
         trace(`t${i}`, "svc", "op", String(i), d),
       ),
-      DEFAULT_GROUP_BY,
+      ["span.name"],
     );
     expect(groups[0]?.p50Ms).toBe(50);
     expect(groups[0]?.p95Ms).toBe(100);
@@ -107,14 +151,22 @@ describe("groupTraces", () => {
   it("uses the single duration for all percentiles of a one-trace group", () => {
     const groups = groupTraces(
       [trace("a", "svc", "op", "1", 42)],
-      DEFAULT_GROUP_BY,
+      ["span.name"],
     );
     expect(groups[0]?.p50Ms).toBe(42);
     expect(groups[0]?.p95Ms).toBe(42);
   });
 
   it("returns no groups for no traces", () => {
-    expect(groupTraces([], DEFAULT_GROUP_BY)).toEqual([]);
+    expect(groupTraces([], ["span.name"])).toEqual([]);
+  });
+});
+
+describe("groupKey", () => {
+  it("matches the key of the group a trace lands in", () => {
+    const t = trace("a", "gateway", "GET /health", "1", 1);
+    const groups = groupTraces([t], ["span.name", "service.name"]);
+    expect(groupKey(t, ["span.name", "service.name"])).toBe(groups[0]?.key);
   });
 });
 
@@ -139,5 +191,14 @@ describe("groupDimensions", () => {
 
   it("offers only the built-ins when traces carry no attributes", () => {
     expect(groupDimensions([])).toEqual(["span.name", "service.name"]);
+  });
+});
+
+describe("formatRate", () => {
+  it("picks a unit that keeps the number readable", () => {
+    expect(formatRate(7200, 3600)).toBe("2/s");
+    expect(formatRate(90, 3600)).toBe("1.5/min");
+    expect(formatRate(2, 3600)).toBe("2/h");
+    expect(formatRate(0, 3600)).toBe("0/h");
   });
 });

--- a/src/ui/src/lib/traceGroups.test.ts
+++ b/src/ui/src/lib/traceGroups.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { TraceSummary } from "../api/tempo";
+import {
+  DEFAULT_GROUP_BY,
+  groupDimensions,
+  groupTraces,
+  groupValue,
+  NOT_SET,
+} from "./traceGroups";
+
+function trace(
+  traceId: string,
+  service: string,
+  name: string,
+  startNs: string,
+  durationMs: number,
+  rootAttributes: TraceSummary["rootAttributes"] = {},
+): TraceSummary {
+  return {
+    traceId,
+    rootServiceName: service,
+    rootTraceName: name,
+    startNs,
+    durationMs,
+    rootAttributes,
+  };
+}
+
+describe("groupValue", () => {
+  it("maps the built-in dimensions to root name and service", () => {
+    const t = trace("a", "gateway", "POST /checkout", "1", 1);
+    expect(groupValue(t, "span.name")).toBe("POST /checkout");
+    expect(groupValue(t, "service.name")).toBe("gateway");
+  });
+
+  it("reads any root span attribute, stringified", () => {
+    const t = trace("a", "gateway", "POST /checkout", "1", 1, {
+      "resource.deployment.environment": "prod",
+      "http.status_code": 500,
+    });
+    expect(groupValue(t, "resource.deployment.environment")).toBe("prod");
+    expect(groupValue(t, "http.status_code")).toBe("500");
+  });
+
+  it("buckets missing attributes under a not-set marker", () => {
+    const t = trace("a", "gateway", "POST /checkout", "1", 1);
+    expect(groupValue(t, "resource.host.name")).toBe(NOT_SET);
+  });
+});
+
+describe("groupTraces", () => {
+  it("groups by root span name by default, largest group first", () => {
+    const groups = groupTraces(
+      [
+        trace("a", "gateway", "POST /checkout", "300", 400),
+        trace("b", "auth", "GET /login", "100", 50),
+        trace("c", "gateway", "POST /checkout", "200", 100),
+      ],
+      DEFAULT_GROUP_BY,
+    );
+    expect(groups.map((g) => [g.value, g.traces.length])).toEqual([
+      ["POST /checkout", 2],
+      ["GET /login", 1],
+    ]);
+  });
+
+  it("groups by an arbitrary attribute and lists each group's services", () => {
+    const groups = groupTraces(
+      [
+        trace("a", "gateway", "POST /checkout", "1", 10, { env: "prod" }),
+        trace("b", "auth", "GET /login", "2", 10, { env: "prod" }),
+        trace("c", "gateway", "POST /checkout", "3", 10, { env: "staging" }),
+      ],
+      "env",
+    );
+    expect(groups.map((g) => [g.value, g.traces.length])).toEqual([
+      ["prod", 2],
+      ["staging", 1],
+    ]);
+    expect(groups[0]?.services).toEqual(["auth", "gateway"]);
+    expect(groups[1]?.services).toEqual(["gateway"]);
+  });
+
+  it("sorts traces within a group newest first and tracks the latest start", () => {
+    const groups = groupTraces(
+      [
+        trace("old", "gateway", "POST /checkout", "9000000000", 100),
+        trace("new", "gateway", "POST /checkout", "10000000000", 100),
+      ],
+      DEFAULT_GROUP_BY,
+    );
+    expect(groups[0]?.traces.map((t) => t.traceId)).toEqual(["new", "old"]);
+    expect(groups[0]?.lastStartNs).toBe("10000000000");
+  });
+
+  it("computes duration percentiles", () => {
+    const groups = groupTraces(
+      [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((d, i) =>
+        trace(`t${i}`, "svc", "op", String(i), d),
+      ),
+      DEFAULT_GROUP_BY,
+    );
+    expect(groups[0]?.p50Ms).toBe(50);
+    expect(groups[0]?.p95Ms).toBe(100);
+  });
+
+  it("uses the single duration for all percentiles of a one-trace group", () => {
+    const groups = groupTraces(
+      [trace("a", "svc", "op", "1", 42)],
+      DEFAULT_GROUP_BY,
+    );
+    expect(groups[0]?.p50Ms).toBe(42);
+    expect(groups[0]?.p95Ms).toBe(42);
+  });
+
+  it("returns no groups for no traces", () => {
+    expect(groupTraces([], DEFAULT_GROUP_BY)).toEqual([]);
+  });
+});
+
+describe("groupDimensions", () => {
+  it("offers the built-ins plus observed root attributes, sorted", () => {
+    const dims = groupDimensions([
+      trace("a", "gateway", "POST /checkout", "1", 1, {
+        "resource.host.name": "web-1",
+        "http.method": "POST",
+      }),
+      trace("b", "auth", "GET /login", "2", 1, {
+        "resource.host.name": "web-2",
+      }),
+    ]);
+    expect(dims).toEqual([
+      "span.name",
+      "service.name",
+      "http.method",
+      "resource.host.name",
+    ]);
+  });
+
+  it("offers only the built-ins when traces carry no attributes", () => {
+    expect(groupDimensions([])).toEqual(["span.name", "service.name"]);
+  });
+});

--- a/src/ui/src/lib/traceGroups.ts
+++ b/src/ui/src/lib/traceGroups.ts
@@ -1,0 +1,79 @@
+// Grouping of trace search results along a user-picked dimension: the root
+// span's name (default), its service, or any root span / resource attribute
+// observed in the results. The dimension and selected group are URL params so
+// a drill-in is deep-linkable.
+
+import type { TraceSummary } from "../api/tempo";
+
+export const DEFAULT_GROUP_BY = "span.name";
+export const BUILTIN_DIMENSIONS = [DEFAULT_GROUP_BY, "service.name"];
+
+/** Bucket for traces whose root span lacks the grouping attribute. */
+export const NOT_SET = "(not set)";
+
+export interface TraceGroup {
+  value: string;
+  /** Newest first. */
+  traces: TraceSummary[];
+  /** Distinct root services in the group, sorted. */
+  services: string[];
+  p50Ms: number;
+  p95Ms: number;
+  lastStartNs: string;
+}
+
+export function groupValue(t: TraceSummary, dimension: string): string {
+  if (dimension === "span.name") return t.rootTraceName;
+  if (dimension === "service.name") return t.rootServiceName;
+  const v = t.rootAttributes[dimension];
+  return v === undefined ? NOT_SET : String(v);
+}
+
+/** Nearest-rank percentile over an ascending-sorted array. */
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.max(0, Math.ceil(p * sorted.length) - 1);
+  return sorted[idx] ?? 0;
+}
+
+export function groupTraces(
+  traces: TraceSummary[],
+  dimension: string,
+): TraceGroup[] {
+  const byValue = new Map<string, TraceSummary[]>();
+  for (const t of traces) {
+    const value = groupValue(t, dimension);
+    const bucket = byValue.get(value);
+    if (bucket) bucket.push(t);
+    else byValue.set(value, [t]);
+  }
+  const groups = [...byValue.entries()].map(([value, members]): TraceGroup => {
+    const sorted = [...members].sort((a, b) =>
+      BigInt(a.startNs) < BigInt(b.startNs) ? 1 : -1,
+    );
+    const durations = members.map((t) => t.durationMs).sort((a, b) => a - b);
+    return {
+      value,
+      traces: sorted,
+      services: [...new Set(members.map((t) => t.rootServiceName))].sort(),
+      p50Ms: percentile(durations, 0.5),
+      p95Ms: percentile(durations, 0.95),
+      lastStartNs: sorted[0]?.startNs ?? "0",
+    };
+  });
+  return groups.sort(
+    (a, b) =>
+      b.traces.length - a.traces.length || a.value.localeCompare(b.value),
+  );
+}
+
+/**
+ * Dimensions offered by the picker: the built-ins plus every attribute key
+ * observed on a root span (resource attributes arrive prefixed "resource.").
+ */
+export function groupDimensions(traces: TraceSummary[]): string[] {
+  const attrs = new Set<string>();
+  for (const t of traces) {
+    for (const key of Object.keys(t.rootAttributes)) attrs.add(key);
+  }
+  return [...BUILTIN_DIMENSIONS, ...[...attrs].sort()];
+}

--- a/src/ui/src/lib/traceGroups.ts
+++ b/src/ui/src/lib/traceGroups.ts
@@ -1,7 +1,8 @@
-// Grouping of trace search results along a user-picked dimension: the root
+// Grouping of trace search results along user-picked dimensions: the root
 // span's name (default), its service, or any root span / resource attribute
-// observed in the results. The dimension and selected group are URL params so
-// a drill-in is deep-linkable.
+// observed in the results — optionally two combined (e.g. span.name then
+// service.name). The dimensions and selected group are URL params so a
+// drill-in is deep-linkable.
 
 import type { TraceSummary } from "../api/tempo";
 
@@ -11,15 +12,34 @@ export const BUILTIN_DIMENSIONS = [DEFAULT_GROUP_BY, "service.name"];
 /** Bucket for traces whose root span lacks the grouping attribute. */
 export const NOT_SET = "(not set)";
 
+/** Joins dimension values into a group key; unit separator avoids collisions. */
+const KEY_SEP = "\u001f";
+
 export interface TraceGroup {
-  value: string;
+  key: string;
+  /** One value per grouping dimension. */
+  values: string[];
   /** Newest first. */
   traces: TraceSummary[];
   /** Distinct root services in the group, sorted. */
   services: string[];
+  errorCount: number;
   p50Ms: number;
   p95Ms: number;
   lastStartNs: string;
+}
+
+/** The `groupBy` URL param: comma-separated dimensions, deduplicated. */
+export function parseGroupBy(param: string): string[] {
+  const dims = [
+    ...new Set(
+      param
+        .split(",")
+        .map((d) => d.trim())
+        .filter((d) => d !== ""),
+    ),
+  ];
+  return dims.length === 0 ? [DEFAULT_GROUP_BY] : dims;
 }
 
 export function groupValue(t: TraceSummary, dimension: string): string {
@@ -27,6 +47,15 @@ export function groupValue(t: TraceSummary, dimension: string): string {
   if (dimension === "service.name") return t.rootServiceName;
   const v = t.rootAttributes[dimension];
   return v === undefined ? NOT_SET : String(v);
+}
+
+export function groupKey(t: TraceSummary, dimensions: string[]): string {
+  return dimensions.map((d) => groupValue(t, d)).join(KEY_SEP);
+}
+
+/** Human form of a group key or values list. */
+export function groupLabel(key: string): string {
+  return key.split(KEY_SEP).join(" · ");
 }
 
 /** Nearest-rank percentile over an ascending-sorted array. */
@@ -37,37 +66,38 @@ function percentile(sorted: number[], p: number): number {
 
 export function groupTraces(
   traces: TraceSummary[],
-  dimension: string,
+  dimensions: string[],
 ): TraceGroup[] {
-  const byValue = new Map<string, TraceSummary[]>();
+  const byKey = new Map<string, TraceSummary[]>();
   for (const t of traces) {
-    const value = groupValue(t, dimension);
-    const bucket = byValue.get(value);
+    const key = groupKey(t, dimensions);
+    const bucket = byKey.get(key);
     if (bucket) bucket.push(t);
-    else byValue.set(value, [t]);
+    else byKey.set(key, [t]);
   }
-  const groups = [...byValue.entries()].map(([value, members]): TraceGroup => {
+  const groups = [...byKey.entries()].map(([key, members]): TraceGroup => {
     const sorted = [...members].sort((a, b) =>
       BigInt(a.startNs) < BigInt(b.startNs) ? 1 : -1,
     );
     const durations = members.map((t) => t.durationMs).sort((a, b) => a - b);
     return {
-      value,
+      key,
+      values: key.split(KEY_SEP),
       traces: sorted,
       services: [...new Set(members.map((t) => t.rootServiceName))].sort(),
+      errorCount: members.filter((t) => t.rootError).length,
       p50Ms: percentile(durations, 0.5),
       p95Ms: percentile(durations, 0.95),
       lastStartNs: sorted[0]?.startNs ?? "0",
     };
   });
   return groups.sort(
-    (a, b) =>
-      b.traces.length - a.traces.length || a.value.localeCompare(b.value),
+    (a, b) => b.traces.length - a.traces.length || a.key.localeCompare(b.key),
   );
 }
 
 /**
- * Dimensions offered by the picker: the built-ins plus every attribute key
+ * Dimensions offered by the pickers: the built-ins plus every attribute key
  * observed on a root span (resource attributes arrive prefixed "resource.").
  */
 export function groupDimensions(traces: TraceSummary[]): string[] {
@@ -76,4 +106,13 @@ export function groupDimensions(traces: TraceSummary[]): string[] {
     for (const key of Object.keys(t.rootAttributes)) attrs.add(key);
   }
   return [...BUILTIN_DIMENSIONS, ...[...attrs].sort()];
+}
+
+/** Trace throughput over the queried range, in the unit that stays >= 1. */
+export function formatRate(count: number, rangeSeconds: number): string {
+  const perSec = count / rangeSeconds;
+  const fmt = (v: number) => String(Number(v.toFixed(1)));
+  if (perSec >= 1) return `${fmt(perSec)}/s`;
+  if (perSec * 60 >= 1) return `${fmt(perSec * 60)}/min`;
+  return `${fmt(perSec * 3600)}/h`;
 }

--- a/src/ui/src/lib/urlState.test.ts
+++ b/src/ui/src/lib/urlState.test.ts
@@ -53,11 +53,20 @@ describe("buildSearch", () => {
       limit: 1000,
       live: true,
       trace: "deadbeef",
+      group: "POST /checkout",
+      groupBy: "resource.host.name",
       promql: "rate(x[5m])",
       tenant: "acme",
       dataset: "production",
     };
     expect(parseExploreState(buildSearch(state))).toEqual(state);
+  });
+
+  it("omits the groupBy param for the default dimension", () => {
+    expect(buildSearch({ ...DEFAULT_STATE, signal: "traces" })).not.toContain(
+      "groupBy",
+    );
+    expect(parseExploreState("").groupBy).toBe("span.name");
   });
 
   it("omits tenant params for the ambient default context", () => {

--- a/src/ui/src/lib/urlState.ts
+++ b/src/ui/src/lib/urlState.ts
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { filterFromParam, filterToParam, type LabelFilter } from "./filters";
+import { DEFAULT_GROUP_BY } from "./traceGroups";
 import {
   DEFAULT_RANGE,
   parseRangeParam,
@@ -22,6 +23,10 @@ export interface ExploreState {
   live: boolean;
   /** Selected trace id — opens the trace view. */
   trace: string;
+  /** Selected trace group value — dives into that group's trace list. */
+  group: string;
+  /** Trace grouping dimension: "span.name", "service.name", or an attribute key. */
+  groupBy: string;
   /** PromQL expression for the metrics view. */
   promql: string;
   /**
@@ -41,6 +46,8 @@ export const DEFAULT_STATE: ExploreState = {
   limit: 500,
   live: false,
   trace: "",
+  group: "",
+  groupBy: DEFAULT_GROUP_BY,
   promql: "",
   tenant: "",
   dataset: "",
@@ -67,6 +74,8 @@ export function parseExploreState(search: string): ExploreState {
     limit: Number.isFinite(limit) && limit > 0 ? Math.min(limit, 5000) : 500,
     live: p.get("live") === "1",
     trace: p.get("trace") ?? "",
+    group: p.get("group") ?? "",
+    groupBy: p.get("groupBy") || DEFAULT_GROUP_BY,
     promql: p.get("promql") ?? "",
     tenant: p.get("tenant") ?? "",
     dataset: p.get("dataset") ?? "",
@@ -84,6 +93,8 @@ export function buildSearch(state: ExploreState): string {
   if (state.limit !== 500) p.set("limit", String(state.limit));
   if (state.live) p.set("live", "1");
   if (state.trace) p.set("trace", state.trace);
+  if (state.group) p.set("group", state.group);
+  if (state.groupBy !== DEFAULT_GROUP_BY) p.set("groupBy", state.groupBy);
   if (state.promql) p.set("promql", state.promql);
   if (state.tenant) p.set("tenant", state.tenant);
   if (state.dataset) p.set("dataset", state.dataset);


### PR DESCRIPTION
## Summary

The traces landing screen in the explore UI now shows **groups of traces** instead of a flat list, with drill-in:

- **Group list** — traces grouped by root span name by default, showing Services, Traces, **Rate** (throughput over the queried range), **Errors** (% of traces with an errored root span), **P50/P95** latency, and Last seen.
- **Selectable dimensions** — "Group by" + optional "Then by" pickers: `span.name` (default), `service.name`, or any attribute observed on root spans (resource attributes arrive prefixed `resource.`). Two dimensions distinguish same-named operations across services.
- **Drill-in** — selecting a group shows just its traces; selecting a trace opens the existing waterfall. `group` and `groupBy` are URL params, so every level is deep-linkable and back-navigable.
- **Sortable columns** in both tables (strings ascend first, metrics descend, timestamps newest-first; `aria-sort` + arrow on the active column).
- Client-side change only: grouping runs over the existing `/tempo/api/search` response. `TraceSummary` gained `rootAttributes`/`rootError`, and an all-zero OTLP `parentSpanID` is now normalized to null for root detection.

## Verification

- TDD: 169 vitest tests (67 new/updated), tsc + eslint clean, production build OK.
- Exercised end-to-end in a browser against a live local stack (`run-dev.sh` + OTLP-HTTP ingest of attributed traces): group list → dimension switch → two-dimension split → composite drill-in → waterfall → back chain.

## Backend findings (out of scope here, issues to follow)

1. Spans ingested **with** span/resource attributes come back `attributes: {}` from both `/tempo/api/search` and `/tempo/api/traces/{id}` — the drop is write-side or in the querier projection. Until fixed, the dimension pickers only offer the two built-ins on real deployments; the UI picks attribute dimensions up automatically once the backend returns them.
2. OTLP `status.code: 1` (OK) maps to `status: "error"` on the read path, inflating the error-rate column.