### PR TITLE
feat(ui): metrics explore visual query builder

### DIFF
--- a/docs/users/explore-ui.md
+++ b/docs/users/explore-ui.md
@@ -29,7 +29,10 @@ visible in the UI is equally queryable from Grafana.
   all sortable. Selecting a group lists just its traces; selecting a trace
   opens a waterfall with span details and error highlighting. Open-by-ID
   works from any level.
-- **Metrics** — a PromQL box charting range queries.
+- **Metrics** — a visual query builder (metric picker, tag filters,
+  aggregation, and range functions, all populated from label metadata) with
+  multi-query formulas for ratios, plus a "PromQL" tab as the raw escape
+  hatch. See [Building metric queries](#building-metric-queries).
 - **Correlation** — log rows with a `trace_id` open the trace waterfall;
   the span panel links back to logs filtered by that trace.
 - Every view is a URL: time range, filters, and selection live in query
@@ -38,6 +41,50 @@ visible in the UI is equally queryable from Grafana.
 ![Explore UI trace waterfall with span details and a link to correlated logs](../assets/screenshots/explore-traces.png)
 
 ![Explore UI metrics view charting a PromQL range query across two services](../assets/screenshots/explore-metrics.png)
+
+## Building metric queries
+
+The metrics view opens on a **visual builder** so you don't have to hand-write
+PromQL. A query row reads left to right as a sentence:
+
+```
+[ a ]  metric ▾   from ⟨ filters ⟩   avg by ⟨ group ⟩   function ▾
+```
+
+- **Metric** — type or pick a metric name; suggestions come from the
+  Prometheus `__name__` label for the current time range.
+- **from** — add tag filters (`+ filter`). Label names and their values are
+  suggested from the metadata endpoints, so you filter on what exists rather
+  than guessing. Each filter has an operator (`=`, `!=`, `=~`, `!~`).
+- **aggregation** — choose a space aggregation (`sum`/`avg`/`min`/`max`/
+  `count`) and an optional comma-separated **group by** to get one series per
+  tag value.
+- **function** — an optional range function (`rate`, `irate`, `increase`, or
+  an `*_over_time` rollup) with a lookback window (default `5m`).
+
+A live preview shows the compiled PromQL beneath the row; **Run** charts it.
+
+### Formulas across multiple queries
+
+Add more rows with **+ query** — each gets a letter (`a`, `b`, …) — and combine
+them in the **formula** box. Single letters are substituted with each query's
+compiled expression, so a ratio like an error rate is:
+
+```
+formula:  (a / b) * 100
+```
+
+with `a` = `sum(rate(http_server_errors[1m]))` and `b` =
+`sum(rate(http_server_requests[1m]))`. PromQL function names are left
+untouched. With no formula, the first row is charted on its own.
+
+### Editing the raw PromQL
+
+The **PromQL** tab is the escape hatch for anything the builder doesn't cover.
+Switching to it seeds the box with the query the builder compiled, so you can
+start visually and finish by hand. (Editing raw PromQL back into the builder
+is not supported yet.) The same PromQL runs unchanged in Grafana or against
+the [`/prometheus/api/v1` endpoints](querying-promql.md).
 
 ## Signing in
 

--- a/src/ui/src/api/prom.test.ts
+++ b/src/ui/src/api/prom.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { promQueryRange, seriesName } from "./prom";
+import {
+  promLabelNames,
+  promLabelValues,
+  promMetricNames,
+  promQueryRange,
+  seriesName,
+} from "./prom";
 
 const RANGE = { fromMs: 1_000_000, toMs: 2_000_000 };
 
@@ -88,5 +94,44 @@ describe("seriesName", () => {
     expect(seriesName({ __name__: "up" })).toBe("up");
     expect(seriesName({})).toBe("value");
     expect(seriesName({ a: "1" })).toBe('{a="1"}');
+  });
+});
+
+describe("metadata pickers", () => {
+  it("promLabelNames returns the data array and sends the window", async () => {
+    const fn = mockFetchOnce({ status: "success", data: ["service", "host"] });
+    await expect(promLabelNames(RANGE)).resolves.toEqual(["service", "host"]);
+    const url = String(fn.mock.calls[0]?.[0]);
+    expect(url).toContain("/prometheus/api/v1/labels?");
+    expect(url).toContain("start=1000");
+    expect(url).toContain("end=2000");
+  });
+
+  it("promLabelValues encodes the label name in the path", async () => {
+    const fn = mockFetchOnce({ status: "success", data: ["checkout"] });
+    await expect(promLabelValues("k8s.pod", RANGE)).resolves.toEqual([
+      "checkout",
+    ]);
+    expect(String(fn.mock.calls[0]?.[0])).toContain(
+      "/prometheus/api/v1/label/k8s.pod/values?",
+    );
+  });
+
+  it("promMetricNames queries the reserved __name__ label", async () => {
+    const fn = mockFetchOnce({ status: "success", data: ["up", "http_reqs"] });
+    await expect(promMetricNames(RANGE)).resolves.toEqual(["up", "http_reqs"]);
+    expect(String(fn.mock.calls[0]?.[0])).toContain(
+      "/prometheus/api/v1/label/__name__/values?",
+    );
+  });
+
+  it("defaults to an empty list when data is absent", async () => {
+    mockFetchOnce({ status: "success" });
+    await expect(promLabelNames(RANGE)).resolves.toEqual([]);
+  });
+
+  it("throws on HTTP failure", async () => {
+    mockFetchOnce("nope", 503);
+    await expect(promLabelNames(RANGE)).rejects.toThrow(/\(503\)/);
   });
 });

--- a/src/ui/src/api/prom.ts
+++ b/src/ui/src/api/prom.ts
@@ -63,3 +63,56 @@ export function seriesName(labels: Record<string, string>): string {
   if (pairs.length === 0) return name ?? "value";
   return `${name ?? ""}{${pairs.join(", ")}}`;
 }
+
+// ---- metadata (feeds the visual builder's metric/label/value pickers) ----
+
+interface PromMetadataResponse {
+  status: string;
+  data?: string[];
+  error?: string;
+}
+
+async function promMetadata(
+  path: string,
+  range: ResolvedRange,
+  extra?: Record<string, string>,
+): Promise<string[]> {
+  const params = new URLSearchParams({
+    start: String(range.fromMs / 1000),
+    end: String(range.toMs / 1000),
+    ...extra,
+  });
+  const res = await fetch(`/prometheus/api/v1/${path}?${params}`, {
+    headers: tenantHeaders(),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ApiError(
+      `Prometheus ${path} failed (${res.status}): ${body.slice(0, 300)}`,
+      res.status,
+    );
+  }
+  const json = (await res.json()) as PromMetadataResponse;
+  if (json.status !== "success") {
+    throw new Error(`Prometheus ${path} failed: ${json.error ?? json.status}`);
+  }
+  return json.data ?? [];
+}
+
+/** Label names available for filtering/grouping in the current window. */
+export function promLabelNames(range: ResolvedRange): Promise<string[]> {
+  return promMetadata("labels", range);
+}
+
+/** Distinct values of a single label. */
+export function promLabelValues(
+  label: string,
+  range: ResolvedRange,
+): Promise<string[]> {
+  return promMetadata(`label/${encodeURIComponent(label)}/values`, range);
+}
+
+/** Metric names — the distinct values of the reserved `__name__` label. */
+export function promMetricNames(range: ResolvedRange): Promise<string[]> {
+  return promLabelValues("__name__", range);
+}

--- a/src/ui/src/features/metrics/MetricsView.test.tsx
+++ b/src/ui/src/features/metrics/MetricsView.test.tsx
@@ -76,6 +76,31 @@ describe("MetricsView", () => {
     expect(update).toHaveBeenCalledWith({ promql: "up" });
   });
 
+  it("runs a two-query formula as a single composed expression", async () => {
+    stubFetchRoutes([
+      {
+        match: /label\/__name__\/values/,
+        body: { status: "success", data: [] },
+      },
+      { match: /\/labels\?/, body: { status: "success", data: [] } },
+      { match: "query_range", body: MATRIX },
+    ]);
+    const update = renderView();
+
+    const metricA = screen.getByLabelText("Metric");
+    await userEvent.type(metricA, "http_errors");
+    await userEvent.click(screen.getByRole("button", { name: "+ query" }));
+
+    const metricB = screen.getAllByLabelText("Metric")[1]!;
+    await userEvent.type(metricB, "http_total");
+    await userEvent.type(screen.getByLabelText("Formula"), "(a / b) * 100");
+
+    await userEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(update).toHaveBeenCalledWith({
+      promql: "((http_errors) / (http_total)) * 100",
+    });
+  });
+
   it("renders the chart and a legend entry per series", async () => {
     stubFetchRoutes([{ match: "query_range", body: MATRIX }]);
     renderView({ promql: "up" });

--- a/src/ui/src/features/metrics/MetricsView.test.tsx
+++ b/src/ui/src/features/metrics/MetricsView.test.tsx
@@ -47,14 +47,31 @@ function renderView(state: Partial<ExploreState> = {}) {
 
 describe("MetricsView", () => {
   it("prompts for a query when none is set", () => {
+    stubFetchRoutes([{ match: "query_range", body: MATRIX }]);
     renderView();
-    expect(screen.getByText(/Enter a PromQL expression/)).toBeInTheDocument();
+    expect(screen.getByText(/Build a query above/)).toBeInTheDocument();
   });
 
-  it("submits the drafted query via update", async () => {
+  it("submits a raw query from the PromQL escape hatch", async () => {
     stubFetchRoutes([{ match: "query_range", body: MATRIX }]);
     const update = renderView();
+    await userEvent.click(screen.getByRole("tab", { name: "PromQL" }));
     await userEvent.type(screen.getByLabelText("PromQL query"), "up ");
+    await userEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(update).toHaveBeenCalledWith({ promql: "up" });
+  });
+
+  it("runs the compiled query built in the visual builder", async () => {
+    stubFetchRoutes([
+      {
+        match: /label\/__name__\/values/,
+        body: { status: "success", data: [] },
+      },
+      { match: /\/labels\?/, body: { status: "success", data: [] } },
+      { match: "query_range", body: MATRIX },
+    ]);
+    const update = renderView();
+    await userEvent.type(screen.getByLabelText("Metric"), "up");
     await userEvent.click(screen.getByRole("button", { name: "Run" }));
     expect(update).toHaveBeenCalledWith({ promql: "up" });
   });

--- a/src/ui/src/features/metrics/MetricsView.tsx
+++ b/src/ui/src/features/metrics/MetricsView.tsx
@@ -9,7 +9,12 @@ import {
 } from "../../lib/time";
 import type { ExploreState } from "../../lib/urlState";
 import { seriesColorVar } from "../../lib/promSeries";
-import { buildPromQL, emptyQuery, type MetricQuery } from "./buildPromQL";
+import {
+  buildFormula,
+  emptyQuery,
+  nextRef,
+  type MetricQuery,
+} from "./buildPromQL";
 import { MetricsChart } from "./MetricsChart";
 import { QueryRow } from "./QueryRow";
 import "./metrics.css";
@@ -23,7 +28,10 @@ type Mode = "builder" | "promql";
 
 export function MetricsView({ state, update }: Props) {
   const [mode, setMode] = useState<Mode>("builder");
-  const [query, setQuery] = useState<MetricQuery>(() => emptyQuery("a"));
+  const [queries, setQueries] = useState<MetricQuery[]>(() => [
+    emptyQuery("a"),
+  ]);
+  const [formula, setFormula] = useState("");
   const [draft, setDraft] = useState(state.promql);
 
   const rangeParam = rangeToParam(state.range);
@@ -37,8 +45,14 @@ export function MetricsView({ state, update }: Props) {
     [rangeKey],
   );
 
-  const compiled = buildPromQL(query);
+  const compiled = buildFormula(queries, formula);
   const promql = state.promql;
+
+  const setQuery = (i: number, next: MetricQuery) =>
+    setQueries((qs) => qs.map((old, j) => (j === i ? next : old)));
+  const addQuery = () => setQueries((qs) => [...qs, emptyQuery(nextRef(qs))]);
+  const removeQuery = (i: number) =>
+    setQueries((qs) => (qs.length > 1 ? qs.filter((_, j) => j !== i) : qs));
 
   const chart = useQuery({
     queryKey: ["prom-range", promql, rangeKey],
@@ -87,7 +101,42 @@ export function MetricsView({ state, update }: Props) {
 
       {mode === "builder" ? (
         <div className="metrics-builder">
-          <QueryRow query={query} range={metaRange} onChange={setQuery} />
+          {queries.map((q, i) => (
+            <div className="builder-query" key={q.ref}>
+              <QueryRow
+                query={q}
+                range={metaRange}
+                onChange={(next) => setQuery(i, next)}
+              />
+              {queries.length > 1 && (
+                <button
+                  type="button"
+                  className="query-remove"
+                  aria-label={`Remove query ${q.ref}`}
+                  onClick={() => removeQuery(i)}
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          ))}
+
+          <div className="builder-formula">
+            <button type="button" className="qrow-add" onClick={addQuery}>
+              + query
+            </button>
+            <span className="formula-ref" aria-hidden>
+              ƒ
+            </span>
+            <input
+              className="formula-input"
+              aria-label="Formula"
+              placeholder="formula, e.g. (a / b) * 100 — optional"
+              value={formula}
+              onChange={(e) => setFormula(e.target.value)}
+            />
+          </div>
+
           <div className="builder-run">
             <code className="builder-preview">
               {compiled || "pick a metric to start"}

--- a/src/ui/src/features/metrics/MetricsView.tsx
+++ b/src/ui/src/features/metrics/MetricsView.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { promQueryRange, seriesName } from "../../api/prom";
 import {
   durationToSeconds,
@@ -9,7 +9,9 @@ import {
 } from "../../lib/time";
 import type { ExploreState } from "../../lib/urlState";
 import { seriesColorVar } from "../../lib/promSeries";
+import { buildPromQL, emptyQuery, type MetricQuery } from "./buildPromQL";
 import { MetricsChart } from "./MetricsChart";
+import { QueryRow } from "./QueryRow";
 import "./metrics.css";
 
 interface Props {
@@ -17,12 +19,28 @@ interface Props {
   update: (patch: Partial<ExploreState>) => void;
 }
 
+type Mode = "builder" | "promql";
+
 export function MetricsView({ state, update }: Props) {
+  const [mode, setMode] = useState<Mode>("builder");
+  const [query, setQuery] = useState<MetricQuery>(() => emptyQuery("a"));
   const [draft, setDraft] = useState(state.promql);
-  const rangeKey = `${rangeToParam(state.range)}|${state.tenant}|${state.dataset}`;
+
+  const rangeParam = rangeToParam(state.range);
+  const rangeKey = `${rangeParam}|${state.tenant}|${state.dataset}`;
+  // Freeze the resolved window per range selection so metadata pickers don't
+  // refetch on every render (relative ranges resolve to a shifting "now").
+  // Keyed on rangeKey rather than state.range so the window only moves when
+  // the user changes the range or tenant/dataset.
+  const metaRange = useMemo(
+    () => resolveRange(state.range, Date.now()),
+    [rangeKey],
+  );
+
+  const compiled = buildPromQL(query);
   const promql = state.promql;
 
-  const query = useQuery({
+  const chart = useQuery({
     queryKey: ["prom-range", promql, rangeKey],
     queryFn: () => {
       const range = resolveRange(state.range, Date.now());
@@ -33,48 +51,98 @@ export function MetricsView({ state, update }: Props) {
     refetchInterval: state.live ? 15_000 : false,
   });
 
+  const run = (q: string) => update({ promql: q.trim() });
+
+  const switchMode = (next: Mode) => {
+    // Builder → PromQL seeds the text box with the compiled query so the raw
+    // editor is the escape hatch. There is no PromQL → builder parse yet.
+    if (next === "promql" && mode === "builder" && compiled !== "") {
+      setDraft(compiled);
+    }
+    setMode(next);
+  };
+
   return (
     <div className="metricsview">
-      <form
-        className="promql-form"
-        onSubmit={(e) => {
-          e.preventDefault();
-          update({ promql: draft.trim() });
-        }}
-      >
-        <input
-          aria-label="PromQL query"
-          className="promql-input"
-          placeholder="PromQL, e.g. rate(http_server_duration_count[5m])"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-        />
-        <button type="submit">Run</button>
-      </form>
+      <div className="metrics-modes" role="tablist" aria-label="Query editor">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "builder"}
+          className={mode === "builder" ? "active" : ""}
+          onClick={() => switchMode("builder")}
+        >
+          Builder
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "promql"}
+          className={mode === "promql" ? "active" : ""}
+          onClick={() => switchMode("promql")}
+        >
+          PromQL
+        </button>
+      </div>
+
+      {mode === "builder" ? (
+        <div className="metrics-builder">
+          <QueryRow query={query} range={metaRange} onChange={setQuery} />
+          <div className="builder-run">
+            <code className="builder-preview">
+              {compiled || "pick a metric to start"}
+            </code>
+            <button
+              type="button"
+              disabled={compiled === ""}
+              onClick={() => run(compiled)}
+            >
+              Run
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form
+          className="promql-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            run(draft);
+          }}
+        >
+          <input
+            aria-label="PromQL query"
+            className="promql-input"
+            placeholder="PromQL, e.g. rate(http_server_duration_count[5m])"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <button type="submit">Run</button>
+        </form>
+      )}
 
       {promql === "" && (
         <div className="metrics-note">
-          Enter a PromQL expression to chart metrics.
+          Build a query above, or switch to PromQL, then Run to chart metrics.
         </div>
       )}
-      {query.isError && (
+      {chart.isError && (
         <div className="query-error" role="alert">
-          Query failed: {(query.error as Error).message}
+          Query failed: {(chart.error as Error).message}
         </div>
       )}
-      {query.isFetching && !query.data && (
+      {chart.isFetching && !chart.data && (
         <div className="metrics-note">Loading…</div>
       )}
-      {query.data && query.data.length === 0 && (
+      {chart.data && chart.data.length === 0 && (
         <div className="metrics-note">No series returned.</div>
       )}
-      {query.data && query.data.length > 0 && (
+      {chart.data && chart.data.length > 0 && (
         <>
           <div className="mchart-wrap">
-            <MetricsChart series={query.data} />
+            <MetricsChart series={chart.data} />
           </div>
           <ul className="mlegend" aria-label="Series">
-            {query.data.map((s, i) => (
+            {chart.data.map((s, i) => (
               <li key={seriesName(s.labels)}>
                 <i style={{ background: seriesColorVar(i) }} />
                 {seriesName(s.labels)}

--- a/src/ui/src/features/metrics/QueryRow.test.tsx
+++ b/src/ui/src/features/metrics/QueryRow.test.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithClient, stubFetchRoutes } from "../../test/render";
+import { buildPromQL, emptyQuery, type MetricQuery } from "./buildPromQL";
+import { QueryRow } from "./QueryRow";
+
+const RANGE = { fromMs: 1_000_000, toMs: 2_000_000 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** QueryRow is controlled; hold its state and surface the compiled PromQL. */
+function Harness() {
+  const [query, setQuery] = useState<MetricQuery>(emptyQuery("a"));
+  return (
+    <>
+      <QueryRow query={query} range={RANGE} onChange={setQuery} />
+      <output data-testid="promql">{buildPromQL(query)}</output>
+    </>
+  );
+}
+
+function stubMetadata() {
+  stubFetchRoutes([
+    { match: /label\/__name__\/values/, body: metaBody(["http_reqs", "up"]) },
+    { match: /\/labels\?/, body: metaBody(["service", "host"]) },
+    { match: /label\/service\/values/, body: metaBody(["checkout"]) },
+  ]);
+}
+
+const metaBody = (data: string[]) => ({ status: "success", data });
+const promql = () => screen.getByTestId("promql").textContent;
+
+describe("QueryRow", () => {
+  it("builds a query step by step from the visual controls", async () => {
+    stubMetadata();
+    renderWithClient(<Harness />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText("Metric"), "http_reqs");
+    expect(promql()).toBe("http_reqs");
+
+    await user.click(screen.getByRole("button", { name: "Add filter" }));
+    await user.type(screen.getByLabelText("Filter label"), "service");
+    await user.type(screen.getByLabelText("Filter value"), "checkout");
+    expect(promql()).toBe('http_reqs{service="checkout"}');
+
+    await user.selectOptions(screen.getByLabelText("Aggregation"), "sum");
+    await user.type(screen.getByLabelText("Group by"), "service");
+    expect(promql()).toBe('sum by (service)(http_reqs{service="checkout"})');
+
+    await user.selectOptions(screen.getByLabelText("Function"), "rate");
+    expect(promql()).toBe(
+      'sum by (service)(rate(http_reqs{service="checkout"}[5m]))',
+    );
+  });
+
+  it("removing a filter drops it from the query", async () => {
+    stubMetadata();
+    renderWithClient(<Harness />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText("Metric"), "up");
+    await user.click(screen.getByRole("button", { name: "Add filter" }));
+    await user.type(screen.getByLabelText("Filter label"), "service");
+    await user.type(screen.getByLabelText("Filter value"), "checkout");
+    expect(promql()).toBe('up{service="checkout"}');
+
+    await user.click(screen.getByRole("button", { name: "Remove filter" }));
+    expect(promql()).toBe("up");
+  });
+
+  it("populates the metric picker from the __name__ endpoint", async () => {
+    stubMetadata();
+    renderWithClient(<Harness />);
+    // Datalist <option>s aren't exposed as ARIA options; assert via the DOM.
+    await waitFor(() =>
+      expect(
+        document.querySelector('datalist option[value="http_reqs"]'),
+      ).not.toBeNull(),
+    );
+  });
+});

--- a/src/ui/src/features/metrics/QueryRow.tsx
+++ b/src/ui/src/features/metrics/QueryRow.tsx
@@ -1,0 +1,252 @@
+// The visual metric-query builder row: metric · from · agg by · function.
+// Each control is populated from the Prometheus metadata endpoints so filters
+// and group-by are pick-from-what-exists rather than typed blind. State is a
+// MetricQuery (see buildPromQL); the row is fully controlled via onChange.
+
+import { useId } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  promLabelNames,
+  promLabelValues,
+  promMetricNames,
+} from "../../api/prom";
+import { FILTER_OPS, type LabelFilter } from "../../lib/filters";
+import type { ResolvedRange } from "../../lib/time";
+import {
+  RANGE_FNS,
+  SPACE_AGGS,
+  type MetricQuery,
+  type RangeFn,
+  type SpaceAgg,
+} from "./buildPromQL";
+
+interface Props {
+  query: MetricQuery;
+  range: ResolvedRange;
+  onChange: (next: MetricQuery) => void;
+}
+
+const rangeKey = (range: ResolvedRange) => `${range.fromMs}-${range.toMs}`;
+
+export function QueryRow({ query, range, onChange }: Props) {
+  const metricList = useId();
+  const labelList = useId();
+
+  const metricNames = useQuery({
+    queryKey: ["prom-metric-names", rangeKey(range)],
+    queryFn: () => promMetricNames(range),
+    staleTime: 60_000,
+  });
+  const labelNames = useQuery({
+    queryKey: ["prom-label-names", rangeKey(range)],
+    queryFn: () => promLabelNames(range),
+    staleTime: 60_000,
+  });
+
+  const patch = (p: Partial<MetricQuery>) => onChange({ ...query, ...p });
+
+  const setFilter = (i: number, f: LabelFilter) =>
+    patch({ filters: query.filters.map((old, j) => (j === i ? f : old)) });
+  const addFilter = () =>
+    patch({ filters: [...query.filters, { label: "", op: "=", value: "" }] });
+  const removeFilter = (i: number) =>
+    patch({ filters: query.filters.filter((_, j) => j !== i) });
+
+  return (
+    <div className="qrow">
+      <datalist id={metricList}>
+        {(metricNames.data ?? []).map((m) => (
+          <option key={m} value={m} />
+        ))}
+      </datalist>
+      <datalist id={labelList}>
+        {(labelNames.data ?? []).map((l) => (
+          <option key={l} value={l} />
+        ))}
+      </datalist>
+
+      <span className="qrow-ref" aria-hidden>
+        {query.ref}
+      </span>
+
+      <input
+        className="qrow-metric"
+        aria-label="Metric"
+        list={metricList}
+        placeholder="metric"
+        value={query.metric}
+        onChange={(e) => patch({ metric: e.target.value })}
+      />
+
+      <span className="qrow-kw">from</span>
+      <div className="qrow-filters">
+        {query.filters.map((f, i) => (
+          <FilterEditor
+            key={i}
+            filter={f}
+            labelListId={labelList}
+            range={range}
+            onChange={(next) => setFilter(i, next)}
+            onRemove={() => removeFilter(i)}
+          />
+        ))}
+        <button
+          type="button"
+          className="qrow-add"
+          onClick={addFilter}
+          aria-label="Add filter"
+        >
+          + filter
+        </button>
+      </div>
+
+      <select
+        className="qrow-agg"
+        aria-label="Aggregation"
+        value={query.agg?.op ?? ""}
+        onChange={(e) =>
+          patch({
+            agg: e.target.value
+              ? { op: e.target.value as SpaceAgg, by: query.agg?.by ?? [] }
+              : undefined,
+          })
+        }
+      >
+        <option value="">no aggregation</option>
+        {SPACE_AGGS.map((op) => (
+          <option key={op} value={op}>
+            {op} by
+          </option>
+        ))}
+      </select>
+      {query.agg && (
+        <input
+          className="qrow-groupby"
+          aria-label="Group by"
+          list={labelList}
+          placeholder="group by (comma-separated)"
+          value={query.agg.by.join(", ")}
+          onChange={(e) =>
+            patch({
+              agg: {
+                op: query.agg?.op ?? "sum",
+                by: e.target.value
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter((s) => s !== ""),
+              },
+            })
+          }
+        />
+      )}
+
+      <select
+        className="qrow-fn"
+        aria-label="Function"
+        value={query.range?.fn ?? ""}
+        onChange={(e) =>
+          patch({
+            range: e.target.value
+              ? {
+                  fn: e.target.value as RangeFn,
+                  window: query.range?.window ?? "5m",
+                }
+              : undefined,
+          })
+        }
+      >
+        <option value="">no function</option>
+        {RANGE_FNS.map((fn) => (
+          <option key={fn} value={fn}>
+            {fn}
+          </option>
+        ))}
+      </select>
+      {query.range && (
+        <input
+          className="qrow-window"
+          aria-label="Window"
+          placeholder="5m"
+          value={query.range.window}
+          onChange={(e) =>
+            patch({
+              range: { fn: query.range?.fn ?? "rate", window: e.target.value },
+            })
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+interface FilterProps {
+  filter: LabelFilter;
+  labelListId: string;
+  range: ResolvedRange;
+  onChange: (f: LabelFilter) => void;
+  onRemove: () => void;
+}
+
+function FilterEditor({
+  filter,
+  labelListId,
+  range,
+  onChange,
+  onRemove,
+}: FilterProps) {
+  const valueList = useId();
+  const values = useQuery({
+    queryKey: ["prom-label-values", filter.label, rangeKey(range)],
+    queryFn: () => promLabelValues(filter.label, range),
+    enabled: filter.label !== "",
+    staleTime: 60_000,
+  });
+
+  return (
+    <span className="qrow-filter">
+      <input
+        className="qrow-filter-label"
+        aria-label="Filter label"
+        list={labelListId}
+        placeholder="label"
+        value={filter.label}
+        onChange={(e) => onChange({ ...filter, label: e.target.value })}
+      />
+      <select
+        className="qrow-filter-op"
+        aria-label="Filter operator"
+        value={filter.op}
+        onChange={(e) =>
+          onChange({ ...filter, op: e.target.value as LabelFilter["op"] })
+        }
+      >
+        {FILTER_OPS.map((op) => (
+          <option key={op} value={op}>
+            {op}
+          </option>
+        ))}
+      </select>
+      <datalist id={valueList}>
+        {(values.data ?? []).map((v) => (
+          <option key={v} value={v} />
+        ))}
+      </datalist>
+      <input
+        className="qrow-filter-value"
+        aria-label="Filter value"
+        list={valueList}
+        placeholder="value"
+        value={filter.value}
+        onChange={(e) => onChange({ ...filter, value: e.target.value })}
+      />
+      <button
+        type="button"
+        className="qrow-filter-remove"
+        onClick={onRemove}
+        aria-label="Remove filter"
+      >
+        ✕
+      </button>
+    </span>
+  );
+}

--- a/src/ui/src/features/metrics/buildPromQL.test.ts
+++ b/src/ui/src/features/metrics/buildPromQL.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { LabelFilter } from "../../lib/filters";
+import {
+  buildPromQL,
+  buildSelector,
+  emptyQuery,
+  type MetricQuery,
+} from "./buildPromQL";
+
+const f = (
+  label: string,
+  op: LabelFilter["op"],
+  value: string,
+): LabelFilter => ({ label, op, value });
+
+const q = (patch: Partial<MetricQuery>): MetricQuery => ({
+  ...emptyQuery("a"),
+  metric: "http_server_duration",
+  ...patch,
+});
+
+describe("buildSelector", () => {
+  it("returns a bare metric with no filters", () => {
+    expect(buildSelector("http_server_duration", [])).toBe(
+      "http_server_duration",
+    );
+  });
+
+  it("compiles matchers for every operator", () => {
+    expect(
+      buildSelector("m", [
+        f("service", "=", "checkout"),
+        f("env", "!=", "dev"),
+        f("host", "=~", "web-.+"),
+        f("route", "!~", "/health"),
+      ]),
+    ).toBe(
+      'm{service="checkout", env!="dev", host=~"web-.+", route!~"/health"}',
+    );
+  });
+
+  it("drops filters with invalid label names", () => {
+    expect(buildSelector("m", [f("bad.label", "=", "x")])).toBe("m");
+  });
+
+  it("escapes quotes and backslashes in values", () => {
+    expect(buildSelector("m", [f("path", "=", 'a"b\\c')])).toBe(
+      'm{path="a\\"b\\\\c"}',
+    );
+  });
+});
+
+describe("buildPromQL", () => {
+  it("returns empty string when no metric is selected", () => {
+    expect(buildPromQL(emptyQuery("a"))).toBe("");
+  });
+
+  it("emits a raw selector for the simplest query", () => {
+    expect(buildPromQL(q({ filters: [f("service", "=", "checkout")] }))).toBe(
+      'http_server_duration{service="checkout"}',
+    );
+  });
+
+  it("wraps a range function around the selector", () => {
+    expect(buildPromQL(q({ range: { fn: "rate", window: "5m" } }))).toBe(
+      "rate(http_server_duration[5m])",
+    );
+  });
+
+  it("supports *_over_time rollups", () => {
+    expect(
+      buildPromQL(
+        q({
+          filters: [f("service", "=", "checkout")],
+          range: { fn: "avg_over_time", window: "1m" },
+        }),
+      ),
+    ).toBe('avg_over_time(http_server_duration{service="checkout"}[1m])');
+  });
+
+  it("applies space aggregation with a group-by clause", () => {
+    expect(buildPromQL(q({ agg: { op: "avg", by: ["service"] } }))).toBe(
+      "avg by (service)(http_server_duration)",
+    );
+  });
+
+  it("aggregates to a single series when group-by is empty", () => {
+    expect(buildPromQL(q({ agg: { op: "sum", by: [] } }))).toBe(
+      "sum(http_server_duration)",
+    );
+  });
+
+  it("composes filter + range function + grouped aggregation (inner→outer)", () => {
+    expect(
+      buildPromQL(
+        q({
+          filters: [f("env", "=", "prod")],
+          range: { fn: "rate", window: "1m" },
+          agg: { op: "sum", by: ["service", "http_status"] },
+        }),
+      ),
+    ).toBe(
+      'sum by (service, http_status)(rate(http_server_duration{env="prod"}[1m]))',
+    );
+  });
+
+  it("ignores invalid group-by labels", () => {
+    expect(
+      buildPromQL(q({ agg: { op: "max", by: ["service", "bad.tag"] } })),
+    ).toBe("max by (service)(http_server_duration)");
+  });
+});

--- a/src/ui/src/features/metrics/buildPromQL.test.ts
+++ b/src/ui/src/features/metrics/buildPromQL.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { LabelFilter } from "../../lib/filters";
 import {
+  buildFormula,
   buildPromQL,
   buildSelector,
   emptyQuery,
+  nextRef,
   type MetricQuery,
 } from "./buildPromQL";
 
@@ -108,5 +110,45 @@ describe("buildPromQL", () => {
     expect(
       buildPromQL(q({ agg: { op: "max", by: ["service", "bad.tag"] } })),
     ).toBe("max by (service)(http_server_duration)");
+  });
+});
+
+describe("nextRef", () => {
+  it("assigns letters in order and skips used ones", () => {
+    expect(nextRef([])).toBe("a");
+    expect(nextRef([emptyQuery("a")])).toBe("b");
+    expect(nextRef([emptyQuery("a"), emptyQuery("c")])).toBe("b");
+  });
+});
+
+describe("buildFormula", () => {
+  const qa = q({ ref: "a", metric: "http_server_duration" });
+  const qb = q({ ref: "b", metric: "http_server_errors" });
+
+  it("charts only the first query when there is no formula", () => {
+    expect(buildFormula([qa, qb], "")).toBe("http_server_duration");
+  });
+
+  it("returns empty when there are no queries", () => {
+    expect(buildFormula([], "")).toBe("");
+  });
+
+  it("substitutes each ref with its parenthesized compilation", () => {
+    expect(buildFormula([qa, qb], "(a / b) * 100")).toBe(
+      "((http_server_duration) / (http_server_errors)) * 100",
+    );
+  });
+
+  it("leaves PromQL function names untouched (multi-char, not refs)", () => {
+    const ra = q({
+      ref: "a",
+      metric: "http_server_duration",
+      range: { fn: "rate", window: "1m" },
+    });
+    expect(buildFormula([ra], "a")).toBe("(rate(http_server_duration[1m]))");
+  });
+
+  it("is not runnable while a referenced query is still empty", () => {
+    expect(buildFormula([qa, emptyQuery("b")], "a / b")).toBe("");
   });
 });

--- a/src/ui/src/features/metrics/buildPromQL.ts
+++ b/src/ui/src/features/metrics/buildPromQL.ts
@@ -1,0 +1,99 @@
+// Structured metric-query model and its PromQL compilation. The visual builder
+// is the primary input; "edit as PromQL" switches to a raw string. The model
+// mirrors the querier's lowering steps (querier/src/query/promql.rs): a bucketed
+// selector, an optional range-vector function (rate/*_over_time), and an
+// optional outer space aggregation with grouping.
+
+import {
+  escapeLogQLString,
+  isValidLabelName,
+  type LabelFilter,
+} from "../../lib/filters";
+
+export type SpaceAgg = "sum" | "avg" | "min" | "max" | "count";
+
+export const SPACE_AGGS: SpaceAgg[] = ["sum", "avg", "min", "max", "count"];
+
+/**
+ * Range-vector functions that turn a step-bucketed selector into a single
+ * value per bucket. `rate`/`irate`/`increase` are counter functions; the
+ * `*_over_time` family are gauge rollups. All take a lookback `window`
+ * (a PromQL duration like `5m`).
+ */
+export type RangeFn =
+  | "rate"
+  | "irate"
+  | "increase"
+  | "avg_over_time"
+  | "min_over_time"
+  | "max_over_time"
+  | "sum_over_time";
+
+export const RANGE_FNS: RangeFn[] = [
+  "rate",
+  "irate",
+  "increase",
+  "avg_over_time",
+  "min_over_time",
+  "max_over_time",
+  "sum_over_time",
+];
+
+export interface RangeFnSpec {
+  fn: RangeFn;
+  /** PromQL duration, e.g. "5m". */
+  window: string;
+}
+
+export interface SpaceAggSpec {
+  op: SpaceAgg;
+  /** Group-by labels; empty aggregates every series into one. */
+  by: string[];
+}
+
+export interface MetricQuery {
+  /** Query letter (a, b, …) — display/formula reference, not part of PromQL. */
+  ref: string;
+  /** Prometheus metric name (already sanitized, from /labels __name__). */
+  metric: string;
+  filters: LabelFilter[];
+  /** Optional range-vector function applied to the raw selector. */
+  range?: RangeFnSpec;
+  /** Optional space aggregation applied outermost. */
+  agg?: SpaceAggSpec;
+}
+
+export function emptyQuery(ref: string): MetricQuery {
+  return { ref, metric: "", filters: [] };
+}
+
+/** `metric{label=~"…", …}` — or bare `metric` when there are no valid filters. */
+export function buildSelector(metric: string, filters: LabelFilter[]): string {
+  const matchers = filters
+    .filter((f) => isValidLabelName(f.label))
+    .map((f) => `${f.label}${f.op}"${escapeLogQLString(f.value)}"`);
+  if (matchers.length === 0) return metric;
+  return `${metric}{${matchers.join(", ")}}`;
+}
+
+/**
+ * Compile a structured metric query to PromQL. Returns "" when no metric is
+ * selected yet, so callers can gate the chart query on a non-empty result.
+ */
+export function buildPromQL(q: MetricQuery): string {
+  if (q.metric.trim() === "") return "";
+
+  let expr = buildSelector(q.metric, q.filters);
+
+  if (q.range) {
+    expr = `${q.range.fn}(${expr}[${q.range.window}])`;
+  }
+
+  if (q.agg) {
+    const by = q.agg.by.filter(isValidLabelName);
+    const grouping = by.length > 0 ? ` by (${by.join(", ")})` : "";
+    expr = `${q.agg.op}${grouping}(${expr})`;
+  }
+
+  return expr;
+}

--- a/src/ui/src/features/metrics/buildPromQL.ts
+++ b/src/ui/src/features/metrics/buildPromQL.ts
@@ -97,3 +97,45 @@ export function buildPromQL(q: MetricQuery): string {
 
   return expr;
 }
+
+/** The reference letters a query can take, in assignment order. */
+export const QUERY_REFS = "abcdefghij".split("");
+
+/** Next unused ref letter for a set of queries (falls back to "a"). */
+export function nextRef(queries: MetricQuery[]): string {
+  const used = new Set(queries.map((q) => q.ref));
+  return QUERY_REFS.find((r) => !used.has(r)) ?? "a";
+}
+
+/**
+ * Compile a set of queries plus an optional formula into a single PromQL
+ * expression. Each single-letter reference in the formula (a, b, …) is
+ * replaced by the parenthesized compilation of that query, so a formula like
+ * `(a / b) * 100` becomes a ratio expression. PromQL function names (rate,
+ * sum, time, …) are multi-character and are left untouched.
+ *
+ * With no formula, only the first query charts. Returns "" when nothing is
+ * runnable yet (empty first query, or a formula referencing empty queries).
+ */
+export function buildFormula(queries: MetricQuery[], formula: string): string {
+  const trimmed = formula.trim();
+  if (trimmed === "") {
+    const first = queries[0];
+    return first ? buildPromQL(first) : "";
+  }
+
+  let referencedEmpty = false;
+  const substituted = trimmed.replace(/\b([a-j])\b/g, (match, ref: string) => {
+    const q = queries.find((qq) => qq.ref === ref);
+    if (!q) return match;
+    const compiled = buildPromQL(q);
+    if (compiled === "") {
+      referencedEmpty = true;
+      return match;
+    }
+    return `(${compiled})`;
+  });
+
+  // A formula that still names an empty query isn't runnable.
+  return referencedEmpty ? "" : substituted;
+}

--- a/src/ui/src/features/metrics/metrics.css
+++ b/src/ui/src/features/metrics/metrics.css
@@ -126,6 +126,50 @@
   font-size: 11px;
 }
 
+.builder-query {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.builder-query + .builder-query {
+  border-top: 1px dashed var(--border);
+}
+
+.query-remove {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--faint);
+  padding: 3px 8px;
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.builder-formula {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.formula-ref {
+  font-family: var(--mono);
+  color: var(--faint);
+  font-style: italic;
+}
+
+.formula-input {
+  flex: 1;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
 .builder-run {
   display: flex;
   align-items: center;

--- a/src/ui/src/features/metrics/metrics.css
+++ b/src/ui/src/features/metrics/metrics.css
@@ -37,6 +37,127 @@
   font-size: 12px;
 }
 
+/* --- editor mode toggle --- */
+.metrics-modes {
+  display: flex;
+  gap: 4px;
+  padding: 8px 16px 0;
+}
+
+.metrics-modes button {
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--faint);
+  background: transparent;
+}
+
+.metrics-modes button.active {
+  color: var(--fg);
+  background: var(--surface2);
+}
+
+/* --- visual builder --- */
+.metrics-builder {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px 12px;
+}
+
+.qrow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.qrow-ref {
+  font-family: var(--mono);
+  color: var(--faint);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.qrow-kw {
+  color: var(--faint);
+}
+
+.qrow input,
+.qrow select {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.qrow-metric,
+.qrow-groupby {
+  font-family: var(--mono);
+}
+
+.qrow-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.qrow-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.qrow-filter-op {
+  padding: 4px 2px;
+}
+
+.qrow-filter-remove,
+.qrow-add {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--faint);
+  padding: 3px 8px;
+  font-size: 11px;
+}
+
+.builder-run {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.builder-preview {
+  flex: 1;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--dim);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.builder-run button {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.builder-run button:disabled {
+  opacity: 0.5;
+}
+
 .mchart-wrap {
   padding: 14px 18px 4px;
 }


### PR DESCRIPTION
## Metrics Explore: a visual query builder

Makes writing PromQL optional in the Explore UI. The metrics view now opens on a
structured builder — each control maps to one step of a query — and PromQL
becomes the escape hatch rather than the only surface. Directly targets the
"writing PromQL is cumbersome" pain point.

### What's here

- **`buildPromQL`** — a `MetricQuery` model (metric · filters · range function ·
  space aggregation) that compiles to PromQL, mirroring the querier's lowering
  steps. The builder just emits a query string the existing lowering already
  accepts, so **no query-engine changes are needed**.
- **Metadata client** — `promMetricNames` / `promLabelNames` / `promLabelValues`
  over the existing `/prometheus/api/v1/labels` + `/label/{name}/values`
  endpoints, feeding the metric/filter/group-by pickers (pick-from-what-exists).
- **`QueryRow`** — the visual builder row: metric · from · agg by · function.
- **`MetricsView`** — hosts the builder with a **Builder ⇄ PromQL** toggle;
  switching to PromQL seeds the box with the compiled query.
- **Formulas** — multiple query rows (`a`, `b`, …) combined by a formula box, so
  ratios like error rate `(a / b) * 100` are composed visually.
- **Docs** — updates `docs/users/explore-ui.md` (already sourced on `src/ui/**`).

### Testing

- 161 UI tests pass (28 in the metrics feature), including an end-to-end drive of
  the builder and a two-query formula asserting the compiled expression.
- `tsc --noEmit`, `eslint`, and `vite build` all clean.

### Not in this PR (follow-ups)

- Cardinality badges (`⚠ high`) on the pickers — needs a stats-annotated
  `/labels` variant reading `attribute_stats.distinct_estimate`.
- Metric catalog sidebar with sparklines; per-query function chips beyond one
  range function; PromQL → builder parse-back.
